### PR TITLE
Switch to dd4hep::CellID for compatibility with dd4hep

### DIFF
--- a/detector/other/Beampipe_o1_v01_geo.cpp
+++ b/detector/other/Beampipe_o1_v01_geo.cpp
@@ -62,7 +62,7 @@ public:
   void setHalfLength( double half_length){
     _half_length = half_length ;
   }
-  void setID( dd4hep::long64 id ) { _id = id ; 
+  void setID( const dd4hep::CellID id ) { _id = id ;
   }
   // overwrite to include points inside the inner radius of the barrel 
   bool insideBounds(const dd4hep::rec::Vector3D& point, double epsilon) const {

--- a/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
@@ -185,7 +185,7 @@ static Ref_t create_detector(Detector& theDetector,xml_h e,SensitiveDetector sen
 	
 	//modified on  comparison with  TrackerEndcap_o2_v06_geo.cpp
 	//get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-	dd4hep::long64 cellID_reflect;
+	dd4hep::CellID cellID_reflect;
 	if(reflect){
 	  encoder[lcio::LCTrackerCellID::side()]=lcio::ILDDetID::bwd;
 	  encoder[lcio::LCTrackerCellID::layer()]=l_id;
@@ -200,7 +200,7 @@ static Ref_t create_detector(Detector& theDetector,xml_h e,SensitiveDetector sen
 	encoder[lcio::LCTrackerCellID::module()]=mod_num;
 	encoder[lcio::LCTrackerCellID::sensor()]=k;
 	
-	dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
+	const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
 	
 	//compute neighbours 
 	

--- a/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
@@ -182,7 +182,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 		encoder[lcio::LCTrackerCellID::module()] = module_idx;
 		encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
 
-		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 

--- a/detector/tracker/TrackerBarrel_o1_v04_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v04_geo.cpp
@@ -183,7 +183,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 		encoder[lcio::LCTrackerCellID::module()] = module_idx;
 		encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
 
-		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 

--- a/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
@@ -197,7 +197,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 		encoder[lcio::LCTrackerCellID::module()] = module_idx;
 		encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
 
-		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 

--- a/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
@@ -213,7 +213,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
 		//encoding
 
-		dd4hep::long64 cellID_reflect;
+		dd4hep::CellID cellID_reflect;
 		if (reflect) {
 		  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
 		  encoder[lcio::LCTrackerCellID::layer()] = l_id;
@@ -228,7 +228,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 		encoder[lcio::LCTrackerCellID::module()] = mod_num;
 		encoder[lcio::LCTrackerCellID::sensor()] = k;
 
-		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 

--- a/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
@@ -217,7 +217,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
 		//encoding
 
-		dd4hep::long64 cellID_reflect;
+		dd4hep::CellID cellID_reflect;
 		if (reflect) {
 		  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
 		  encoder[lcio::LCTrackerCellID::layer()] = l_id;
@@ -232,7 +232,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 		encoder[lcio::LCTrackerCellID::module()] = mod_num;
 		encoder[lcio::LCTrackerCellID::sensor()] = k;
 
-		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 

--- a/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
@@ -233,7 +233,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
 		//encoding
 
-		dd4hep::long64 cellID_reflect;
+		dd4hep::CellID cellID_reflect;
 		if (reflect) {
 		  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
 		  encoder[lcio::LCTrackerCellID::layer()] = l_id;
@@ -248,7 +248,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 		encoder[lcio::LCTrackerCellID::module()] = mod_num;
 		encoder[lcio::LCTrackerCellID::sensor()] = k;
 
-		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 

--- a/detector/tracker/VertexEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v05_geo.cpp
@@ -211,7 +211,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
 		//encoding
 
-		dd4hep::long64 cellID_reflect;
+		dd4hep::CellID cellID_reflect;
 		if (reflect) {
 		  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
 		  encoder[lcio::LCTrackerCellID::layer()] = l_id;
@@ -226,7 +226,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 		encoder[lcio::LCTrackerCellID::module()] = 0; // only 1 ring so always 0 
 		encoder[lcio::LCTrackerCellID::sensor()] = k;
 
-		dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
+		const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
 
 		//compute neighbours 
 

--- a/detector/tracker/ZPlanarTracker_geo.cpp
+++ b/detector/tracker/ZPlanarTracker_geo.cpp
@@ -255,7 +255,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
       encoder[lcio::LCTrackerCellID::module()] = nLadders;
       encoder[lcio::LCTrackerCellID::sensor()] = 0; // there is no sensor defintion in VertexBarrel at the moment
 
-      dd4hep::long64 cellID = encoder.lowWord(); // 32 bits
+      const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
 
       //compute neighbours 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Move to `dd4hep::CellID` for cellIDs, after [AIDASoft/DD4hep#1125](https://github.com/AIDASoft/DD4hep/pull/1125)

ENDRELEASENOTES

~@andresailer To make this slightly less brittle, I would need a new DD4hep tag, so that I can put in some pre-processor conditions.~ Actually scratch that, the `CellID` typedef exists in older versions as well, so this should be transparent.