### PR TITLE
add a region definition to SEcal06_hybrid

### DIFF
--- a/ILD/compact/ILD_common_v02/SEcal06_hybrid_Barrel.xml
+++ b/ILD/compact/ILD_common_v02/SEcal06_hybrid_Barrel.xml
@@ -1,7 +1,14 @@
 <lccdd>
+
+  <regions>
+    <region name="EcalBarrelRegion">
+    </region>
+  </regions>
+
   <detectors>
 
-    <detector name="EcalBarrel" type="SEcal06_Barrel" id="ILDDetID_ECAL" readout="EcalBarrelCollection" vis="BlueVis" >
+    <detector name="EcalBarrel" type="SEcal06_Barrel" id="ILDDetID_ECAL" readout="EcalBarrelCollection" vis="BlueVis"
+     region="EcalBarrelRegion">
 
       <comment>EM Calorimeter Barrel</comment>
 

--- a/ILD/compact/ILD_common_v02/SEcal06_hybrid_Endcaps.xml
+++ b/ILD/compact/ILD_common_v02/SEcal06_hybrid_Endcaps.xml
@@ -1,7 +1,12 @@
 <lccdd>
-  <detectors>
+  <regions>
+    <region name="EcalEndcapRegion">
+    </region>
+  </regions>
 
-    <detector name="EcalEndcap" type="SEcal06_Endcaps" id="ILDDetID_ECAL_ENDCAP" readout="EcalEndcapsCollection" vis="BlueVis" >
+  <detectors>
+    <detector name="EcalEndcap" type="SEcal06_Endcaps" id="ILDDetID_ECAL_ENDCAP" readout="EcalEndcapsCollection" vis="BlueVis"
+	      region="EcalEndcapRegion">
       <comment>EM Calorimeter Endcaps</comment>
 
       <envelope vis="ILD_ECALVis">


### PR DESCRIPTION

BEGINRELEASENOTES
-  add definitions of regions to the SEcal06_hybrid barrel and endcap models of ILD:
     - `EcalBarrelRegion` and `EcalEndcapRegion`
     - these can be used for fast simulation (ML generation)
     
ENDRELEASENOTES