### PR TITLE
Fix setting RPATH for the installed binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ option(INSTALL_COMPACT_FILES "Copy compact files to install area" OFF)
 
 
 find_package(DD4hep REQUIRED COMPONENTS DDRec DDG4 DDParsers)
+# dd4hep_set_compiler_flags() expects DD4hep_SET_RPATH to be set to ON
+# otherwise it will not set the rpath when installing
+set(DD4HEP_SET_RPATH ON)
 dd4hep_set_compiler_flags()
 
 find_package ( ROOT REQUIRED COMPONENTS Geom GenVector)


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix setting RPATH for the installed binaries

ENDRELEASENOTES

this fixes some tests that have been failing lately. They started to fail when xerces stopped being in `LD_LIBRARY_PATH` in the nightlies