### PR TITLE
Remove a couple of unneeded lines in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 #---Options-------------------------------------------------------------------------
 
 option(BUILD_TESTING "Enable and build tests" ON)
-option(CMAKE_MACOSX_RPATH "Build with rpath on macos" ON)
 option(INSTALL_COMPACT_FILES "Copy compact files to install area" OFF)
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -88,12 +87,9 @@ dd4hep_instantiate_package(${PackageName})
 
 #---Testing-------------------------------------------------------------------------
 if(BUILD_TESTING)
-
   include(CTest)
-  enable_testing()
   add_subdirectory(lcgeoTests)
   set(BUILDNAME "${CMAKE_SYSTEM}-${CMAKE_CXX_COMPILER}-${CMAKE_BUILD_TYPE}" CACHE STRING "set build string for cdash")
-
 endif(BUILD_TESTING)
 
 #--- install remaining targets--------------------------


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove a couple of unneeded lines in CMakeLists.txt

ENDRELEASENOTES

`enable_testing()` is not needed: https://cmake.org/cmake/help/latest/command/enable_testing.html
`CMAKE_MACOSX_RPATH` is set by `dd4hep_set_compiler_flags` in https://github.com/AIDASoft/DD4hep/blob/master/cmake/DD4hepBuild.cmake#L114