### PR TITLE
ALLEGRO: EcalBarrel CaloData: caloDim.dZ is already the half length

### DIFF
--- a/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01_geo.cpp
@@ -568,7 +568,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
   caloData->extent[0] = Rmin;
   caloData->extent[1] = Rmax; // or r_max ?
   caloData->extent[2] = 0.;      // NN: for barrel detectors this is 0
-  caloData->extent[3] = caloDim.dz()/2;
+  caloData->extent[3] = caloDim.dz();
 
   // Set type flags
   dd4hep::xml::setDetectorTypeFlag(xmlDetElem, caloDetElem);


### PR DESCRIPTION

BEGINRELEASENOTES
- ALLEGRO: EcalBarrel: fix the length of the Z extent for the calorimeter data extension for reconstruction

ENDRELEASENOTES