### PR TITLE
CMAKE: lcgeo to k4geo rename, k4geoConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,8 @@ add_library(lcgeo ALIAS k4geo)
 target_include_directories(${PackageName}   PRIVATE ${PROJECT_SOURCE_DIR}/detector/include )
 target_include_directories(${PackageName}G4 PRIVATE ${PROJECT_SOURCE_DIR}/detector/include )
 
-target_include_directories(${PackageName}   SYSTEM PUBLIC ${LCIO_INCLUDE_DIRS})
-target_include_directories(${PackageName}G4 SYSTEM PUBLIC ${LCIO_INCLUDE_DIRS})
-
-target_link_libraries(${PackageName}   DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers ROOT::Core ${LCIO_LIBRARIES} detectorSegmentations)
-target_link_libraries(${PackageName}G4 DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers DD4hep::DDG4 ROOT::Core ${Geant4_LIBRARIES} ${LCIO_LIBRARIES})
+target_link_libraries(${PackageName}   DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers ROOT::Core LCIO::LCIO detectorSegmentations)
+target_link_libraries(${PackageName}G4 DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers DD4hep::DDG4 ROOT::Core ${Geant4_LIBRARIES} LCIO::LCIO)
 
 #Create this_package.sh file, and install
 dd4hep_instantiate_package(${PackageName})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,12 @@ target_link_libraries(${PackageName}G4 DD4hep::DDCore DD4hep::DDRec DD4hep::DDPa
 #Create this_package.sh file, and install
 dd4hep_instantiate_package(${PackageName})
 
+# Destination directories are hardcoded because GNUdirectories are not included
+install(TARGETS ${PackageName}  ${PackageName}G4
+  EXPORT ${PROJECT_NAME}Targets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT shlib
+)
+
 #---Testing-------------------------------------------------------------------------
 if(BUILD_TESTING)
   include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ set(CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}  ${PROJECT_SOURCE_DIR}/cmake )
 set(LIBRARY_OUTPUT_PATH    ${PROJECT_BINARY_DIR}/lib)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 
+include(GNUInstallDirs)
+set(CMAKE_INSTALL_LIBDIR lib)
+set(CMAKE_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+
 #------------- set the default installation directory to be the source directory
 
 IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -106,3 +110,25 @@ INSTALL(FILES ${hfiles}
 if(INSTALL_COMPACT_FILES)
   INSTALL(DIRECTORY CaloTB CLIC FCalTB FCCee ILD fieldmaps SiD DESTINATION share/k4geo )
 endif()
+
+# create k4geoConfig and friends
+
+INSTALL(EXPORT ${PROJECT_NAME}Targets
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
+  FILE k4geoConfig-targets.cmake)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(cmake/k4geoConfig.cmake.in ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/k4geoConfig.cmake
+  PATH_VARS CMAKE_INSTALL_CMAKEDIR
+  INSTALL_DESTINATION ${CMAKE_INSTALL_CMAKEDIR} )
+
+write_basic_package_version_file(
+  ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/k4geoConfigVersion.cmake
+  VERSION ${${PackageName}_VERSION}
+  COMPATIBILITY SameMajorVersion )
+
+install(FILES ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/k4geoConfig.cmake
+              ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/k4geoConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_CMAKEDIR} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 #---------------------------
-set( PackageName lcgeo )
+set( PackageName k4geo )
 #---------------------------
 
 project(${PackageName})
@@ -74,6 +74,8 @@ endif()
 
 add_dd4hep_plugin(${PackageName} SHARED ${sources})
 add_dd4hep_plugin(${PackageName}G4 SHARED ${G4sources})
+
+add_library(lcgeo ALIAS k4geo)
 
 target_include_directories(${PackageName}   PRIVATE ${PROJECT_SOURCE_DIR}/detector/include )
 target_include_directories(${PackageName}G4 PRIVATE ${PROJECT_SOURCE_DIR}/detector/include )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,8 @@ target_include_directories(${PackageName}G4 PRIVATE ${PROJECT_SOURCE_DIR}/detect
 target_include_directories(${PackageName}   SYSTEM PUBLIC ${LCIO_INCLUDE_DIRS})
 target_include_directories(${PackageName}G4 SYSTEM PUBLIC ${LCIO_INCLUDE_DIRS})
 
-target_link_libraries(${PackageName}   DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers ${ROOT_LIBRARIES} ${LCIO_LIBRARIES} detectorSegmentations)
-target_link_libraries(${PackageName}G4 DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers DD4hep::DDG4 ${ROOT_LIBRARIES} ${Geant4_LIBRARIES} ${LCIO_LIBRARIES})
+target_link_libraries(${PackageName}   DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers ROOT::Core ${LCIO_LIBRARIES} detectorSegmentations)
+target_link_libraries(${PackageName}G4 DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers DD4hep::DDG4 ROOT::Core ${Geant4_LIBRARIES} ${LCIO_LIBRARIES})
 
 #Create this_package.sh file, and install
 dd4hep_instantiate_package(${PackageName})

--- a/cmake/k4geoConfig.cmake.in
+++ b/cmake/k4geoConfig.cmake.in
@@ -1,0 +1,14 @@
+set(k4geo_VERSION @k4geo_VERSION@)
+
+@PACKAGE_INIT@
+
+set_and_check(k4geo_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@")
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(DD4hep REQUIRED)
+find_dependency(Geant4 REQUIRED)
+find_dependency(ROOT REQUIRED COMPONENTS Geom GenVector)
+find_dependency(LCIO REQUIRED)
+
+include(${k4geo_CMAKE_DIR}/k4geoConfig-targets.cmake)

--- a/detectorSegmentations/CMakeLists.txt
+++ b/detectorSegmentations/CMakeLists.txt
@@ -30,10 +30,10 @@ target_include_directories(detectorSegmentationsPlugin
 # Destination directories are hardcoded because GNUdirectories are not included
 install(TARGETS detectorSegmentations detectorSegmentationsPlugin
   EXPORT ${PROJECT_NAME}Targets
-  RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin" COMPONENT bin
-  LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/lib" COMPONENT shlib
-  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_PREFIX}/include/detectorSegmentations"
-  COMPONENT dev)
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIDIR} COMPONENT shlib
+  PUBLIC_HEADER DESTINATION include/detectorSegmentations COMPONENT dev
+)
 
 #
 #include(CTest)


### PR DESCRIPTION
BEGINRELEASENOTES
- CMake: The lcgeo project is renamed to k4geo, this also changes library names
- CMake: add the creation of a k4geoConfig.cmake file

ENDRELEASENOTES

Would be good to have https://github.com/iLCSoft/LCIO/pull/177/files for the LCIO::LCIO target