### PR TITLE
Change in the type of inclined calorimeter and adding units to cell size

### DIFF
--- a/FCCee/CLD/compact/CLD_o4_v05/LAr_ECalBarrel.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/LAr_ECalBarrel.xml
@@ -96,7 +96,7 @@
   </readouts>
 
   <detectors>
-    <detector id="DetID_ECal_Barrel" name="ECalBarrel" type="EmCaloBarrelInclined" readout="ECalBarrelEta">
+    <detector id="DetID_ECal_Barrel" name="ECalBarrel" type="ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01" readout="ECalBarrelEta">
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
       <sensitive type="SimpleCalorimeterSD"/>
       <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>

--- a/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01_geo.cpp
@@ -626,8 +626,8 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
     caloLayer.outer_thickness           = difference_bet_r1r2 / 2;
 
     caloLayer.absorberThickness         = absorberThickness;
-    caloLayer.cellSize0 = 2;
-    caloLayer.cellSize1 = 2;
+    caloLayer.cellSize0 = 2 * dd4hep::mm;
+    caloLayer.cellSize1 = 2 * dd4hep::mm;
   
     caloData->layers.push_back(caloLayer);
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- CLD_o4_v05: The name of the inclined calorimeter was given as `EmCaloBarrelInclined` before. This is now changed to the latest naming convention as `ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01`
- ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01: The units for cell sizes has been added to the CaloLayerData ensure that they are given correctly and not mistaken due to confusion in units. now they are represented in mm. 

ENDRELEASENOTES