### PR TITLE
CMake: add shim for LCIO::lcio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,15 @@ message ( STATUS "ROOT_VERSION: ${ROOT_VERSION}" )
 
 find_package( Geant4 REQUIRED ) 
 find_package( LCIO REQUIRED)
+# Shim for older LCIO versions
+if(NOT TARGET LCIO::lcio)
+  add_library(LCIO::lcio INTERFACE IMPORTED GLOBAL)
+  set_target_properties(LCIO::lcio
+    PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${LCIO_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES "${LCIO_LIBRARIES}"
+  )
+endif()
 
 add_subdirectory(detectorSegmentations)
 add_subdirectory(detectorCommon)

--- a/plugins/LinearSortingPolicy.cpp
+++ b/plugins/LinearSortingPolicy.cpp
@@ -91,9 +91,13 @@ namespace {
 
           dd4hep::rec::DoubleParameters* para = nullptr;
           try { // use existing map, or create a new one
-            para = ddsurf->detElement().extension<dd4hep::rec::DoubleParameters>();
+            para = ddsurf->detElement().extension<dd4hep::rec::DoubleParameters>(false);
+            if(not para) {
+              para = new dd4hep::rec::DoubleParameters;
+              ddsurf->detElement().addExtension<dd4hep::rec::DoubleParameters>(para);
+            }
             para->doubleParameters["SortingPolicy"] = rValue;
-          } catch(...){
+          } catch(...) {
             para = new dd4hep::rec::DoubleParameters;
             para->doubleParameters["SortingPolicy"] = rValue;
             ddsurf->detElement().addExtension<dd4hep::rec::DoubleParameters>(para);


### PR DESCRIPTION
BEGINRELEASENOTES
- CMake: Add shim for older LCIO versions that do not have LCIO::lcio yet
- LinearSortingPolicy: adapt check for existing extension to silence error message from DD4hep

ENDRELEASENOTES