### PR TITLE
Test: fix ARC test for new version of dd4hep, where ddsim writes edm4…

### DIFF
--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -88,6 +88,8 @@ if __name__ == "__main__":
 
     # Output file (assuming CWD)
     SIM.outputFile = "arcsim.root"
+    if hasattr(SIM, "outputConfig") and hasattr(SIM.outputConfig, "forceDD4HEP"):
+        SIM.outputConfig.forceDD4HEP = True  # use DD4hep root format, not EDM4HEP
     #SIM.outputFile = "arcsim_edm4hep.root"
 
     # Override with user options

--- a/lcgeoTests/CMakeLists.txt
+++ b/lcgeoTests/CMakeLists.txt
@@ -80,7 +80,7 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_ARC_o1_v01_run" )
 ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
 	python3 ${CMAKE_CURRENT_SOURCE_DIR}/../example/arcfullsim.py --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../FCCee/CLD/compact/CLD_o3_v01/CLD_o3_v01.xml --runType batch  )
-SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  " Exception;EXCEPTION;ERROR;Error" )
 set_tests_properties( t_${test_name} PROPERTIES TIMEOUT 120) 
 
 SET( test_name "test_ARC_o1_v01_overlap" )


### PR DESCRIPTION
…hep output preferably

BEGINRELEASENOTES

- Examples: make arcsim example always create DD4hep ROOT output

ENDRELEASENOTES