### PR TITLE
fixing overlaps in ALLEGRO Ecal barrel geometry

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/FCCee_ECalBarrel_thetamodulemerged.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/FCCee_ECalBarrel_thetamodulemerged.xml
@@ -27,7 +27,7 @@
     <constant name="LArGapThickness" value="1.256*2*mm"/>
 
     <!-- Air margin, thicknesses of cryostat and LAr bath -->
-    <constant name="AirMarginThickness" value="54*mm"/>    <!-- Space holder for air gap between cryostat vessels --> 
+    <constant name="AirMarginThickness" value="49*mm"/>    <!-- Space holder for air gap between cryostat vessels --> 
 
     <constant name="CryoBarrelFrontWarm" value="10*mm"/>   <!-- Al solid corresponding to 0.11 X0 -->
     <constant name="CryoBarrelFrontCold" value="3.8*mm"/>  <!-- Al solid equivalent of 0.043 X0 sandwich CFRP -->
@@ -42,7 +42,7 @@
     <constant name="CryoBarrelSideCold" value="3.8*mm"/>
     <constant name="CryoBarrelSide" value="CryoBarrelSideWarm+CryoBarrelSideCold"/>
 
-    <constant name="LArBathThicknessFront" value="5*mm"/>
+    <constant name="LArBathThicknessFront" value="10*mm"/>
     <constant name="LArBathThicknessBack" value="40*mm"/>
 
     <!-- air margin around calorimeter -->
@@ -53,6 +53,11 @@
     <constant name="EMBarrel_rmin" value="BarCryoECal_rmin+CryoBarrelFront+LArBathThicknessFront"/>
     <constant name="EMBarrel_rmax" value="BarCryoECal_rmax-CryoBarrelBack-LArBathThicknessBack"/>
     <constant name="EMBarrel_dz" value="BarECal_dz-CryoBarrelSide"/>
+    <!-- Bath with margin for safe inclination -->
+    <constant name="safeMargin" value="3*mm"/>
+    <constant name="Bath_rmin" value="EMBarrel_rmin - safeMargin"/>
+    <constant name="Bath_rmax" value="EMBarrel_rmax + safeMargin"/>
+
     <!-- thickness of active volume between two absorber plates at EMBarrel_rmin, measuring perpendicular to the readout plate -->
     <constant name="LAr_thickness" value="LArGapThickness"/>
     <!-- passive layer consists of lead in the middle and steel on the outside, glued -->
@@ -107,6 +112,10 @@
         <side sensitive="false"/> <!-- both sides of the cryostat -->
         <back sensitive="false"/> <!-- outer wall of the cryostat -->
       </cryostat>
+      <bath name="ECAL_bath">
+        <material name="LAr"/>
+        <dimensions rmin="Bath_rmin" rmax="Bath_rmax" dz="EMBarrel_dz"/>
+      </bath>
       <calorimeter name="EM_barrel">
         <!-- offset defines the numbering of the modules: module==0 for phi=0 direction -->
         <dimensions rmin="EMBarrel_rmin" rmax="EMBarrel_rmax" dz="EMBarrel_dz" offset="-InclinationAngle"/>

--- a/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v02_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v02_geo.cpp
@@ -108,8 +108,10 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
   double passiveThickness = passiveInnerThicknessMin + passiveOuterThickness + passiveGlueThickness;
   double angle = passive.rotation().angle();
 
-  double bathRmin = caloDim.rmin(); // - margin for inclination
-  double bathRmax = caloDim.rmax(); // + margin for inclination
+  dd4hep::xml::DetElement bath = aXmlElement.child(_Unicode(bath));
+  dd4hep::xml::Dimension bathDim(bath.dimensions());
+  double bathRmin = bathDim.rmin();
+  double bathRmax = bathDim.rmax();
   dd4hep::Tube bathOuterShape(bathRmin, bathRmax, caloDim.dz()); // make it 4 volumes + 5th for detector envelope
   dd4hep::Tube bathAndServicesOuterShape(cryoDim.rmin2(), cryoDim.rmax1(), caloDim.dz()); // make it 4 volumes + 5th for detector envelope
   if (cryoThicknessFront > 0) {

--- a/detector/calorimeter/README.md
+++ b/detector/calorimeter/README.md
@@ -14,6 +14,8 @@ Original version taken from [FCCDetectors](https://github.com/HEP-FCC/FCCDetecto
 ### o1_v02
 New version, with module-theta based segmentation. In each layer adjacent cells along theta or module directions can be grouped together, with possibly different merging per layer. This is specified with the `mergedCells_Theta` and `mergedModules` vectors in the `segmentation` tag of the xml file. The baseline grouping in theta is by four in all layers except L1 (the strip layer). The baseline grouping in module direction is by two in all layers. The LAr gap has also been slightly adjusted to bring back the number of modules to 1536 (it was 1545 before). The segmentation class needs to know the number of modules, which is passed via the `nModules` parameter of the `segmentation` tag. To ensure that number of modules and layers (length of the mergedXXX vectors) are consistent with number of modules and layers of the detector, the xml defines `ECalBarrelNumLayers` and `ECalBarrelNumPlanes`, and the c++ file doing the detector construction checks that the number of planes and layers calculated dynamically from other parameters matches that in the xml (if not, the code will crash).
 
+Overlaps in the LAr bath volume fixed.
+
 ## CaloDisks
 This sub-detector makes calorimeter endcaps (original and reflected). It is used in ALLEGRO detector concept.
 


### PR DESCRIPTION
BEGINRELEASENOTES
- fixing the overlaps in ALLEGRO Ecal barrel geometry by increasing the LAr bath volume.
ENDRELEASENOTES