### PR TITLE
Change `${LCIO_LIBRARIES}` to `LCIO::lcio`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ target_include_directories(${PackageName}   SYSTEM PUBLIC ${LCIO_INCLUDE_DIRS})
 target_include_directories(${PackageName}G4 SYSTEM PUBLIC ${LCIO_INCLUDE_DIRS})
 
 target_link_libraries(${PackageName}   DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers ${ROOT_LIBRARIES} ${LCIO_LIBRARIES} detectorSegmentations)
-target_link_libraries(${PackageName}G4 DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers DD4hep::DDG4 ${ROOT_LIBRARIES} ${Geant4_LIBRARIES} ${LCIO_LIBRARIES})
+target_link_libraries(${PackageName}G4 DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers DD4hep::DDG4 ${ROOT_LIBRARIES} ${Geant4_LIBRARIES} LCIO::lcio)
 
 #Create this_package.sh file, and install
 dd4hep_instantiate_package(${PackageName})


### PR DESCRIPTION
BEGINRELEASENOTES
- Change ${LCIO_LIBRARIES} to `LCIO::lcio` in CMakeLists.txt for cases when `LCIO_LIBRARIES` is empty. Also prevents linking to `SIO` when it's not necessary but it's included in `LCIO_LIBRARIES`

ENDRELEASENOTES

This is the same as https://github.com/iLCSoft/LCCD/pull/7