### PR TITLE
Lumical

### DIFF
--- a/FCCee/CLD/compact/CLD_o2_v06/BeamInstrumentation_o3_v02_fitShield.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/BeamInstrumentation_o3_v02_fitShield.xml
@@ -1,0 +1,26 @@
+<lccdd>
+
+    <detectors>
+        <comment>Beampipe Instrumentation</comment>
+
+        <detector name="CompSol" type="DD4hep_Mask_o1_v01" insideTrackingVolume="true" vis="CompSolVis">
+            <parameter crossingangle="CrossingAngle" />
+            <envelope vis="CoilVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <section type="Center"               start="CompSol_min_z"    end="QD0_min_z" rMin1="103*mm"  rMin2="180*mm"  rMax1="123*mm" rMax2="200*mm"    material="SolenoidMixture"  name="CompSol" />
+        </detector>
+
+        <detector name="ScreenSol" type="DD4hep_Mask_o1_v01" insideTrackingVolume="true" vis="ScreenSolVis">
+            <parameter crossingangle="CrossingAngle" />
+            <envelope vis="CoilVis">
+                <shape type="Assembly"/>
+            </envelope>
+
+           <section type="Center"  start="QD0_min_z" end="QD0_min_z+5*cm" rMin1="SeparatedBeamPipe_rmax+1*mm+5*cm" rMin2="SeparatedBeamPipe_rmax+1*mm+5*cm" rMax1="200*mm" rMax2="200*mm" material="SolenoidMixture"  name="CompSol" />
+
+            <section type="Center"    start="QD0_min_z+5*cm"    end="QD0_max_z" rMin1="180*mm"  rMin2="180*mm"  rMax1="200*mm" rMax2="200*mm"    material="SolenoidMixture"  name="CompSol" />
+        </detector>
+
+    </detectors>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/Beampipe_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/Beampipe_o4_v05.xml
@@ -1,0 +1,158 @@
+<lccdd>
+
+  <info name="FCCee"
+        title="FCCee low impedance Beam pipe with small radius"
+        author="Andre Sailer"
+        url="no"
+        status="development"
+        version="1.0">
+    <comment>A beampipe for FCCee detector based on CLD</comment>
+  </info>
+    
+    <!--  Definition of global dictionary constants          -->
+    <define>
+    <!--  Definition of global dictionary constants          -->
+      <constant name="beampipegoldwidth" value="BeamPipeGoldWidth"/>
+      <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
+    </define>
+
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
+        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
+    </display>
+
+    <detectors>
+
+      <!-- ;radius calculator lisp
+      (+ 12.0 (* (/ (- 28.9 12.0) (- 1190.0 90.0)) (- 110.0 90.0) ) )
+      -->
+        <comment>Part of beampipe made of AlBeMet162 and Paraffin flow</comment>
+
+        <detector name="BeBeampipe" type="DD4hep_Beampipe_o1_v01" insideTrackingVolume="true" nocore="true" vis="BeamPipeVis">
+            <parameter crossingangle="CrossingAngle" />
+            <envelope vis="BlueVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <!-- central section made of two walls of 0.35 mm albemet and liquid paraffin in the middle -->
+            <section type="Center" start="0*mm"                  end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax"                  rMin2="CentralBeamPipe_rmax"                 rMax1="CentralBeamPipe_rmax+BPWWall"                rMax2="CentralBeamPipe_rmax+BPWWall"             material="AlBeMet162"    name="VertexInnerAlb" />
+            <section type="Center" start="0*mm"                  end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax+BPWWall"          rMin2="CentralBeamPipe_rmax+BPWWall"         rMax1="CentralBeamPipe_rmax+BPWWall+BPWCool"        rMax2="CentralBeamPipe_rmax+BPWWall+BPWCool"     material="LiquidNDecane" name="VertexParaffin" />
+            <section type="Center" start="0*mm"                  end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax+BPWWall+BPWCool"  rMin2="CentralBeamPipe_rmax+BPWWall+BPWCool" rMax1="CentralBeamPipe_rmax+2*BPWWall+BPWCool"      rMax2="CentralBeamPipe_rmax+2*BPWWall+BPWCool"   material="AlBeMet162"    name="VertexOuterAlb" />
+            <section type="Center" start="CentralBeamPipe_zmax"  end="SeparatedBeamPipe_z"  rMin1="CentralBeamPipe_rmax"                  rMin2="ConeBeamPipe_Rmax"                    rMax1="CentralBeamPipe_rmax+BeamPipeWidthFirstCone" rMax2="ConeBeamPipe_Rmax+BeamPipeWidthFirstCone" material="AlBeMet162"     name="ConicalChamber" />
+
+        </detector>
+
+	<detector name="BeamPipe" type="DD4hep_Beampipe_o1_v01" insideTrackingVolume="true" vis="BeamPipeVis" >
+            <envelope vis="BlueVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <parameter crossingangle="CrossingAngle" />
+
+            <!--             &A                       Z1                  Z2                    RIn1                RIn2                                 ROut1                        ROut2                                              Material -->
+
+            <comment>Golden foil in the inner part of the Be beampipe</comment>
+
+            <section type="Center"               start="0*mm"    end="CentralBeamPipe_zmax" rMin1="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"  rMin2="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"    rMax1="CentralBeamPipe_rmax-beampipegoldtolerance"  rMax2="CentralBeamPipe_rmax-beampipegoldtolerance"                material="Gold" name="VertexInnerGold"  />
+
+            <section type="Center" start="CentralBeamPipe_zmax"  end="SeparatedBeamPipe_z"  rMin1="CentralBeamPipe_rmax-(beampipegoldwidth+beampipegoldtolerance)"  rMin2="ConeBeamPipe_Rmax-(beampipegoldwidth+beampipegoldtolerance)"      rMax1="CentralBeamPipe_rmax-beampipegoldtolerance"  rMax2="ConeBeamPipe_Rmax-beampipegoldtolerance" material="Gold" name="ConicalChamberGold" />
+
+	    <section type="PunchedCenter"        start="SeparatedBeamPipe_z" end="SeparatedBeamPipe_z+3*mm" rMin1="SeparatedBeamPipe_rmax"      rMin2="SeparatedBeamPipe_rmax" rMax1="ConeBeamPipe_Rmax+BeamPipeWidthFirstCone" rMax2="ConeBeamPipe_Rmax+BeamPipeWidthFirstCone" material="Copper"     name="SplitVacChambers"/>
+
+             <section type="DnstreamClippedFront" start="SeparatedBeamPipe_z+3.0*mm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="DownStreamBeamPipe_1"/>
+
+
+	   <section type="UpstreamClippedFront"  start="SeparatedBeamPipe_z+3.0*mm" end="MiddleOfSRMask_z -3*cm" rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="UpStreamBeamPipe_1"/>
+
+           <section type="Upstream" start="MiddleOfSRMask_z -3*cm" end="MiddleOfSRMask_z -1*cm" rMin1="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm" rMin2="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax2="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" material="Copper"      name="UpStreamBeamPipe_2" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z -1*cm" end="MiddleOfSRMask_z +1*cm" rMin1="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax1="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" rMin2="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax2="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" material="Copper"      name="UpStreamBeamPipe_3" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z +1*cm" end="MiddleOfSRMask_z +3*cm" rMin1="SeparatedBeamPipe_rmax-SynchRadMaskSize" rMax1="SeparatedBeamPipe_rmax+0.01*mm - SynchRadMaskSize" rMin2="SeparatedBeamPipe_rmax" rMax2="SeparatedBeamPipe_rmax+1*mm" material="Copper"      name="UpStreamBeamPipe_4" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z +3*cm" end="6000*mm"  rMin1="SeparatedBeamPipe_rmax"  rMin2="SeparatedBeamPipe_rmax" rMax1="SeparatedBeamPipe_rmax+1*mm"  rMax2="SeparatedBeamPipe_rmax+1*mm"  material="Copper"      name="UpStreamBeamPipe_5" />
+
+</detector>
+
+<!-- 2020.04.08 : Synch Radiation mask (symmetyric in phi for the while) -->
+
+<comment>Synch Radiation mask inside the beam-pipe, at z = 2.1 m </comment>
+<detector name="SynchRadMask" type="DD4hep_Mask_o1_v01" insideTrackingVolume="true" vis="TantalumVis" >
+        <parameter crossingangle="CrossingAngle" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z -3*cm" end="MiddleOfSRMask_z -1*cm" rMin1="SeparatedBeamPipe_rmax +1*mm + mask_epsilon" rMax1="SeparatedBeamPipe_rmax+1*mm +2*mask_epsilon" rMin2="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize + mask_epsilon" rMax2="SeparatedBeamPipe_rmax+1*mm +2* mask_epsilon" material="Tungsten"      name="UpStreamBeamPipe_SRmask_1" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z -1*cm" end="MiddleOfSRMask_z +1*cm" rMin1="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize + mask_epsilon" rMax1="SeparatedBeamPipe_rmax+1*mm +2*mask_epsilon " rMin2="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize + mask_epsilon" rMax2="SeparatedBeamPipe_rmax+1*mm + 2*mask_epsilon" material="Tungsten"    name="UpStreamBeamPipe_SRmask_2" />
+
+           <section type="Upstream" start="MiddleOfSRMask_z +1*cm" end="MiddleOfSRMask_z +3*cm" rMin1="SeparatedBeamPipe_rmax +0.01*mm -SynchRadMaskSize +mask_epsilon" rMax1="SeparatedBeamPipe_rmax+1*mm + 2*mask_epsilon" rMin2="SeparatedBeamPipe_rmax +1*mm + mask_epsilon" rMax2="SeparatedBeamPipe_rmax+1*mm +2*mask_epsilon" material="Tungsten"      name="UpStreamBeamPipe_SRmask_3" />
+
+</detector>
+
+<comment>Full Cone Tungsten Shield</comment>
+<detector name="BeamPipeShield" type="DD4hep_Mask_o1_v01" insideTrackingVolume="true" vis="TantalumVis" >
+        <parameter crossingangle="CrossingAngle" />
+
+        <comment>Beampipe Shield (APS: WHAT????? +18 cm (??plus??) as solenoid is now closer to IP) </comment>
+        <section type="PunchedCenter"
+        start="SeparatedBeamPipe_z + 5*mm" end="QD0_min_z + 18*cm"
+        rMin1="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm"
+        rMin2="SeparatedBeamPipe_rmax + BeamPipeWidth + 0.1*mm "
+        rMax1="SeparatedBeamPipe_rmax + (SeparatedBeamPipe_z + 5*mm) * 0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        rMax2="SeparatedBeamPipe_rmax + (QD0_min_z + 18*cm) * 0.015 + BeamPipeWidth + 0.1*mm + BeamPipeTantalShieldWidth"
+        material="Tungsten" name="TaShield" />
+
+</detector>
+
+
+<comment>Asymmetric Tungsten Shield no Rotation</comment>
+        
+<detector name="BeamPipeShield_noRot" type="DD4hep_Mask_o1_v01" insideTrackingVolume="true" vis="TantalumVis"  >
+        <parameter crossingangle="CrossingAngle" rotationX="true"/>
+
+        <section type="Center"
+        start="500*mm" end="LumiCal_max_z + 4.9*mm"
+        rMin1="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (500.0*mm               - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm"
+        rMin2="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm"
+        rMax1="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (500.0*mm               - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm + TopFillerShieldWidth"
+        rMax2="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm + BeamPipeTantalShieldWidth"
+        phi1="326*degree"
+        phi2="34*degree"
+        material="Tungsten" name="TaShieldTopPart" />
+
+        <comment>was 370. Add 0.1*mm so that rmax1 is larger than rmin1 </comment>
+        <section type="Center"
+        start="330*mm" end="500*mm"
+        rMin1="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (330*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm"
+        rMin2="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (500*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm"
+        rMax1="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (330*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm + 0.1*mm"
+        rMax2="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (500*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm + TopFillerShieldWidth"
+        phi1="326*degree"
+        phi2="34*degree"
+        material="Tungsten" name="TaShieldTopPart2" />
+
+	<comment>one degree less, to fit lumical window</comment>
+        <section type="Center"
+        start="600*mm" end="LumiCal_max_z + 4.9*mm"
+        rMin1="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (600*mm                 - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm"
+        rMin2="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm"
+        rMax1="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (600*mm                 - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm + SideFillerShieldWidth"
+        rMax2="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm + BeamPipeTantalShieldWidth"
+        phi1="34*degree"
+        phi2="70*degree"
+        material="Tungsten" name="TaShieldFiller1" />
+
+        <section type="Center"
+        start="600*mm" end="LumiCal_max_z + 4.9*mm"
+        rMin1="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (600*mm                 - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm"
+        rMin2="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm"
+        rMax1="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (600*mm                 - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm + SideFillerShieldWidth"
+        rMax2="CentralBeamPipe_rmax + BeamPipeWidthFirstCone + (LumiCal_max_z + 4.9*mm - CentralBeamPipe_zmax) * BeamPipeConeHalfAngle + 0.1*mm + BeamPipeTantalShieldWidth"
+        phi1="291*degree"
+        phi2="326*degree"
+        material="Tungsten" name="TaShieldFiller2" />
+
+</detector>
+
+    </detectors>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml
@@ -1,0 +1,432 @@
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+    <info name="CLD_o2_v05"
+        title="FCCee detector model option 2 version 05 (updated Beampipe and VXD)"
+	author="Andre Sailer"
+        url="http://ilcsoft.desy.de"
+        status="development"
+        version="5">
+        <comment>The compact format for the FCCee Detector design</comment>
+    </info>
+
+    <includes>
+        <gdmlFile  ref="elements.xml"/>
+        <gdmlFile  ref="materials.xml"/>
+    </includes>
+
+    <define>
+        <constant name="world_side" value="6100*mm"/>
+        <constant name="world_x" value="world_side"/>
+        <constant name="world_y" value="world_side"/>
+        <constant name="world_z" value="world_side"/>
+
+        <constant name="CrossingAngle" value="0.030*rad"/>
+
+        <constant name="SolenoidField" value="2*tesla"/>
+
+        <constant name="DetID_NOTUSED"          value=" 0"/>
+
+        <constant name="DetID_VXD_Barrel"       value=" 1"/>
+        <constant name="DetID_VXD_Endcap"       value=" 2"/>
+
+        <constant name="DetID_IT_Barrel"        value=" 3"/>
+        <constant name="DetID_IT_Endcap"        value=" 4"/>
+
+        <constant name="DetID_OT_Barrel"        value=" 5"/>
+        <constant name="DetID_OT_Endcap"        value=" 6"/>
+
+        <constant name="DetID_ECal_Barrel"      value=" 20"/>
+        <constant name="DetID_ECal_Endcap"      value=" 29"/>
+        <constant name="DetID_ECal_Plug"        value=" 21"/>
+
+        <constant name="DetID_HCAL_Barrel"      value=" 10"/>
+        <constant name="DetID_HCAL_Endcap"      value=" 11"/>
+        <constant name="DetID_HCAL_Ring"        value=" 12"/>
+
+        <constant name="DetID_Yoke_Barrel"      value=" 13"/>
+        <constant name="DetID_Yoke_Endcap"      value=" 14"/>
+
+        <constant name="DetID_LumiCal"          value=" 15"/>
+        <constant name="DetID_LumiCalInstrumentation"          value=" 16"/>
+        <constant name="DetID_LumiCalBackShield"          value=" 18"/>
+        <constant name="DetID_LumiCalCooling"          value=" 17"/>
+        <constant name="DetID_LumiCalNoseShield"          value=" 22"/>
+
+        <constant name="DetID_HOMAbsorber"          value=" 19"/>
+
+        <!-- BPW: Beam Pipe Width -->
+        <constant name="BPWWall"       value="0.35*mm" />
+        <constant name="BPWCool"       value="1.0*mm" />
+        <constant name="BeamPipeWidth" value="2.0*BPWWall + BPWCool"/>
+
+	<constant name="BeamPipeWidthFirstCone" value="2.0*mm" />
+        <!-- this is the inner length of the longer elipse axis -->
+	<constant name="ConeBeamPipe_Rmax" value="28.9*mm" />
+        <constant name="CentralBeamPipe_zmax" value="90*mm"/>
+	<constant name="SeparatedBeamPipe_z" value="1190.0*mm"/>
+        <constant name="CentralBeamPipe_rmax" value="10.0*mm"/>
+	<constant name="BeamPipeGoldWidth" value="0.005*mm" />
+	<constant name="BeamPipeGoldTolerance" value="0.001*mm" />  <!-- dummy tolerance, some small non zero value -->
+	<constant name="BeamPipeConeHalfAngle" value="(ConeBeamPipe_Rmax + BeamPipeWidthFirstCone - CentralBeamPipe_rmax ) / (SeparatedBeamPipe_z - CentralBeamPipe_zmax)" />
+
+        <constant name="InnerTracker_half_length" value="2300*mm" />
+
+        <!-- used in the tracker detector -->
+        <constant name="ConeBeamPipe_zmax" value="InnerTracker_half_length" />
+        <constant name="ConeBeamPipe_rmax_1"  value="InnerTracker_half_length * 0.1 + 1*mm" />
+
+        <constant name="SeparatedBeamPipe_rmax"  value="15*mm"/>
+        <constant name="BeamPipeTantalShieldWidth"  value="15*mm"/>
+        <constant name="SideFillerShieldWidth"  value="7*mm"/>
+        <constant name="TopFillerShieldWidth"  value="8*mm"/>
+        <constant name="BeamPipe_end" value="12500*mm"/>
+
+        <!-- Mike Sullivan's Synch Rad mask -->
+        <constant name="MiddleOfSRMask_z" value="2.1*m" />
+        <constant name="SynchRadMaskSize" value="5*mm" /> <!-- mask tip is at 10 mm from the beamline -->
+        <constant name="mask_epsilon" value="0.001*mm" />
+
+
+        <constant name="size_x" value="60*mm"/>
+        <constant name="size_y" value="12*mm"/>
+        <constant name="size_z" value="50*mm"/>
+
+        <!-- ################### ENVELOPE PARAMETERS ######################################################## -->
+
+        <comment> suggested naming convention:
+
+            main parameters:
+
+            DET_inner_radius    : inner radius of tube like envelope  ( inscribed cylinder )
+            DET_outer_radius    : outer radius of tube like envelope  ( circumscribed cylinder )
+            DET_half_length     : half length along z axis
+            DET_min_z           : smallest absolute value on z-axis
+            DET_max_z           : largest  absolute value on z-axis
+            DET_inner_symmetry  : number of sides on the inside  ( 0 for tube )
+            DET_outer_symmetry  : number of sides on the inside  ( 0 for tube )
+            DET_inner_phi0      : optional rotation of the inner polygon ( in r-phi plane )
+            DET_outer_phi0      : optional rotation of the outer polygon ( in r-phi plane )
+
+            additional parameters for cutting away volumes/shapes use one of the above with a number
+            appended and/or an extra specifiaction such as cone ( for a cut away cone )
+
+            DET_inner_radius_1
+            DET_outer_radius_2
+            DET_cone_min_z
+            DET_cone_max_z
+
+        </comment>
+
+        <constant name="env_safety" value="0.1*mm"/>
+
+
+
+        <constant name="Vertex_inner_radius" value="12.5*mm"/>
+        <constant name="Vertex_outer_radius" value="111*mm"/>
+        <constant name="Vertex_half_length" value="302*mm"/>
+        <!-- cone to describe the upper acceptance of the LumiCal -->
+        <constant name="Vertex_LumiCal_Clearence" value="110*mrad"/>
+
+        <constant name="InnerTracker_inner_radius" value="61*mm"/>
+        <constant name="InnerTracker_outer_radius" value="696*mm"/>
+
+        <constant name="OuterTracker_inner_radius" value="696*mm"/>
+        <constant name="OuterTracker_outer_radius" value="2145*mm"/>  <!-- to avoid overlap with CaloFace, but it has to be large enough to accommodate OT-->
+        <constant name="OuterTracker_half_length" value="2300*mm"/>
+
+        <constant name="ECalBarrel_inner_radius" value="2150*mm"/>
+        <constant name="ECalBarrel_outer_radius" value="2352*mm"/>
+        <constant name="ECalBarrel_half_length" value="2210*mm"/>
+        <constant name="ECalBarrel_symmetry" value="12"/>
+
+        <constant name="ECalEndcap_inner_radius" value="340*mm"/>
+        <constant name="ECalEndcap_outer_radius" value="2455*mm"/>
+        <constant name="ECalEndcap_min_z" value="2307*mm"/>
+        <constant name="ECalEndcap_max_z" value="2509*mm"/>
+        <constant name="ECalEndcap_outer_symmetry" value="12"/>
+        <constant name="ECalEndcap_inner_symmetry" value="12"/>
+
+        <!-- ECal plug not used -->
+        <constant name="ECalPlug_inner_radius" value="260*mm"/>
+        <constant name="ECalPlug_outer_radius" value="380*mm"/>
+        <constant name="ECalPlug_min_z" value="2307*mm"/>
+        <constant name="ECalPlug_max_z" value="2509*mm"/>
+        <constant name="ECalPlug_outer_symmetry" value="12"/>
+        <constant name="ECalPlug_inner_symmetry" value="12"/>
+
+        <constant name="HCalBarrel_inner_radius" value="2400*mm"/>
+        <constant name="HCalBarrel_outer_radius" value="3566*mm"/>
+        <constant name="HCalBarrel_half_length" value="2210*mm"/>
+        <constant name="HCalBarrel_symmetry" value="12"/>
+
+        <constant name="HCalEndcap_inner_radius" value="340*mm"/>
+        <constant name="HCalEndcap_outer_radius" value="3566*mm"/>
+        <constant name="HCalEndcap_min_z" value="2539*mm"/>
+        <constant name="HCalEndcap_max_z" value="3705*mm"/>
+        <constant name="HCalEndcap_symmetry" value="12"/>
+        <constant name="HCalEndcap_zcutout" value="200*mm"/>
+        <constant name="HCalEndcap_rcutout" value="0*mm"/>
+
+        <constant name="HCalRing_inner_radius" value="2475*mm"/>
+        <constant name="HCalRing_outer_radius" value="HCalEndcap_outer_radius"/>
+        <constant name="HCalRing_min_z" value="2353.5*mm"/>
+        <constant name="HCalRing_max_z" value="HCalEndcap_min_z"/>
+        <constant name="HCalRing_symmetry" value="12"/>
+
+        <constant name="Solenoid_inner_radius" value="3719*mm"/>
+        <constant name="Solenoid_outer_radius" value="4272*mm"/>
+        <constant name="Solenoid_half_length" value="3705*mm"/>
+        <constant name="Solenoid_Coil_half_length" value="3476*mm"/>
+        <constant name="Solenoid_Coil_radius" value="3930*mm"/>
+
+        <constant name="YokeBarrel_inner_radius" value="4479*mm"/>
+        <constant name="YokeBarrel_outer_radius" value="6000*mm"/>
+        <constant name="YokeBarrel_half_length" value="3755*mm"/>
+        <constant name="YokeBarrel_symmetry" value="12"/>
+
+        <constant name="YokeEndcap_inner_radius" value="400*mm"/>
+        <constant name="YokeEndcap_outer_radius" value="6000*mm"/>
+        <constant name="YokeEndcap_min_z" value="3755*mm"/>
+        <constant name="YokeEndcap_max_z" value="5300*mm"/>
+        <constant name="YokeEndcap_outer_symmetry" value="12"/>
+        <constant name="YokeEndcap_inner_symmetry" value="0"/>
+
+        <constant name="CompSol_min_z" value="1230*mm"/>
+
+        <!-- For convenience, z here refers to dimensions *along the beam pipe*, which is tilted by CrossingAngle/2 w.r.t the global z axis -->
+        <constant name="LumiCal_min_z" value="1074*mm"/>
+        <constant name="LumiCal_dz" value="112.5/2.0"/> <!-- Must be consistent with layers defined in the lumiCal xml (25*4.5 mm)-->
+        <constant name="LumiCal_max_z" value="LumiCal_min_z+LumiCal_dz*2*mm" />
+
+        <constant name="LumiCal_inner_radius" value="55.0*mm"/>
+        <constant name="LumiCal_outer_radius" value="115.0*mm- env_safety"/>
+
+        <constant name="LumiCal_Instr_thickness" value="20*mm"/>
+        <constant name="LumiCal_Instr_inner_radius" value="LumiCal_outer_radius"/>
+        <constant name="LumiCal_Instr_outer_radius" value="LumiCal_outer_radius+LumiCal_Instr_thickness - env_safety"/>
+
+        <constant name="LumiCal_Cool_thickness" value="9.75*mm"/>
+        <constant name="LumiCal_Cool_inner_radius" value="LumiCal_Instr_outer_radius"/>
+        <constant name="LumiCal_Cool_outer_radius" value="LumiCal_Instr_outer_radius+LumiCal_Cool_thickness"/>
+
+        <!--preliminary LumiCal shielding-->
+        <!--back shielding-->
+        <constant name="LumiCal_Shield_inner_radius" value="LumiCal_inner_radius"/>
+        <constant name="LumiCal_Shield_outer_radius" value="LumiCal_outer_radius+LumiCal_Instr_thickness+LumiCal_Cool_thickness"/>
+        <!-- For convenience, z here refers to dimensions *along the beam pipe*, which is tilted by CrossingAngle/2 w.r.t the global z axis -->
+        <constant name="LumiCal_shield_dz" value="3.5/2.0*mm"/> <!-- Must be consistent with layers defined in the lumiCal xml (1*3.5 mm)-->
+
+        <constant name="BeamCal_inner_radius" value="32*mm"/>
+        <constant name="BeamCal_outer_radius" value="150*mm"/>
+        <constant name="BeamCal_min_z" value="3181*mm"/>
+        <constant name="BeamCal_max_z" value="3441*mm"/>
+        <constant name="BeamCal_dz" value="(BeamCal_max_z-BeamCal_min_z)/2.0"/>
+
+        <constant name="Kicker_inner_radius" value="4*mm"/>
+        <constant name="Kicker_outer_radius" value="25*mm"/>
+        <constant name="Kicker_min_z" value="3480*mm"/>
+        <constant name="Kicker_max_z" value="3780*mm"/>
+
+        <constant name="BPM_inner_radius" value="36*mm"/>
+        <constant name="BPM_outer_radius" value="55*mm"/>
+        <constant name="BPM_min_z" value="3790*mm"/>
+        <constant name="BPM_max_z" value="3880*mm"/>
+
+        <constant name="QD0_min_z" value="2000*mm"/>
+        <constant name="QD0_max_z" value="5400*mm"/>
+	<constant name="QD0Coil_outer_radius" value="30*mm"/>
+        <constant name="CollimatorInFrontOfQD0_dz" value="20*cm"/>
+        <constant name="CollimatorInFrontOfQD0_radius" value="10*mm"/>
+        <constant name="CollimatorInFrontOfQD0_dr" value="16*mm"/>
+
+        <constant name="tracker_region_zmax" value="OuterTracker_half_length"/>
+        <constant name="tracker_region_rmax" value="OuterTracker_outer_radius"/>
+
+        <constant name="GlobalTrackerReadoutID" type="string" value="system:5,side:-2,layer:6,module:11,sensor:8"/>
+    </define>
+
+    <limits>
+        <limitset name="cal_limits">
+            <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+        </limitset>
+    </limits>
+    <regions>
+        <region name="BeampipeRegion"            />
+        <region name="VertexBarrelRegion"        />
+        <region name="VertexEndcapRegion"        />
+        <region name="InnerTrackerBarrelRegion"  />
+        <region name="OuterTrackerBarrelRegion"  />
+        <region name="InnerTrackerEndcapRegion"  />
+        <region name="OuterTrackerEndcapRegion"  />
+    </regions>
+
+
+    <display>
+      <vis name="VXDVis"        alpha="0.1" r="0.1" 	g=".5"      b=".5"    showDaughters="true"  visible="false"/>
+      <vis name="ITVis"       	alpha="1.0" r="0.54"  	g="0.43"    b="0.04"  showDaughters="true"  visible="true"/>
+      <vis name="OTVis"       	alpha="1.0" r="0.8"   	g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
+      <vis name="ECALVis"     	alpha="1.0" r="0.0"   	g="0.48"    b="0.0"   showDaughters="true"  visible="true"/>
+      <vis name="HCALVis"     	alpha="1.0" r="0.74" 	g="0.81"    b="0.55"  showDaughters="true"  visible="true"/>
+      <vis name="SOLVis"      	alpha="1.0" r="0.4"   	g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
+      <vis name="YOKEVis"     	alpha="1.0" r="0.0"   	g="0.56"    b="0.28"  showDaughters="true"  visible="true"/>
+      <vis name="LCALInstrVis"  alpha="1.0" r="0.35"  	g="0.0"     b="0.47"  showDaughters="true"  visible="true"/>
+      <vis name="LCALVis"    	alpha="1.0" r="0.25"  	g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
+      <vis name="LCALCoolVis"   alpha="1.0" r="0.2"   	g="0.6"     b="0"     showDaughters="true"  visible="true"/>
+      <vis name="CompSolVis"    alpha="1.0" r="0.5"   	g="0.5"     b="0.0"   showDaughters="true"  visible="true"/>
+      <vis name="ScreenSolVis"  alpha="1.0" r="1"   	g="1"       b="0"     showDaughters="true"  visible="true"/>
+      <vis name="TantalumVis"   alpha="1.0" r="1"   	g="0.5"     b="0.5"   showDaughters="true"  visible="true"/>
+      <vis name="SupportVis"  	alpha="1"   r="0.2"   	g="0.2"     b="0.2"   showDaughters="true" visible="true"/>
+    </display>
+
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+    <include ref="Beampipe_o4_v05.xml"/>
+
+    <include ref="BeamInstrumentation_o3_v02_fitShield.xml"/>
+
+    <include ref="LumiCal_o3_v02_04.xml"/>
+
+    <include ref="Vertex_o4_v07_smallBP.xml"/>
+
+    <include ref="InnerTracker_o2_v07.xml"/>
+    <include ref="OuterTracker_o2_v07.xml"/>
+
+    <include ref="ECalBarrel_o2_v01_03.xml"/>
+    <include ref="ECalEndcap_o2_v01_03.xml"/>
+
+    <include ref="HCalBarrel_o1_v01_01.xml"/>
+    <include ref="HCalEndcap_o1_v01_01.xml"/>
+
+    <include ref="Solenoid_o1_v01_02.xml"/>
+
+    <include ref="YokeBarrel_o1_v01_02.xml"/>
+    <include ref="YokeEndcap_o1_v01_02.xml"/>
+
+    <plugins>
+      <plugin name="DD4hepVolumeManager"/>
+      <plugin name="InstallSurfaceManager"/>
+
+      <plugin name="lcgeo_LinearSortingPolicy">
+
+        <argument value="/InnerTrackerEndcapSupport_layer8" />
+        <argument value="InnerTracker_Barrel_half_length_0" />
+        <argument value="InnerTracker_Barrel_radius_0+0.5*mm" />
+        <argument value="0" />
+
+        <argument value="/InnerTrackerEndcapSupport_layer9" />
+        <argument value="InnerTracker_Barrel_half_length_0" />
+        <argument value="InnerTracker_Barrel_radius_1+0.5*mm" />
+        <argument value="0" />
+
+        <argument value="/InnerTrackerEndcapSupport" />
+        <argument value="InnerTracker_Barrel_half_length_0" />
+        <argument value="InnerTracker_Barrel_radius_1+0.5*mm" />
+        <argument value="(InnerTracker_outer_radius-InnerTracker_Barrel_radius_1)/(InnerTracker_half_length-InnerTracker_Barrel_half_length_0)" />
+
+        <argument value="/InnerTrackerEndcap/" />
+        <argument value="InnerTracker_Barrel_half_length_0" />
+        <argument value="InnerTracker_Barrel_radius_1" />
+        <argument value="(InnerTracker_outer_radius-InnerTracker_Barrel_radius_1)/(InnerTracker_half_length-InnerTracker_Barrel_half_length_0)" />
+
+        <argument value="/OuterTrackerEndcap/" />
+        <argument value="OuterTracker_Barrel_half_length" />
+        <argument value="OuterTracker_Barrel_radius_1" />
+        <argument value="(OuterTracker_Endcap_radius_2-OuterTracker_Barrel_radius_1)/(OuterTracker_half_length-OuterTracker_Barrel_half_length)" />
+
+        <argument value="/OuterTrackerEndcapSupport_layer4" />
+        <argument value="OuterTracker_Barrel_half_length" />
+        <argument value="OuterTracker_Barrel_radius_0+0.5*cm" />
+        <argument value="0.0" />
+
+        <argument value="/OuterTrackerEndcapSupport_layer5" />
+        <argument value="OuterTracker_Barrel_half_length" />
+        <argument value="OuterTracker_Barrel_radius_1+0.5*cm" />
+        <argument value="0.0" />
+
+        <argument value="/OuterTrackerEndcapSupport" />
+        <argument value="OuterTracker_Barrel_half_length" />
+        <argument value="OuterTracker_Barrel_radius_1+3*cm" />
+        <argument value="(OuterTracker_Endcap_radius_2-OuterTracker_Barrel_radius_1)/(OuterTracker_half_length-OuterTracker_Barrel_half_length)" />
+
+        <argument value="/VertexEndcap/" />
+        <argument value="VertexEndcap_z1" />
+        <argument value="VertexBarrel_r3+1*cm" />
+        <argument value="(VertexEndcap_rmax-VertexBarrel_r3+1*cm)/(VertexEndcap_z3-VertexEndcap_z1)" />
+
+        <argument value="/VertexVerticalCable" />
+        <argument value="0" />
+        <argument value="VertexBarrel_r3+0.5*cm" />
+        <argument value="0" />
+      </plugin>
+
+    </plugins>
+
+    <fields>
+
+      <field name="GlobalSolenoid" type="solenoid"
+             inner_field="SolenoidField"
+             outer_field="-1.0*tesla"
+             zmax="Solenoid_Coil_half_length"
+             outer_radius="Solenoid_Coil_radius">
+      </field>
+
+      <field name="CompensatingSolenoidZplus" type="solenoid"
+             inner_field="-SolenoidField -SolenoidField * QD0_min_z / ( QD0_min_z - CompSol_min_z)"
+             outer_field="0*tesla"
+             zmax="QD0_min_z"
+	     zmin="CompSol_min_z"
+             outer_radius="20*cm">
+      </field>
+
+      <field name="CompensatingSolenoidZminus" type="solenoid"
+             inner_field="-SolenoidField -SolenoidField * QD0_min_z / ( QD0_min_z - CompSol_min_z)"
+             outer_field="0*tesla"
+             zmin="-QD0_min_z"
+             zmax="-CompSol_min_z"
+             outer_radius="20*cm">
+      </field>
+
+<!-- Detailed field map -->
+<!--field name="TestField" type="FieldXYZ"
+             filename    = "fieldMapXYZ_120218.root"
+             treeName    = "ntuple"
+             xVarName    = "X"
+             yVarName    = "Y"
+             zVarName    = "Z"
+             BxVarName   = "Bx"
+             ByVarName   = "By"
+             BzVarName   = "Bz"
+             xScale      = "1.0"
+             yScale      = "1.0"
+             zScale      = "1.0"
+             bScale      = "1.0"
+             inner_radius="0*mm"
+             outer_radius="500*mm"
+             zmax="3000*mm"
+             coorUnits   = "mm"
+             BfieldUnits = "tesla">
+      </field-->
+
+<!-- to check with the visualisation that this works... :
+      <field name="GlobalSolenoid" type="solenoid"
+             inner_field="SolenoidField"
+             outer_field="-1.5*tesla"
+             zmax="1*m"
+             outer_radius="Solenoid_Coil_radius">
+      </field>
+      <field name="CompensatingSolenoid" type="solenoid"
+             inner_field="-SolenoidField"
+             outer_field="0*tesla"
+             zmax="3*m"
+             zmin="1*m"
+             outer_radius="Solenoid_Coil_radius">
+      </field>
+-->
+
+
+    </fields>
+
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/ECalBarrel_o2_v01_03.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/ECalBarrel_o2_v01_03.xml
@@ -1,0 +1,66 @@
+<lccdd>
+
+    <!--  Definition of the readout segmentation  -->
+    <define>
+        <constant name="ECal_cell_size" value="5.1*mm"/>
+    </define>
+
+    <readouts>
+        <readout name="ECalBarrelCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="ECal_cell_size" grid_size_y="ECal_cell_size" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+
+    <!--  Definitions of visualization attributes  -->
+    <display>
+        <vis name="ECalStaveVis"      alpha="1.0" r="0.0"  g="0.8"  b="1.0"  showDaughters="true"  visible="true"/>
+        <vis name="ECalLayerVis"      alpha="1.0" r="0.8"  g="0.8"  b="0.0"  showDaughters="true"  visible="true"/>
+        <vis name="ECalSensitiveVis"  alpha="1.0" r="0.7"  g="0.3"  b="0.0"  showDaughters="false" visible="true"/>
+        <vis name="ECalAbsorberVis"   alpha="1.0" r="0.4"  g="0.4"  b="0.0"  showDaughters="false" visible="true"/>
+        <vis name="ECalEndcapVis"     alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true"  visible="true"/>
+	<vis name="HiddenEnvelope"    alpha="0.0" r="1.0"  g="1.0"  b="1.0"  showDaughters="true"  visible="false"/>
+	<vis name="CompositeVis"      alpha="1.0" r="1.0"  g="0.0"  b="0.0"  showDaughters="true"  visible="true"/>
+    </display>
+
+    <detectors>
+        <detector name="ECalBarrel" type="GenericCalBarrel_o1_v01" id="DetID_ECal_Barrel" readout="ECalBarrelCollection" vis="ECALVis" gap="0.*cm">
+
+            <comment>EM Calorimeter Barrel</comment>
+
+            <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
+
+            <envelope vis="ECALVis">
+                <shape type="PolyhedraRegular" numsides="ECalBarrel_symmetry"  rmin="ECalBarrel_inner_radius" rmax="ECalBarrel_outer_radius" dz="2.*ECalBarrel_half_length"  material="Air"/>
+		<!-- Radii definitions as in http://cern.ch/go/r9mZ -->
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/ECalBarrel_symmetry"/>
+            </envelope>
+
+            <dimensions numsides="ECalBarrel_symmetry" rmin="ECalBarrel_inner_radius" z="ECalBarrel_half_length*2" />
+            <staves vis="ECalStaveVis" />
+            <layer repeat="40" vis="ECalLayerVis">
+                <slice material = "TungstenDens24" thickness = "1.90*mm" vis="ECalAbsorberVis" radiator="yes"/>
+                <slice material = "G10"            thickness = "0.15*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "GroundOrHVMix"  thickness = "0.10*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Silicon"        thickness = "0.50*mm" sensitive="yes" limits="cal_limits" vis="ECalSensitiveVis"/>
+                <slice material = "Air"            thickness = "0.10*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "siPCBMix"       thickness = "1.30*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Air"            thickness = "0.25*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "G10"            thickness = "0.75*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+        </detector>
+    </detectors>
+
+    <plugins>
+        <plugin name="DD4hep_CaloFaceBarrelSurfacePlugin">
+            <argument value="ECalBarrel"/>
+            <argument value="length=2.*ECalBarrel_half_length"    />
+            <argument value="radius=ECalBarrel_inner_radius"  />
+            <argument value="phi0=0"    />
+            <argument value="symmetry=ECalBarrel_symmetry"/>
+            <argument value="systemID=DetID_ECal_Barrel"/>
+        </plugin>
+    </plugins>
+
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/ECalEndcap_o2_v01_03.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/ECalEndcap_o2_v01_03.xml
@@ -1,0 +1,57 @@
+<lccdd>
+
+
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="ECalEndcapCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="ECal_cell_size" grid_size_y="ECal_cell_size" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+
+    <!--  Includes for sensitives and support                -->
+    <detectors>
+
+        <detector name="ECalEndcap" type="GenericCalEndcap_o1_v01" id="DetID_ECal_Endcap" readout="ECalEndcapCollection" vis="ECALVis" >
+
+            <comment>Electromagnetic Calorimeter Endcap</comment>
+
+            <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP"/>
+
+            <envelope vis="ECALVis">
+                <shape type="BooleanShape" operation="Subtraction" material="Air">
+                        <shape type="PolyhedraRegular"  numsides="ECalEndcap_outer_symmetry" rmin="ECalEndcap_inner_radius-env_safety" rmax="ECalEndcap_outer_radius+ 10.0*env_safety" dz="2.0*ECalEndcap_max_z+2*env_safety"/>
+                        <shape type="PolyhedraRegular"  numsides="ECalEndcap_outer_symmetry" rmin="0" rmax="ECalEndcap_outer_radius+ 100.0*env_safety" dz="2.0*ECalEndcap_min_z-2*env_safety"/>
+                    </shape>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/ECalEndcap_outer_symmetry"/>
+            </envelope>
+
+
+            <dimensions nsides_inner="ECalEndcap_inner_symmetry" nsides_outer="(int) ECalEndcap_outer_symmetry" zmin="ECalEndcap_min_z" rmin="ECalEndcap_inner_radius" rmax="ECalEndcap_outer_radius"/>
+
+            <layer repeat="40" vis="ECalLayerVis">
+                <slice material = "TungstenDens24" thickness = "1.90*mm" vis="ECalAbsorberVis" radiator="yes"/>
+                <slice material = "G10"            thickness = "0.15*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "GroundOrHVMix"  thickness = "0.10*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Silicon"        thickness = "0.50*mm" sensitive="yes" limits="cal_limits" vis="ECalSensitiveVis"/>
+                <slice material = "Air"            thickness = "0.10*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "siPCBMix"       thickness = "1.30*mm" vis="ECalAbsorberVis"/>
+                <slice material = "Air"            thickness = "0.25*mm" vis="InvisibleNoDaughters"/>
+                <slice material = "G10"            thickness = "0.75*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+
+        </detector>
+    </detectors>
+
+    <plugins>
+        <plugin name="DD4hep_CaloFaceEndcapSurfacePlugin">
+            <argument value="ECalEndcap"/>
+	        <argument value="zpos=ECalEndcap_min_z"    />
+	        <argument value="radius=ECalEndcap_outer_radius"  />
+	        <argument value="phi0=0"    />
+	        <argument value="symmetry=ECalEndcap_outer_symmetry"/>
+	        <argument value="systemID=DetID_ECal_Endcap"/>
+	  </plugin>
+    </plugins>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/HCalBarrel_o1_v01_01.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/HCalBarrel_o1_v01_01.xml
@@ -1,0 +1,58 @@
+<lccdd>
+    <!--  Definition of global dictionary constants          -->
+    <define>
+        <constant name="HCalBarrel_layers" value="(int) 44"/>
+        <constant name="HCalBarrel_layer_thickness" value="2.0*cm + 0.65*cm"/>
+        <constant name="HCal_cell_size" value="3.0*cm"/>
+
+    </define>
+
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="HCalBarrelVis"    alpha="1" r="0.0"  g="0.3"  b="0.8" showDaughters="true" visible="true"/>
+        <vis name="HCalStavesVis"    alpha="1" r="0.0"  g="0.0"  b="0.1" showDaughters="true" visible="false"/>
+        <vis name="HCalLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
+        <vis name="HCalSensorVis"    alpha="1" r="1.0"  g="0.0"  b="0.2" showDaughters="true" visible="true"/>
+        <vis name="HCalAbsorberVis"  alpha="1" r="0.4"  g="0.4"  b="0.6" showDaughters="true" visible="true"/>
+
+        <vis name="HCalEndcapVis"          alpha="1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
+        <vis name="HCalEndcapLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
+    </display>
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="HCalBarrelCollection">
+          <segmentation type="CartesianGridXY" grid_size_x="HCal_cell_size" grid_size_y="HCal_cell_size" />
+          <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+
+    <detectors>
+        <detector id="DetID_HCAL_Barrel" name="HCalBarrel" type="GenericCalBarrel_o1_v01" readout="HCalBarrelCollection" vis="HCALVis" calorimeterType="HAD_BARREL" gap="0.*cm" material="Steel235">
+
+            <comment>Hadron Calorimeter Barrel</comment>
+
+	    <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_BARREL"/>
+
+            <envelope vis="HCALVis">
+                <shape type="PolyhedraRegular" numsides="HCalBarrel_symmetry"  rmin="HCalBarrel_inner_radius-10*env_safety" rmax="HCalBarrel_outer_radius+10*env_safety" dz="HCalBarrel_half_length*2+10*env_safety" material = "Air"/>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/HCalBarrel_symmetry"/>
+            </envelope>
+
+
+            <dimensions numsides="HCalBarrel_symmetry" rmin="HCalBarrel_inner_radius" z="HCalBarrel_half_length*2"/>
+            <staves vis="HCalStavesVis"/>
+            <layer repeat="(int) HCalBarrel_layers" vis="HCalLayerVis">
+                <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
+                <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Air" thickness="2.7*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+        </detector>
+
+    </detectors>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/HCalEndcap_o1_v01_01.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/HCalEndcap_o1_v01_01.xml
@@ -1,0 +1,131 @@
+<lccdd>
+    <define>
+        <constant name="HCalEndcap_layers" value="44"/>
+        <constant name="HCalEndcap_layer_thickness" value="2.0*cm + 0.65*cm"/>
+        <constant name="HCal_cell_size" value="3.0*cm"/>
+        <constant name="HCalEndcap_cutout_layers" value="- floor( -HCalEndcap_zcutout / HCalEndcap_layer_thickness)"/>
+        <constant name="HCalRing_layers" value=" floor( (HCalEndcap_min_z - HCalRing_min_z) / HCalEndcap_layer_thickness + 0.5)"/>
+    </define>
+
+
+    <detectors>
+        <detector name="HCalEndcaps" type="DD4hep_SubdetectorAssembly" vis="HCALVis">
+
+                <shape type="BooleanShape" operation="Subtraction" material="Air">
+                    <shape type="BooleanShape" operation="Subtraction">
+                        <shape type="BooleanShape" operation="Subtraction">
+                            <shape type="BooleanShape" operation="Subtraction">
+                                <shape type="PolyhedraRegular"  numsides="HCalEndcap_symmetry" rmin="0" rmax="HCalEndcap_outer_radius+5*env_safety" dz="2.0*HCalEndcap_max_z+10*env_safety"/>
+                                <shape type="PolyhedraRegular"  numsides="HCalEndcap_symmetry" rmin="0" rmax="HCalEndcap_outer_radius+10*env_safety" dz="2.0*HCalRing_min_z-5*env_safety"/>
+                            </shape>
+                            <shape type="PolyhedraRegular"  numsides="HCalEndcap_symmetry" rmin="0" rmax="HCalRing_inner_radius-5*env_safety" dz="2.0*HCalEndcap_min_z-10*env_safety"/>
+                        </shape>
+                        <shape type="PolyhedraRegular"  numsides="HCalEndcap_symmetry" rmin="0" rmax="HCalEndcap_inner_radius + HCalEndcap_rcutout" dz="2.0*HCalEndcap_min_z + 2*HCalEndcap_zcutout"/>
+                    </shape>
+                    <shape type="Tube" rmin="0" rmax="HCalEndcap_inner_radius-env_safety" dz="2.0*HCalEndcap_max_z + 2*HCalEndcap_zcutout"/>
+                </shape>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/HCalEndcap_symmetry"/>
+
+
+            <comment>HCalEndcap Assembly</comment>
+            <composite name="HCalEndcap"/>
+            <composite name="HCalRing"/>
+        </detector>
+    </detectors>
+
+
+
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="HCalEndcapCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="HCal_cell_size" grid_size_y="HCal_cell_size" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+        <readout name="HCalRingCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="HCal_cell_size" grid_size_y="HCal_cell_size" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+
+
+    <detectors>
+
+        <detector name="HCalEndcap" type="GenericCalEndcap_o1_v01" id="DetID_HCAL_Endcap" readout="HCalEndcapCollection" vis="HCALVis" >
+
+            <comment>Hadronic Calorimeter Endcap</comment>
+
+	    <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_ENDCAP"/>
+
+            <envelope vis="HCALVis">
+                <shape type="Assembly"/>
+            </envelope>
+
+
+            <dimensions nsides_inner="HCalEndcap_symmetry" nsides_outer="(int) HCalEndcap_symmetry" zmin="HCalEndcap_min_z" rmin="HCalEndcap_inner_radius" rmax="HCalEndcap_outer_radius" phi0="0" rmin2="HCalEndcap_rcutout" z2="HCalEndcap_cutout_layers * HCalEndcap_layer_thickness"/>
+
+            <layer repeat="HCalEndcap_cutout_layers" gap="HCalEndcap_rcutout" vis="HCalEndcapLayerVis">
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
+                <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Air" thickness="2.7*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+
+            <layer repeat="HCalEndcap_layers - HCalEndcap_cutout_layers" vis="HCalEndcapLayerVis">
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
+                <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Air" thickness="2.7*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+
+
+        </detector>
+
+    </detectors>
+
+
+
+    <detectors>
+
+        <detector name="HCalRing" type="GenericCalEndcap_o1_v01" id="DetID_HCAL_Ring" readout="HCalRingCollection" vis="HCALVis" >
+
+            <comment>Hadronic Calorimeter Endcap</comment>
+
+	    <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_ENDCAP + DetType_AUXILIARY"/>
+
+            <envelope vis="HCALVis">
+                <shape type="Assembly"/>
+            </envelope>
+
+
+            <dimensions nsides_inner="HCalEndcap_symmetry" nsides_outer="(int) HCalEndcap_symmetry" zmin="HCalRing_min_z" rmin="HCalRing_inner_radius" rmax="HCalRing_outer_radius" phi0="0" rmin2="0" z2="HCalRing_layers * HCalEndcap_layer_thickness"/>
+
+
+            <layer repeat="HCalRing_layers" vis="HCalEndcapLayerVis">
+                <slice material="Steel235" thickness="19*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Polystyrene" thickness="3*mm" sensitive="yes" limits="cal_limits" vis="HCalSensorVis"/>
+                <slice material="Copper" thickness="0.1*mm" vis="HCalCopperVis"/>
+                <slice material="PCB" thickness="0.7*mm" vis="HCalPCBVis"/>
+                <slice material="Steel235" thickness="0.5*mm" vis="HCalAbsorberVis" radiator="yes"/>
+                <slice material="Air" thickness="2.7*mm" vis="InvisibleNoDaughters"/>
+            </layer>
+
+
+        </detector>
+
+    </detectors>
+
+
+
+
+
+
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/InnerTrackerBarrelModuleDown.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/InnerTrackerBarrelModuleDown.xml
@@ -1,0 +1,25 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"  sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"         sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"  sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"               sensitive="false"/>
+
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer" sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"      sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer" sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"             sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"               sensitive="true" />
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Module: Glue"                 sensitive="false"/>
+    <module_component thickness="0.120*mm"  material="CarbonFiber"      info="Module: Plate"                sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"               sensitive="false"/>
+
+    <module_component thickness="0.020*mm"  material="CarbonFiber_25D"  info="Cold Plate: Carbon fleece"    sensitive="false"/>
+    <module_component thickness="0.120*mm"  material="CarbonFiber"      info="Cold Plate: Carbon plate"     sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Cold Plate: Cooling fluid"    sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Cold Plate: Cooling pipe"     sensitive="false"/>
+    <module_component thickness="0.030*mm"  material="CarbonFiber"      info="Cold Plate: Graphite foil"    sensitive="false"/>
+    <module_component thickness="0.020*mm"  material="CarbonFiber_25D"  info="Cold Plate: Carbon fleece"    sensitive="false"/>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/InnerTrackerBarrelModuleUp.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/InnerTrackerBarrelModuleUp.xml
@@ -1,0 +1,25 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.020*mm"  material="CarbonFiber_25D"  info="Cold Plate: Carbon fleece"    sensitive="false"/>
+    <module_component thickness="0.030*mm"  material="CarbonFiber"      info="Cold Plate: Graphite foil"    sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Cold Plate: Cooling pipe"     sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Cold Plate: Cooling fluid"    sensitive="false"/>
+    <module_component thickness="0.120*mm"  material="CarbonFiber"      info="Cold Plate: Carbon plate"     sensitive="false"/>
+    <module_component thickness="0.020*mm"  material="CarbonFiber_25D"  info="Cold Plate: Carbon fleece"    sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"               sensitive="false"/>
+
+    <module_component thickness="0.120*mm"  material="CarbonFiber"      info="Module: Plate"                sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Module: Glue"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"               sensitive="true" />
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"             sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer" sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"      sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer" sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"               sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"  sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"         sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"  sensitive="false"/>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/InnerTracker_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/InnerTracker_o2_v07.xml
@@ -1,0 +1,582 @@
+<lccdd>
+    <define>
+
+        <constant name="InnerTracker_Barrel_radius_0" value="127*mm"/>
+        <constant name="InnerTracker_Barrel_radius_1" value="400*mm"/>
+        <constant name="InnerTracker_Barrel_radius_2" value="670*mm"/>
+
+        <constant name="InnerTracker_Barrel_half_length_0" value="481.6*mm"/>
+        <constant name="InnerTracker_Barrel_half_length_1" value="481.6*mm"/>
+        <constant name="InnerTracker_Barrel_half_length_2" value="692.3*mm"/>
+
+        <constant name="InnerTracker_Endcap_z_0" value="524*mm"/>
+        <constant name="InnerTracker_Endcap_z_1" value="808*mm"/>
+        <constant name="InnerTracker_Endcap_z_2" value="1093*mm"/>
+        <constant name="InnerTracker_Endcap_z_3" value="1377*mm"/>
+        <constant name="InnerTracker_Endcap_z_4" value="1661*mm"/>
+        <constant name="InnerTracker_Endcap_z_5" value="1946*mm"/>
+        <constant name="InnerTracker_Endcap_z_6" value="2190*mm"/>
+
+        <constant name="InnerTracker_Endcap_radius_0" value="79.5*mm"/>
+        <constant name="InnerTracker_Endcap_radius_1" value="123.5*mm"/>
+        <constant name="InnerTracker_Endcap_radius_2" value="165*mm"/>
+        <constant name="InnerTracker_Endcap_radius_3" value="207.5*mm"/>
+        <constant name="InnerTracker_Endcap_radius_4" value="249.5*mm"/>
+        <constant name="InnerTracker_Endcap_radius_5" value="293*mm"/>
+        <constant name="InnerTracker_Endcap_radius_6" value="330*mm"/>
+
+        <constant name="VertexCoolingGap"            value="5*mm"/>
+        <constant name="VertexCoolingShellThickness" value="1*mm"/>
+
+        <constant name="ITM" value="15.1*mm"/>
+        <constant name="ITEnvelopeClearanceConeHalfAngle" value="149*mrad" />
+    </define>
+
+
+    <comment>Tracking detectors</comment>
+    <detectors>
+        <detector name="InnerTrackers" type="DD4hep_SubdetectorAssembly" vis="ITVis">
+
+            <shape type="Polycone" material="Air">
+              <zplane z="-InnerTracker_half_length"       rmin="ITEnvelopeClearanceConeHalfAngle * ConeBeamPipe_zmax"             rmax="InnerTracker_outer_radius" />
+              <zplane z="-(Vertex_half_length + 5 * mm)"  rmin="ITEnvelopeClearanceConeHalfAngle * (Vertex_half_length + 5 * mm)" rmax="InnerTracker_outer_radius" />
+              <zplane z="-(Vertex_half_length)"           rmin="Vertex_outer_radius"                                              rmax="InnerTracker_outer_radius" />
+              <zplane z="+(Vertex_half_length)"           rmin="Vertex_outer_radius"                                              rmax="InnerTracker_outer_radius" />
+              <zplane z="+(Vertex_half_length + 5 * mm)"  rmin="ITEnvelopeClearanceConeHalfAngle * (Vertex_half_length + 5 * mm)" rmax="InnerTracker_outer_radius" />
+              <zplane z="+InnerTracker_half_length"       rmin="ITEnvelopeClearanceConeHalfAngle * ConeBeamPipe_zmax"             rmax="InnerTracker_outer_radius" />
+	    </shape>
+
+            <comment>Inner Tracker Assembly</comment>
+            <composite name="InnerTrackerBarrel"/>
+            <composite name="InnerTrackerEndcap"/>
+	    <composite name="InnerTrackerBarrelSupport"/>
+	    <composite name="InnerTrackerEndcapSupport"/>
+	    <composite name="InnerTrackerInterlink"/>
+	    <composite name="InnerTrackerVertexCable"/>
+	    <!-- <composite name="BeampipeShell"/> -->
+	    <composite name="BeampipeShell2"/>
+	    <composite name="BeampipeShell3"/>
+        </detector>
+    </detectors>
+
+
+    <display>
+        <vis name="InnerTrackerModuleVis"  alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+        <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+        <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+        <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
+        <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+    </display>
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="InnerTrackerBarrelCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+        <readout name="InnerTrackerEndcapCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+    </readouts>
+
+    <detectors>
+
+        <detector id="DetID_IT_Barrel" name="InnerTrackerBarrel" type="TrackerBarrel_o1_v05" readout="InnerTrackerBarrelCollection" region="InnerTrackerBarrelRegion">
+            <envelope vis="ITVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Silicon Inner Tracker Barrel</comment>
+
+            <type_flags type=" DetType_TRACKER + DetType_BARREL"/>
+
+            <module name="InnerTrackerBarrelModule_01" vis="InnerTrackerModuleVis">
+                <module_envelope width="30.1*mm" length="30.1*mm"/>
+                <include ref="InnerTrackerBarrelModuleDown.xml"/>
+            </module>
+
+            <layer module="InnerTrackerBarrelModule_01" id="0" type="1" >
+                <rphi_layout phi_tilt="0*deg" nphi="14*2" phi0="0" rc="InnerTracker_Barrel_radius_0" dr="2.5*mm"/>
+                <z_layout dr="0" z0="InnerTracker_Barrel_half_length_0-15.05*mm" nz="32"/>
+            </layer>
+            <layer module="InnerTrackerBarrelModule_01" id="1" >
+                <rphi_layout phi_tilt="0*deg" nphi="43*2" phi0="0" rc="InnerTracker_Barrel_radius_1" dr="2.5*mm"/>
+                <z_layout dr="0" z0="InnerTracker_Barrel_half_length_1-15.05*mm" nz="32"/>
+            </layer>
+            <layer module="InnerTrackerBarrelModule_01" id="2" >
+                <rphi_layout phi_tilt="0*deg" nphi="71*2" phi0="0" rc="InnerTracker_Barrel_radius_2" dr="2.5*mm"/>
+                <z_layout dr="0" z0="InnerTracker_Barrel_half_length_2-15.05*mm" nz="46"/>
+            </layer>
+
+        </detector>
+
+
+        <detector id="DetID_IT_Endcap" name="InnerTrackerEndcap" type="TrackerEndcap_o2_v06" readout="InnerTrackerEndcapCollection" reflect="true" region="InnerTrackerEndcapRegion">
+            <envelope vis="ITVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Silicon Inner Tracker Endcaps</comment>
+
+            <type_flags type=" DetType_TRACKER + DetType_ENDCAP"/>
+
+            <module name="InnerTrackerEndcapModule_2x2_Out" vis="InnerTrackerModuleVis">
+                <trd x="30.2*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_3x2_Out" vis="InnerTrackerModuleVis">
+                <trd x="45.3*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_3x4_Out" vis="InnerTrackerModuleVis">
+                <trd x="45.3*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_4x2_Out" vis="InnerTrackerModuleVis">
+                <trd x="60.4*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_4x4_Out" vis="InnerTrackerModuleVis">
+                <trd x="60.4*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x2_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x4_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x5_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_6x4_Out" vis="InnerTrackerModuleVis">
+                <trd x="90.6*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x6_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="90.6*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x7_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x8_Out" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_6x7_Out" vis="InnerTrackerModuleVis">
+                <trd x="90.6*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_6x8_Out" vis="InnerTrackerModuleVis">
+                <trd x="90.6*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_7x5_Out" vis="InnerTrackerModuleVis">
+                <trd x="105.7*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_7x8_Out" vis="InnerTrackerModuleVis">
+                <trd x="105.7*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x4_Out" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x5_Out" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x7_Out" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x8_Out" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x3_Out" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="45.3*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x5_Out" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x8_Out" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x9_Out" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="135.9*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_10x4_Out" vis="InnerTrackerModuleVis">
+              <trd x="151*mm" y="60.4*mm"/>
+              <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_10x8_Out" vis="InnerTrackerModuleVis">
+              <trd x="151*mm" y="120.8*mm"/>
+              <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_10x9_Out" vis="InnerTrackerModuleVis">
+              <trd x="151*mm" y="135.9*mm"/>
+              <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x2_Out" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x3_Out" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="45.3*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x5_Out" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x6_Out" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="90.6*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_12x3_Out" vis="InnerTrackerModuleVis">
+                <trd x="181.2*mm" y="45.3*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_12x5_Out" vis="InnerTrackerModuleVis">
+                <trd x="181.2*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_12x8_Out" vis="InnerTrackerModuleVis">
+                <trd x="181.2*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+
+            <module name="InnerTrackerEndcapModule_2x2_In" vis="InnerTrackerModuleVis">
+                <trd x="30.2*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_3x2_In" vis="InnerTrackerModuleVis">
+                <trd x="45.3*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_3x4_In" vis="InnerTrackerModuleVis">
+                <trd x="45.3*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_4x2_In" vis="InnerTrackerModuleVis">
+                <trd x="60.4*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_4x4_In" vis="InnerTrackerModuleVis">
+                <trd x="60.4*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x2_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x4_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x5_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x6_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="90.6*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x7_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_5x8_In" vis="InnerTrackerModuleVis">
+                <trd x="75.5*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_6x4_In" vis="InnerTrackerModuleVis">
+                <trd x="90.6*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_6x7_In" vis="InnerTrackerModuleVis">
+                <trd x="90.6*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_6x8_In" vis="InnerTrackerModuleVis">
+                <trd x="90.6*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_7x5_In" vis="InnerTrackerModuleVis">
+                <trd x="105.7*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_7x8_In" vis="InnerTrackerModuleVis">
+                <trd x="105.7*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x4_In" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="60.4*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x5_In" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x7_In" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="105.7*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_8x8_In" vis="InnerTrackerModuleVis">
+                <trd x="120.8*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x3_In" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="45.3*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x5_In" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x8_In" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_9x9_In" vis="InnerTrackerModuleVis">
+                <trd x="135.9*mm" y="135.9*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_10x4_In" vis="InnerTrackerModuleVis">
+              <trd x="151*mm" y="60.4*mm"/>
+              <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_10x8_In" vis="InnerTrackerModuleVis">
+              <trd x="151*mm" y="120.8*mm"/>
+              <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_10x9_In" vis="InnerTrackerModuleVis">
+              <trd x="151*mm" y="135.9*mm"/>
+              <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x2_In" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="30.2*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x3_In" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="45.3*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x5_In" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_11x6_In" vis="InnerTrackerModuleVis">
+                <trd x="166.1*mm" y="90.6*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_12x3_In" vis="InnerTrackerModuleVis">
+                <trd x="181.2*mm" y="45.3*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_12x5_In" vis="InnerTrackerModuleVis">
+                <trd x="181.2*mm" y="75.5*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="InnerTrackerEndcapModule_12x8_In" vis="InnerTrackerModuleVis">
+                <trd x="181.2*mm" y="120.8*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+
+           <layer id="0">
+                <ring r="InnerTracker_Endcap_radius_0"        zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_2x2_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_0+2*ITM"  zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_3x4_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_0+6*ITM"  zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_4x4_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_0+10*ITM" zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_5x4_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_0+14*ITM" zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_6x4_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_0+18*ITM" zstart="InnerTracker_Endcap_z_0" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_8x7_Out" phi0="0"/>
+            </layer>
+
+            <layer id="1">
+                <ring r="InnerTracker_Endcap_radius_1"        zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_3x2_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_1+2*ITM"  zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_4x2_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_1+4*ITM"  zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_6x7_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_1+11*ITM" zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_8x8_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_1+19*ITM" zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x8_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_1+27*ITM" zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_11x3_In" phi0="0"/>
+		<ring r="InnerTracker_Endcap_radius_1+30*ITM" zstart="InnerTracker_Endcap_z_1" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_12x5_In"  phi0="0"/>
+            </layer>
+
+
+            <layer id="2">
+                <ring r="InnerTracker_Endcap_radius_2"        zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_4x2_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_2+2*ITM"  zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_6x7_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_2+9*ITM"  zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_8x8_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_2+17*ITM" zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_10x8_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_2+25*ITM" zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_12x3_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_2+28*ITM" zstart="InnerTracker_Endcap_z_2" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_12x5_Out" phi0="0"/>
+            </layer>
+
+
+            <layer id="3">
+                <ring r="InnerTracker_Endcap_radius_3"        zstart="InnerTracker_Endcap_z_3" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_5x5_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_3+5*ITM"  zstart="InnerTracker_Endcap_z_3" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x8_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_3+13*ITM" zstart="InnerTracker_Endcap_z_3" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_10x9_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_3+22*ITM" zstart="InnerTracker_Endcap_z_3" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_12x8_In" phi0="0"/>
+            </layer>
+
+
+            <layer id="4">
+                <ring r="InnerTracker_Endcap_radius_4"        zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_6x4_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_4+4*ITM"  zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_8x8_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_4+12*ITM" zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x5_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_4+17*ITM" zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_10x4_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_4+21*ITM" zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_11x3_Out" phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_4+24*ITM" zstart="InnerTracker_Endcap_z_4" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_12x3_Out" phi0="0"/>
+            </layer>
+
+
+            <layer id="5">
+                <ring r="InnerTracker_Endcap_radius_5"        zstart="InnerTracker_Endcap_z_5" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x5_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_5+5*ITM"  zstart="InnerTracker_Endcap_z_5" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x8_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_5+13*ITM" zstart="InnerTracker_Endcap_z_5" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_10x4_In"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_5+17*ITM" zstart="InnerTracker_Endcap_z_5" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_11x6_In"  phi0="0"/>
+            </layer>
+
+            <layer id="6">
+                <ring r="InnerTracker_Endcap_radius_6"        zstart="InnerTracker_Endcap_z_6" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_7x5_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_6+5*ITM"  zstart="InnerTracker_Endcap_z_6" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x3_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_6+8*ITM"  zstart="InnerTracker_Endcap_z_6" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_9x5_Out"  phi0="0"/>
+                <ring r="InnerTracker_Endcap_radius_6+13*ITM" zstart="InnerTracker_Endcap_z_6" nmodules="24" dz="3*mm" module="InnerTrackerEndcapModule_12x8_Out" phi0="0"/>
+            </layer>
+
+        </detector>
+
+	<detector name="InnerTrackerBarrelSupport" type="TrackerBarrelSupport_o1_v01" id="0"  reflect="true" region="InnerTrackerBarrelRegion">
+	    <envelope>
+		<shape type="Assembly"/>
+	    </envelope>
+	    <layer id="1" inner_r="InnerTracker_Barrel_radius_0+0.5*cm" outer_z="InnerTracker_Barrel_half_length_0" vis="SupportVis">
+		<slice material="CarbonFiber" thickness="0.17/3.5959*cm" />
+	    </layer>
+	    <layer id="2" inner_r="InnerTracker_Barrel_radius_1+0.5*cm" outer_z="InnerTracker_Barrel_half_length_1" vis="SupportVis">
+		<slice material="CarbonFiber" thickness="0.17/3.5959*cm" />
+	    </layer>
+	    <layer id="3" inner_r="InnerTracker_Barrel_radius_2+0.5*cm" outer_z="InnerTracker_Barrel_half_length_2" vis="SupportVis">
+		<slice material="CarbonFiber" thickness="0.17/3.5959*cm" />
+	    </layer>
+	    <layer id="4" inner_r="InnerTracker_outer_radius-1*cm" outer_z="InnerTracker_half_length" vis="SupportVis">
+		<slice material="CarbonFiber" thickness="1.25/3.5959*cm" />
+	    </layer>
+	    <comment>3.5959*cm = X0 for Carbon fibre</comment>
+	</detector>
+
+
+	<detector name="InnerTrackerEndcapSupport" type="TrackerEndcapSupport_o1_v02" reflect="true" region="InnerTrackerEndcapRegion">
+	  <envelope>
+	    <shape type="Assembly"/>
+	  </envelope>
+	  <layer id="0" inner_r="InnerTracker_Endcap_radius_0" inner_z="InnerTracker_Endcap_z_0-1*cm" outer_r="456*mm" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.330/3.5959*cm" />
+	  </layer>
+	  <layer id="1" inner_r="InnerTracker_Endcap_radius_1" inner_z="InnerTracker_Endcap_z_1+1*cm" outer_r="InnerTracker_Barrel_radius_2+1*mm" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.308/3.5959*cm" />
+	  </layer>
+	  <layer id="2" inner_r="InnerTracker_Endcap_radius_2" inner_z="InnerTracker_Endcap_z_2-1*cm" outer_r="InnerTracker_Barrel_radius_2+1*mm" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.308/3.5959*cm" />
+	  </layer>
+	  <layer id="3" inner_r="InnerTracker_Endcap_radius_3+20*env_safety" inner_z="InnerTracker_Endcap_z_3+1*cm" outer_r="InnerTracker_Barrel_radius_2+1*mm" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.343/3.5959*cm" />
+	  </layer>
+	  <layer id="4" inner_r="InnerTracker_Endcap_radius_4" inner_z="InnerTracker_Endcap_z_4-1*cm" outer_r="InnerTracker_Barrel_radius_2+1*mm" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.343/3.5959*cm" />
+	  </layer>
+	  <layer id="5" inner_r="InnerTracker_Endcap_radius_5+20*env_safety" inner_z="InnerTracker_Endcap_z_5+1*cm" outer_r="InnerTracker_Barrel_radius_2+1*mm" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.369/3.5959*cm" />
+	  </layer>
+	  <layer id="6" inner_r="InnerTracker_Endcap_radius_6" inner_z="InnerTracker_Endcap_z_6-1*cm" outer_r="InnerTracker_Barrel_radius_2+1*mm" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.369/3.5959*cm" />
+	  </layer>
+	  <layer id="7" inner_r="InnerTracker_Barrel_radius_2-2*cm+0.6/3.5959*cm" inner_z="InnerTracker_Barrel_half_length_2+2*cm" outer_r="InnerTracker_outer_radius-1*cm" vis="InterlinkVis">
+	    <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+	  </layer>
+	  <layer id="8" inner_r="InnerTracker_Barrel_radius_0" inner_z="InnerTracker_Barrel_half_length_1+2*cm" outer_r="InnerTracker_Barrel_radius_1" vis="InterlinkVis">
+            <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+          </layer>
+          <layer id="9" inner_r="InnerTracker_Barrel_radius_1" inner_z="InnerTracker_Barrel_half_length_1+2*cm" outer_r="InnerTracker_Barrel_radius_2-2*cm" vis="InterlinkVis">
+	    <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+          </layer>
+    </detector>
+
+
+	<detector name="InnerTrackerInterlink" type="TubeSupport_o1_v01" reflect="true" region="InnerTrackerEndcapRegion">
+	    <envelope>
+		<shape type="Assembly"/>
+	    </envelope>
+	    <section start="InnerTracker_Barrel_half_length_1+2*cm"  end="InnerTracker_Barrel_half_length_2+2*cm"        rMin="InnerTracker_Barrel_radius_2-2*cm"  rMax="InnerTracker_Barrel_radius_2-2*cm+0.6/3.5959*cm"  material="CarbonFiber" name="InterlinkTube" vis="InterlinkVis"/>
+	</detector>
+
+	<detector name="InnerTrackerVertexCable" type="TubeSupport_o1_v01" reflect="true" region="BeampipeRegion">
+	    <envelope>
+		<shape type="Assembly"/>
+	    </envelope>
+	    <section start="12.6*cm" end="495*mm" rMin="Vertex_outer_radius+0.5*mm" rMax="Vertex_outer_radius+0.5*mm+0.067*mm" material="Copper" name="VertexCableTube" vis="SiVertexCableVis"/>
+	</detector>
+
+
+	<!-- <detector name="BeampipeShell" type="ConicalSupport_o1_v01" reflect="true" region="BeampipeRegion"> -->
+	<!--     <envelope> -->
+	<!--         <shape type="Assembly"/> -->
+	<!--     </envelope> -->
+	<!--     <section start="500*mm"  end="ConeBeamPipe_zmax"        rMin1="52.7*mm+VertexCoolingGap"  rMin2="ConeBeamPipe_rmax_1+VertexCoolingGap" rMax1="52.7*mm+VertexCoolingGap+VertexCoolingShellThickness"           rMax2="ConeBeamPipe_rmax_1+VertexCoolingGap+VertexCoolingShellThickness" material="CarbonFiber" name="ConeSupport" vis="SupportVis"/> -->
+	<!--     <section start="ConeBeamPipe_zmax" end="InnerTracker_half_length" rMin1="ConeBeamPipe_rmax_1+VertexCoolingGap" rMin2="ConeBeamPipe_rmax_1+VertexCoolingGap" rMax1="ConeBeamPipe_rmax_1+VertexCoolingGap+VertexCoolingShellThickness" rMax2="ConeBeamPipe_rmax_1+VertexCoolingGap+VertexCoolingShellThickness" material="CarbonFiber" name="TubeSupport" vis="SupportVis"/> -->
+	<!-- </detector> -->
+
+
+	<detector name="BeampipeShell2" type="TrackerEndcapSupport_o1_v02" reflect="true" region="BeampipeRegion">
+	    <envelope>
+		<shape type="Assembly"/>
+	    </envelope>
+	    <layer id="0" inner_r="70*mm+VertexCoolingGap" inner_z="500*mm-2*VertexCoolingShellThickness" outer_r="Vertex_outer_radius+0.1*mm" vis="SupportVis">
+		<slice material="CarbonFiber" thickness="VertexCoolingShellThickness" />
+	    </layer>
+	    <comment> The next section is the cable for the vertex </comment>
+	    <layer id="1" inner_r="70*mm+VertexCoolingGap" inner_z="495*mm" outer_r="Vertex_outer_radius" vis="SiVertexCableVis">
+		<slice material="Copper" thickness="0.067*mm" />
+	    </layer>
+	</detector>
+
+
+	<detector name="BeampipeShell3" type="TrackerBarrelSupport_o1_v01" id="0"  reflect="true" region="BeampipeRegion">
+	    <envelope>
+		<shape type="Assembly"/>
+	    </envelope>
+	    <layer id="4" inner_r="Vertex_outer_radius+0.1*cm" outer_z="500*mm" vis="SupportVis">
+		<slice material="CarbonFiber" thickness="VertexCoolingShellThickness" />
+	    </layer>
+	</detector>
+    </detectors>
+
+    <plugins>
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="InnerTrackerBarrel"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=1."/>
+            <argument value="v_y=1."/>
+            <argument value="n_z=1."/>
+        </plugin>
+
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="InnerTrackerEndcap"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=1."/>
+            <argument value="v_y=1."/>
+            <argument value="n_z=1."/>
+        </plugin>
+
+    </plugins>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/LumiCal_o3_v02_04.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/LumiCal_o3_v02_04.xml
@@ -1,0 +1,188 @@
+<lccdd>
+
+    <define>
+            <constant name="LumiCal_cell_size" value="1.81*mm"/>
+    </define>
+
+    <readouts>
+        <readout name="LumiCalCollection">
+	    <segmentation type="PolarGridRPhi"
+			  grid_size_r="(LumiCal_outer_radius-LumiCal_inner_radius)/32"
+			  grid_size_phi="360/32*degree"
+			  offset_r="LumiCal_inner_radius + (LumiCal_outer_radius-LumiCal_inner_radius)/64"
+			  />
+	    <id>system:8,barrel:3,layer:8,slice:8,r:32:-16,phi:-16</id>
+        </readout>
+    </readouts>
+
+<!--offset_r="LumiCal_inner_radius+0.5*((LumiCal_outer_radius-LumiCal_inner_radius)/32)"-->
+
+    <detectors>
+        <detector name="LumiCal" type="LumiCal_o1_v04" vis="SeeThrough" id="DetID_LumiCal" readout="LumiCalCollection" insideTrackingVolume="false" >
+
+            <envelope vis="LCALVis">
+                <shape type="BooleanShape" operation="union" material="Air">
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz"/>
+                        <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+                        <position x="sin(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="cos(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz"/>
+                        <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+                        <position x="sin(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-cos(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                </shape>
+            </envelope>
+
+            <parameter crossingangle="CrossingAngle" />
+
+            <dimensions inner_r = "LumiCal_inner_radius"
+            inner_z = "LumiCal_min_z"
+            outer_r = "LumiCal_outer_radius"
+            modules = "8"
+            phi_sectors = "4"
+            r_sectors = "32"
+            phi_gap = "2*mm"
+            r_gap = "2*mm" />
+
+
+            <layer repeat="25" vis="SeeThrough">
+                <slice material = "TungstenDens24" thickness = "3.5*mm" 		   vis="BCLayerVis1" />
+                <slice material = "Kapton"     thickness = "0.28*mm" />
+                <slice material = "Silicon" thickness = "0.32*mm" 	sensitive = "yes"  vis="BCLayerVis2"/>
+                <slice material = "Copper"  thickness = "0.4*mm"                    vis="BCLayerVis3"/>
+            </layer>
+
+
+        </detector>
+
+        <detector name="LumiCalInstrumentation" type="LumiCal_o1_v04" vis="SeeThrough" id="DetID_LumiCalInstrumentation" readout="LumiCalCollection" insideTrackingVolume="false" >
+
+            <envelope vis="LCALInstrVis">
+                <shape type="BooleanShape" operation="union" material="Air">
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz"/>
+                        <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+                        <position x="sin(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="cos(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz"/>
+                        <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+                        <position x="sin(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-cos(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                </shape>
+            </envelope>
+
+            <parameter crossingangle="CrossingAngle" />
+
+            <dimensions inner_r = "LumiCal_Instr_inner_radius"
+            inner_z = "LumiCal_min_z"
+            outer_r = "LumiCal_Instr_outer_radius"
+            modules = "8"
+            phi_sectors = "4"
+            r_sectors = "32"
+            phi_gap = "2*mm"
+            r_gap = "2*mm" />
+
+
+            <layer repeat="25" vis="SeeThrough">
+                <slice material = "Aluminum" thickness = "2.0*mm" 	sensitive = "no"  vis="SupportVis"/>
+		<slice material = "Air" thickness = "2.5*mm" 	sensitive = "no"  vis="SupportVis"/>
+            </layer>
+
+
+        </detector>
+
+
+        <detector name="LumiCalCooling" type="LumiCal_o1_v04" vis="SeeThrough" id="DetID_LumiCalCooling" readout="LumiCalCollection" insideTrackingVolume="false" >
+
+            <envelope vis="LCALCoolVis">
+                <shape type="BooleanShape" operation="union" material="Air">
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz"/>
+                        <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+                        <position x="sin(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="cos(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                    <shape type="BooleanShape" operation="Intersection">
+                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+                        <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz"/>
+                        <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+                        <position x="sin(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-cos(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)"/>
+                        <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+                    </shape>
+                </shape>
+            </envelope>
+
+            <parameter crossingangle="CrossingAngle" />
+
+            <dimensions inner_r = "LumiCal_Cool_inner_radius"
+            inner_z = "LumiCal_min_z"
+            outer_r = "LumiCal_Cool_outer_radius"
+            modules = "8"
+            phi_sectors = "4"
+            r_sectors = "32"
+            phi_gap = "2*mm"
+            r_gap = "2*mm" />
+
+
+            <layer repeat="25" vis="SeeThrough">
+		<slice material = "Air" thickness = "4.5*mm" 	sensitive = "no"  vis="SupportVis"/>
+            </layer>
+
+
+        </detector>
+
+   <detector name="LumiCalBackShield" type="LumiCal_o1_v04" vis="SeeThrough" id="DetID_LumiCalBackShield"  readout="LumiCalCollection" insideTrackingVolume="false" >
+
+     <envelope vis="LCALShieldVis">
+       <shape type="BooleanShape" operation="union" material="Air">
+
+         <shape type="BooleanShape" operation="Intersection">
+           <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+           <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz"/>
+           <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+           <position x="sin(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="cos(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)"/>
+           <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+         </shape>
+         <shape type="BooleanShape" operation="Intersection">
+           <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
+           <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz"/>
+           <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+           <position x="sin(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="-cos(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)"/>
+           <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+         </shape>
+
+       </shape>
+     </envelope>
+
+     <parameter crossingangle="CrossingAngle" />
+
+
+
+     <dimensions inner_r = "LumiCal_Shield_inner_radius"
+		 outer_r = "LumiCal_Shield_outer_radius"
+		 outer_z = "LumiCal_max_z+2*LumiCal_shield_dz"
+		 inner_z = "LumiCal_max_z"/>
+
+
+            <layer repeat="1" vis="SeeThrough">
+                <slice material = "TungstenDens24" thickness = "3.5*mm" 	sensitive = "no"  vis="SupportVis"/>
+            </layer>
+
+
+        </detector>
+
+    </detectors>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/OuterTrackerBarrelModuleDown.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/OuterTrackerBarrelModuleDown.xml
@@ -1,0 +1,27 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="2.800*mm"  material="Rohacell_IG51"    info="Structure and cooling: Core"          sensitive="false"/>
+    <module_component thickness="0.700*mm"  material="Allcomp_K9"       info="Structure and cooling: Carbon Foam"   sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Structure and cooling: Cooling Pipe"  sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Structure and cooling: Cooling fluid" sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"                       sensitive="true"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"                     sensitive="false" />
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"              sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/OuterTrackerBarrelModuleUp.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/OuterTrackerBarrelModuleUp.xml
@@ -1,0 +1,27 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"              sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"                     sensitive="false" />
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"                       sensitive="true"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Structure and cooling: Cooling fluid" sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Structure and cooling: Cooling Pipe"  sensitive="false"/>
+    <module_component thickness="0.700*mm"  material="Allcomp_K9"       info="Structure and cooling: Carbon Foam"   sensitive="false"/>
+    <module_component thickness="2.800*mm"  material="Rohacell_IG51"    info="Structure and cooling: Core"          sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/OuterTracker_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/OuterTracker_o2_v07.xml
@@ -1,0 +1,226 @@
+<lccdd>
+
+    <define>
+        <constant name="OuterTracker_Barrel_radius_0" value="1000*mm"/>
+        <constant name="OuterTracker_Barrel_radius_1" value="1568*mm"/>
+        <constant name="OuterTracker_Barrel_radius_2" value="2136*mm"/>
+
+        <constant name="OuterTracker_Barrel_half_length" value="1264.2*mm"/>
+
+        <constant name="OuterTracker_Endcap_outer_radius" value="2080*mm"/>
+        <constant name="OuterTracker_Endcap_inner_radius" value="718*mm"/>
+
+        <constant name="OuterTracker_Endcap_z_0" value="1310*mm"/>
+        <constant name="OuterTracker_Endcap_z_1" value="1617*mm"/>
+        <constant name="OuterTracker_Endcap_z_2" value="1883*mm"/>
+        <constant name="OuterTracker_Endcap_z_3" value="2190*mm"/>
+
+        <constant name="OuterTracker_Endcap_radius_0" value="718*mm"/>
+        <constant name="OuterTracker_Endcap_radius_1" value="988.9*mm"/>
+        <constant name="OuterTracker_Endcap_radius_2" value="1289.9*mm"/>
+        <constant name="OuterTracker_Endcap_radius_3" value="1530.6*mm"/>
+
+    </define>
+
+    <comment>Tracking detectors</comment>
+    <detectors>
+        <detector name="OuterTrackers" type="DD4hep_SubdetectorAssembly" vis="OTVis">
+            <shape name="OuterTrackersEnvelope" type="Tube" rmin="OuterTracker_inner_radius" rmax="OuterTracker_outer_radius" dz="OuterTracker_half_length" material="Air">
+            </shape>
+            <comment>Outer Tracker Assembly</comment>
+            <composite name="OuterTrackerBarrel"/>
+            <composite name="OuterTrackerEndcap"/>
+            <composite name="OuterTrackerBarrelSupport"/>
+	    <composite name="OuterTrackerEndcapSupport"/>
+        </detector>
+    </detectors>
+
+
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="OuterTrackerLayerVis"   alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
+        <vis name="OuterTrackerModuleVis"  alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+        <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+        <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+    </display>
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="OuterTrackerBarrelCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+        <readout name="OuterTrackerEndcapCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+    </readouts>
+
+
+    <detectors>
+
+        <detector id="DetID_OT_Barrel" name="OuterTrackerBarrel" type="TrackerBarrel_o1_v05" readout="OuterTrackerBarrelCollection" region="OuterTrackerBarrelRegion">
+            <envelope vis="OTVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Silicon Outer Tracker Barrel</comment>
+
+            <type_flags type=" DetType_TRACKER + DetType_BARREL"/>
+
+            <module name="OuterTrackerBarrelModule_In" vis="OuterTrackerModuleVis">
+                <module_envelope width="30.1*mm" length="30.1*mm"/>
+                <include ref="OuterTrackerBarrelModuleUp.xml"/>
+            </module>
+
+	        <module name="OuterTrackerBarrelModule_Out" vis="OuterTrackerModuleVis">
+                <module_envelope width="30.1*mm" length="30.1*mm"/>
+                <include ref="OuterTrackerBarrelModuleDown.xml"/>
+            </module>
+
+
+            <layer module="OuterTrackerBarrelModule_In" id="0" vis="OuterTrackerLayerVis" type="4">
+                <rphi_layout phi_tilt="0*deg" nphi="53*4" phi0="0" rc="OuterTracker_Barrel_radius_0" dr="5.5*mm"/>
+                <z_layout dr="0" z0="OuterTracker_Barrel_half_length-15.05*mm" nz="84"/>
+            </layer>
+            <layer module="OuterTrackerBarrelModule_In" id="1" vis="OuterTrackerLayerVis" type="4">
+                <rphi_layout phi_tilt="0*deg" nphi="83*4" phi0="0" rc="OuterTracker_Barrel_radius_1" dr="5.5*mm"/>
+                <z_layout dr="0" z0="OuterTracker_Barrel_half_length-15.05*mm" nz="84"/>
+            </layer>
+            <layer module="OuterTrackerBarrelModule_Out" id="2" vis="OuterTrackerLayerVis" type="4">
+                <rphi_layout phi_tilt="0*deg" nphi="113*4" phi0="0" rc="OuterTracker_Barrel_radius_2" dr="5.5*mm"/>
+                <z_layout dr="0" z0="OuterTracker_Barrel_half_length-15.05*mm" nz="84"/>
+            </layer>
+
+        </detector>
+
+
+        <detector id="DetID_OT_Endcap" name="OuterTrackerEndcap" type="TrackerEndcap_o2_v06" readout="OuterTrackerEndcapCollection" reflect="true" region="OuterTrackerEndcapRegion">
+            <envelope vis="OTVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Silicon Outer Tracker Endcaps</comment>
+
+            <type_flags type=" DetType_TRACKER + DetType_ENDCAP"/>
+
+            <module name="OuterTrackerEndcapModule_0_In" vis="OuterTrackerModuleVis">
+                <trd x="125.3*mm" y="270.9*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_1_In" vis="OuterTrackerModuleVis">
+                <trd x="180.6*mm" y="301*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_2_In" vis="OuterTrackerModuleVis">
+                <trd x="240.7*mm" y="240.7*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_3_In" vis="OuterTrackerModuleVis">
+                <trd x="300*mm" y="549.4*mm"/>
+                <include ref="TrackerDiskModuleIn.xml"/>
+            </module>
+
+            <module name="OuterTrackerEndcapModule_0_Out" vis="OuterTrackerModuleVis">
+                <trd x="125.3*mm" y="270.9*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_1_Out" vis="OuterTrackerModuleVis">
+                <trd x="180.6*mm" y="301*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_2_Out" vis="OuterTrackerModuleVis">
+                <trd x="240.7*mm" y="240.7*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+            <module name="OuterTrackerEndcapModule_3_Out" vis="OuterTrackerModuleVis">
+                <trd x="300*mm" y="549.4*mm"/>
+                <include ref="TrackerDiskModuleOut.xml"/>
+            </module>
+
+            <layer id="0">
+                <ring r="OuterTracker_Endcap_radius_0" zstart="OuterTracker_Endcap_z_0" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_0_In" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_1" zstart="OuterTracker_Endcap_z_0" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_1_In" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_2" zstart="OuterTracker_Endcap_z_0" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_2_In" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_3" zstart="OuterTracker_Endcap_z_0" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_3_In" phi0="0"/>
+            </layer>
+            <layer id="1">
+                <ring r="OuterTracker_Endcap_radius_0" zstart="OuterTracker_Endcap_z_1" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_0_Out" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_1" zstart="OuterTracker_Endcap_z_1" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_1_Out" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_2" zstart="OuterTracker_Endcap_z_1" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_2_Out" phi0="0"/>
+		<ring r="OuterTracker_Endcap_radius_3" zstart="OuterTracker_Endcap_z_1" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_3_Out" phi0="0"/>
+            </layer>
+
+            <layer id="2">
+                <ring r="OuterTracker_Endcap_radius_0" zstart="OuterTracker_Endcap_z_2" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_0_In" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_1" zstart="OuterTracker_Endcap_z_2" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_1_In" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_2" zstart="OuterTracker_Endcap_z_2" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_2_In" phi0="0"/>
+		<ring r="OuterTracker_Endcap_radius_3" zstart="OuterTracker_Endcap_z_2" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_3_In" phi0="0"/>
+            </layer>
+
+            <layer id="3">
+                <ring r="OuterTracker_Endcap_radius_0" zstart="OuterTracker_Endcap_z_3" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_0_Out" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_1" zstart="OuterTracker_Endcap_z_3" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_1_Out" phi0="0"/>
+                <ring r="OuterTracker_Endcap_radius_2" zstart="OuterTracker_Endcap_z_3" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_2_Out" phi0="0"/>
+		<ring r="OuterTracker_Endcap_radius_3" zstart="OuterTracker_Endcap_z_3" nmodules="48" dz="3*mm" module="OuterTrackerEndcapModule_3_Out" phi0="0"/>
+            </layer>
+
+        </detector>
+
+        <detector name="OuterTrackerBarrelSupport" type="TrackerBarrelSupport_o1_v01" id="0" reflect="true" region="OuterTrackerBarrelRegion">
+            <envelope>
+                <shape type="Assembly"/>
+            </envelope>
+            <layer id="0" inner_r="OuterTracker_Barrel_radius_0+1*cm" outer_z="OuterTracker_Barrel_half_length" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.26/3.5959*cm" />
+            </layer>
+            <layer id="1" inner_r="OuterTracker_Barrel_radius_1+1*cm" outer_z="OuterTracker_Barrel_half_length" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.125/3.5959*cm" />
+            </layer>
+            <layer id="2" inner_r="OuterTracker_Barrel_radius_2-1*cm" outer_z="OuterTracker_Barrel_half_length" vis="SupportVis">
+                <slice material="CarbonFiber" thickness="0.125/3.5959*cm" />
+            </layer>
+        </detector>
+
+
+	<detector name="OuterTrackerEndcapSupport" type="TrackerEndcapSupport_o1_v02" reflect="true" region="OuterTrackerEndcapRegion">
+	  <envelope>
+	    <shape type="Assembly"/>
+	  </envelope>
+
+	  <layer id="0" inner_r="OuterTracker_inner_radius" inner_z="OuterTracker_Endcap_z_0+1*cm" outer_r="OuterTracker_Endcap_outer_radius" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.365/3.5959*cm" />
+	  </layer>
+	  <layer id="1" inner_r="OuterTracker_inner_radius" inner_z="OuterTracker_Endcap_z_1-1*cm" outer_r="OuterTracker_Endcap_outer_radius" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.365/3.5959*cm" />
+	  </layer>
+	  <layer id="2" inner_r="OuterTracker_inner_radius" inner_z="OuterTracker_Endcap_z_2+1*cm" outer_r="OuterTracker_Endcap_outer_radius" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.365/3.5959*cm" />
+	  </layer>
+	  <layer id="3" inner_r="OuterTracker_inner_radius" inner_z="OuterTracker_Endcap_z_3-1*cm" outer_r="OuterTracker_Endcap_outer_radius" vis="SupportVis">
+	    <slice material="CarbonFiber" thickness="0.365/3.5959*cm" />
+	  </layer>
+	  <layer id="4" inner_r="OuterTracker_Barrel_radius_0-1*cm" inner_z="OuterTracker_Barrel_half_length+2*cm" outer_r="OuterTracker_Barrel_radius_1-0.5*cm" vis="OuterTrackerInterlinkVis">
+	    <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+	  </layer>
+	  <layer id="5" inner_r="OuterTracker_Barrel_radius_1-0.5*cm" inner_z="OuterTracker_Barrel_half_length+2*cm" outer_r="OuterTracker_outer_radius" vis="OuterTrackerInterlinkVis">
+	    <slice material="CarbonFiber" thickness="0.6/3.5959*cm" />
+          </layer>
+	</detector>
+
+    </detectors>
+
+    <plugins>
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="OuterTrackerBarrel"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=1."/>
+            <argument value="v_y=1."/>
+            <argument value="n_z=1."/>
+        </plugin>
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="OuterTrackerEndcap"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=1."/>
+            <argument value="v_y=1."/>
+            <argument value="n_z=1."/>
+        </plugin>
+    </plugins>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/Solenoid_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/Solenoid_o1_v01_02.xml
@@ -1,0 +1,54 @@
+<lccdd>
+
+    <define>
+        <constant name="SolenoidVacuumTank_thickness" value="40*mm"/>
+        <constant name="SolenoidCoil_thickness" value="90*mm"/>
+    </define>
+
+
+
+    <display>
+        <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
+        <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
+        <vis name="SolenoidVacuum"         alpha="0" r="1"    g="1"    b="1"   showDaughters="false" visible="true"/>
+    </display>
+
+
+
+    <comment>Solenoid</comment>
+    <detectors>
+        <detector name="Solenoid" type="DD4hep_SubdetectorAssembly" vis="SOLVis">
+            <shape type="Tube" rmin="Solenoid_inner_radius-2*env_safety" rmax="Solenoid_outer_radius+2*env_safety" dz="Solenoid_half_length+2*env_safety" material="Vacuum"/>
+            <composite name="SolenoidBarrel"/>
+            <composite name="SolenoidEndcaps"/>
+        </detector>
+    </detectors>
+
+
+
+    <detectors>
+
+        <detector name="SolenoidBarrel" type="DD4hep_Solenoid_o1_v01" id="0" reflect="true">
+            <type_flags type=" DetType_COIL"/>
+            <envelope vis="SOLVis">
+                <shape type="Assembly"/>
+            </envelope>
+
+            <layer id="1" inner_r="Solenoid_inner_radius" outer_z="Solenoid_half_length" vis="SolenoidBarrelLayerVis">
+                <slice material="Steel235" thickness="SolenoidVacuumTank_thickness"/>
+            </layer>
+            <layer id="2" inner_r="Solenoid_Coil_radius-SolenoidCoil_thickness/2.0" outer_z="Solenoid_Coil_half_length">
+                <slice material="Aluminium" thickness="SolenoidCoil_thickness" vis="SolenoidCoilEndsVis" />
+            </layer>
+            <layer id="3" inner_r="Solenoid_outer_radius-SolenoidVacuumTank_thickness" outer_z="Solenoid_half_length" vis="SolenoidBarrelLayerVis">
+                <slice material="Steel235" thickness="SolenoidVacuumTank_thickness"/>
+            </layer>
+        </detector>
+
+        <detector name="SolenoidEndcaps" type="DD4hep_DiskTracker" id="0" reflect="true" vis="SolenoidBarrelLayerVis">
+            <layer id="1" inner_r="Solenoid_inner_radius+SolenoidVacuumTank_thickness" inner_z="Solenoid_half_length-SolenoidVacuumTank_thickness" outer_r="Solenoid_outer_radius-SolenoidVacuumTank_thickness" vis="SolenoidBarrelLayerVis">
+	        <slice material="Steel235" thickness="SolenoidVacuumTank_thickness/2.0" />
+          </layer>
+        </detector>
+    </detectors>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/TrackerDiskModuleIn.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/TrackerDiskModuleIn.xml
@@ -1,0 +1,27 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"              sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"                     sensitive="false" />
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"                       sensitive="true"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Structure and cooling: Cooling fluid" sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Structure and cooling: Cooling Pipe"  sensitive="false"/>
+    <module_component thickness="0.700*mm"  material="Allcomp_K9"       info="Structure and cooling: Carbon Foam"   sensitive="false"/>
+    <module_component thickness="2.800*mm"  material="Rohacell_IG51"    info="Structure and cooling: Core"          sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/TrackerDiskModuleOut.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/TrackerDiskModuleOut.xml
@@ -1,0 +1,27 @@
+<lccdd>
+    <!-- Build slices top-down from innermost slice (closest to IP) to outer-most (away from IP)-->
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="2.800*mm"  material="Rohacell_IG51"    info="Structure and cooling: Core"          sensitive="false"/>
+    <module_component thickness="0.700*mm"  material="Allcomp_K9"       info="Structure and cooling: Carbon Foam"   sensitive="false"/>
+    <module_component thickness="0.068*mm"  material="Kapton"           info="Structure and cooling: Cooling Pipe"  sensitive="false"/>
+    <module_component thickness="0.235*mm"  material="Water"            info="Structure and cooling: Cooling fluid" sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Structure and cooling: Glue layer"    sensitive="false"/>
+    <module_component thickness="0.025*mm"  material="CarbonFiber"      info="Structure and cooling: Interface"     sensitive="false"/>
+    <module_component thickness="0.150*mm"  material="CarbonFiber"      info="Structure and cooling: CF Skins"      sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: Sensor"                       sensitive="true"/>
+    <module_component thickness="0.100*mm"  material="Silicon"          info="Module: r/o ASIC"                     sensitive="false" />
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Aluminium"        info="Module: FPC metal layer"              sensitive="false"/>
+    <module_component thickness="0.050*mm"  material="Kapton"           info="Module: FPC insulating layer"         sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Epoxy"            info="Glue: Eccobond"                       sensitive="false"/>
+
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+    <module_component thickness="0.200*mm"  material="Aluminium"        info="Power bus: Conductor"                 sensitive="false"/>
+    <module_component thickness="0.100*mm"  material="Kapton"           info="Power bus: Insulating layer"          sensitive="false"/>
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/Vertex_o4_v07_smallBP.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/Vertex_o4_v07_smallBP.xml
@@ -1,0 +1,225 @@
+<!-- Changes :
+   o4_v04 : scaled version of the CLIC VTX Barrel (CLIC_04_v11); distance between sensitive layers in double layers are set to 1*mm and is similar in all 3 layers
+-->
+
+<lccdd>
+
+    <comment>Tracking detectors</comment>
+    <detectors>
+       <!-- The envelope consists of a tube generally surrounding the vertex barrel and endcap disks, subtracted by a
+            cone describing the upper acceptance of the LumiCal, about 110 mrad in this version of the detector.
+       -->
+        <detector name="Vertex" type="DD4hep_SubdetectorAssembly" vis="VXDVis">
+            <shape type="Polycone" material="Air">
+              <zplane z="-Vertex_half_length"  rmin="Vertex_LumiCal_Clearence * Vertex_half_length" rmax="Vertex_outer_radius" />
+              <zplane z="-(111 * mm)"          rmin="Vertex_inner_radius + 0.5*mm"                  rmax="Vertex_outer_radius" />
+              <zplane z="+(111 * mm)"          rmin="Vertex_inner_radius + 0.5*mm"                  rmax="Vertex_outer_radius" />
+              <zplane z="+Vertex_half_length"  rmin="Vertex_LumiCal_Clearence * Vertex_half_length" rmax="Vertex_outer_radius" />
+	    </shape>
+
+            <comment>Vertex Assembly</comment>
+            <composite name="VertexBarrel"/>
+            <composite name="VertexEndcap"/>
+            <composite name="VertexVerticalCable"/>
+        </detector>
+    </detectors>
+
+    <display>
+        <vis name="SiVertexModuleVis"    alpha="1.0" r="1" g="1"    b="0.6"     showDaughters="true"  visible="false"/>
+        <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2"  b="0.2"     showDaughters="true"  visible="true"/>
+        <vis name="SiVertexPassiveVis"   alpha="1.0" r="0.274" g="0.274"  b="0.274"       showDaughters="true"  visible="true"/>
+        <vis name="SiVertexCableVis"     alpha="1.0" r="0.85" g="0.53"    b="0.4"       showDaughters="true"  visible="true"/>
+        <vis name="SiVertexAir"          alpha="1.0" r="0" g="0"    b="0"       showDaughters="false"  visible="false"/>
+    </display>
+
+    <define>
+        <constant name="VertexBarrel_zmax" value="109*mm"/>
+<!--
+	<constant name="VertexBarrel_r1" value="1.75*cm"/>
+        <constant name="VertexBarrel_r2" value="3.7*cm"/>
+        <constant name="VertexBarrel_r3" value="5.7*cm"/>
+-->
+	<constant name="VertexBarrel_r1" value="1.3*cm"/>
+        <constant name="VertexBarrel_r2" value="3.5*cm"/>
+        <constant name="VertexBarrel_r3" value="5.7*cm"/>
+
+        <constant name="VertexBarrel_Sensitive_Thickness"   value="5.000000000e-02*mm"/>
+	<constant name="VertexBarrel_Support_Thickness"     value="23.500000000e-02*mm"/> <!-- +50% more material budget as in CLIC VTX -->
+	<constant name="VertexBarrel_DoubleLayer_Gap"       value="1.0*mm"/> <!-- FCC-ee VTX detector is "scaled" version of the CLIC VTX. However one want to keep constant width of double layers (which is not the case if one directly scale all dimentions). This is why gap was chosen to be 1mm to avoid holes in coverage as function of phi -->
+
+        <constant name="VertexEndcap_Sensitive_Thickness"   value="5.000000000e-02*mm"/>
+        <constant name="VertexEndcap_Support_Thickness"     value="28.000000000e-02*mm"/> <!-- +50% more material budget as in CLIC VTX -->
+        <constant name="VertexEndcap_DoubleLayer_Gap"       value="2.0*mm"/>
+
+        <constant name="VertexBarrel_Layer1_width" value="5.5*mm"/>
+        <constant name="VertexBarrel_Layer2_width" value="19.25*mm"/>
+        <constant name="VertexBarrel_Layer3_width" value="23.0948*mm"/>
+
+        <constant name="VertexBarrel_Layer1_offset" value="1.12903*mm"/>
+        <constant name="VertexBarrel_Layer2_offset" value="0.840909*mm"/>
+        <constant name="VertexBarrel_Layer3_offset" value="0.982759*mm"/>
+
+        <constant name="VertexBarrel_Layer1_Staves" value="16"/>
+        <constant name="VertexBarrel_Layer2_Staves" value="12"/>
+        <constant name="VertexBarrel_Layer3_Staves" value="16"/>
+
+        <constant name="VertexEndcap_rmax" value="102*mm"/>
+        <constant name="VertexEndcap_z1" value="160*mm"/>
+        <constant name="VertexEndcap_z2" value="230*mm"/>
+        <constant name="VertexEndcap_z3" value="300*mm"/>
+        <constant name="VertexEndcapModules" value="8"/>
+	<constant name="VertexEndcap_rmin1" value="24*mm"/>
+        <constant name="VertexEndcap_rmin2" value="34.5*mm"/>
+        <constant name="VertexEndcap_rmin3" value="45*mm"/>
+        <constant name="VertexEndcapModuleThickness" value="1.22*mm"/>
+        <constant name="VertexEndcapOverlap" value="0*mm"/>
+    </define>
+
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="VertexBarrelCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+        <readout name="VertexEndcapCollection">
+            <id>${GlobalTrackerReadoutID}</id>
+        </readout>
+    </readouts>
+
+
+    <detectors>
+        <detector name="VertexBarrel" type="ZPlanarTracker" vis="VXDVis" id="DetID_VXD_Barrel" readout="VertexBarrelCollection"  region="VertexBarrelRegion">
+
+            <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_BARREL"/>
+
+
+            <layer nLadders="VertexBarrel_Layer1_Staves" phi0="0" id="0">
+                <ladder    distance="VertexBarrel_r1" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer1_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer1_offset"    material="Silicon"  vis="SiVertexPassiveVis"/>
+                <sensitive distance="VertexBarrel_r1+VertexBarrel_Support_Thickness" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer1_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer1_offset" material="Silicon" vis="SiVertexSensitiveVis" />
+            </layer>
+            <layer nLadders="VertexBarrel_Layer1_Staves" phi0="0" id="1">
+                <sensitive distance="VertexBarrel_r1+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer1_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer1_offset" material="Silicon" vis="SiVertexSensitiveVis" />
+                <ladder    distance="VertexBarrel_r1+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap+VertexBarrel_Sensitive_Thickness" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer1_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer1_offset"    material="Silicon"  vis="SiVertexPassiveVis" />
+            </layer>
+
+
+            <layer nLadders="VertexBarrel_Layer2_Staves" phi0="0" id="2">
+                <ladder    distance="VertexBarrel_r2" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer2_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer2_offset"    material="Silicon" vis="SiVertexPassiveVis" />
+                <sensitive distance="VertexBarrel_r2+VertexBarrel_Support_Thickness" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer2_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer2_offset" material="Silicon" vis="SiVertexSensitiveVis"/>
+            </layer>
+            <layer nLadders="VertexBarrel_Layer2_Staves" phi0="0" id="3">
+                <sensitive distance="VertexBarrel_r2+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer2_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer2_offset" material="Silicon" vis="SiVertexSensitiveVis"/>
+                <ladder    distance="VertexBarrel_r2+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap+VertexBarrel_Sensitive_Thickness" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer2_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer2_offset"    material="Silicon" vis="SiVertexPassiveVis" />
+            </layer>
+
+
+            <layer nLadders="VertexBarrel_Layer3_Staves" phi0="0" id="4">
+                <ladder    distance="VertexBarrel_r3" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer3_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer3_offset"    material="Silicon" vis="SiVertexPassiveVis" />
+                <sensitive distance="VertexBarrel_r3+VertexBarrel_Support_Thickness" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer3_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer3_offset" material="Silicon" vis="SiVertexSensitiveVis"/>
+            </layer>
+            <layer nLadders="VertexBarrel_Layer3_Staves" phi0="0" id="5">
+                <sensitive distance="VertexBarrel_r3+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap" thickness="VertexBarrel_Sensitive_Thickness" width="VertexBarrel_Layer3_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer3_offset" material="Silicon" vis="SiVertexSensitiveVis"/>
+                <ladder    distance="VertexBarrel_r3+VertexBarrel_Support_Thickness+VertexBarrel_Sensitive_Thickness+VertexBarrel_DoubleLayer_Gap+VertexBarrel_Sensitive_Thickness" thickness="VertexBarrel_Support_Thickness" width="VertexBarrel_Layer3_width" length="VertexBarrel_zmax" offset="VertexBarrel_Layer3_offset"    material="Silicon" vis="SiVertexPassiveVis"/>
+            </layer>
+
+        </detector>
+
+
+        <detector id="DetID_VXD_Endcap" name="VertexEndcap" type="VertexEndcap_o1_v06" readout="VertexEndcapCollection" reflect="true" region="VertexEndcapRegion">
+            <envelope vis="VXDVis">
+                <shape type="Assembly"/>
+            </envelope>
+            <comment>Vertex Detector Endcaps</comment>
+
+	    <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_ENDCAP"/>
+
+            <module name="SiVertexEndcapModule1" vis="SiVertexModuleVis">
+                <trd x1="VertexEndcap_rmin1 * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" x2="VertexEndcap_rmax * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" z="(VertexEndcap_rmax - VertexEndcap_rmin1) / 2" />
+                <module_component thickness="VertexEndcap_Support_Thickness/2.0"  material="Silicon" vis="SiVertexPassiveVis"/>
+                <module_component thickness="VertexEndcap_Sensitive_Thickness/2.0"  material="Silicon" sensitive="true" vis="SiVertexSensitiveVis"/>
+                <module_component thickness="VertexEndcap_DoubleLayer_Gap/2.0"  material="Air" vis="SiVertexAir" />
+            </module>
+
+            <module name="SiVertexEndcapModule2" vis="SiVertexModuleVis">
+                <trd x1="VertexEndcap_rmin1 * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" x2="VertexEndcap_rmax * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" z="(VertexEndcap_rmax - VertexEndcap_rmin1) / 2" />
+                <module_component thickness="VertexEndcap_DoubleLayer_Gap/2.0"  material="Air" vis="SiVertexAir" />
+                <module_component thickness="VertexEndcap_Sensitive_Thickness/2.0"  material="Silicon" sensitive="true" vis="SiVertexSensitiveVis"/>
+                <module_component thickness="VertexEndcap_Support_Thickness/2.0"  material="Silicon" vis="SiVertexPassiveVis"/>
+            </module>
+
+            <module name="SiVertexEndcapModule3" vis="SiVertexModuleVis">
+                <trd x1="VertexEndcap_rmin2 * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" x2="VertexEndcap_rmax * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" z="(VertexEndcap_rmax - VertexEndcap_rmin2) / 2" />
+                <module_component thickness="VertexEndcap_Support_Thickness/2.0"  material="Silicon" vis="SiVertexPassiveVis"/>
+                <module_component thickness="VertexEndcap_Sensitive_Thickness/2.0"  material="Silicon" sensitive="true" vis="SiVertexSensitiveVis"/>
+                <module_component thickness="VertexEndcap_DoubleLayer_Gap/2.0"  material="Air" vis="SiVertexAir" />
+            </module>
+
+            <module name="SiVertexEndcapModule4" vis="SiVertexModuleVis">
+                <trd x1="VertexEndcap_rmin2 * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" x2="VertexEndcap_rmax * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" z="(VertexEndcap_rmax - VertexEndcap_rmin2) / 2" />
+                <module_component thickness="VertexEndcap_DoubleLayer_Gap/2.0"  material="Air" vis="SiVertexAir" />
+                <module_component thickness="VertexEndcap_Sensitive_Thickness/2.0"  material="Silicon" sensitive="true" vis="SiVertexSensitiveVis"/>
+                <module_component thickness="VertexEndcap_Support_Thickness/2.0"  material="Silicon" vis="SiVertexPassiveVis"/>
+            </module>
+
+	    <module name="SiVertexEndcapModule5" vis="SiVertexModuleVis">
+                <trd x1="VertexEndcap_rmin3 * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" x2="VertexEndcap_rmax * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" z="(VertexEndcap_rmax - VertexEndcap_rmin3) / 2" />
+                <module_component thickness="VertexEndcap_Support_Thickness/2.0"  material="Silicon" vis="SiVertexPassiveVis"/>
+                <module_component thickness="VertexEndcap_Sensitive_Thickness/2.0"  material="Silicon" sensitive="true" vis="SiVertexSensitiveVis"/>
+                <module_component thickness="VertexEndcap_DoubleLayer_Gap/2.0"  material="Air" vis="SiVertexAir" />
+            </module>
+
+            <module name="SiVertexEndcapModule6" vis="SiVertexModuleVis">
+                <trd x1="VertexEndcap_rmin3 * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" x2="VertexEndcap_rmax * tan(pi/(VertexEndcapModules))+VertexEndcapOverlap*sin(pi/VertexEndcapModules)" z="(VertexEndcap_rmax - VertexEndcap_rmin3) / 2" />
+                <module_component thickness="VertexEndcap_DoubleLayer_Gap/2.0"  material="Air" vis="SiVertexAir" />
+                <module_component thickness="VertexEndcap_Sensitive_Thickness/2.0"  material="Silicon" sensitive="true" vis="SiVertexSensitiveVis"/>
+                <module_component thickness="VertexEndcap_Support_Thickness/2.0"  material="Silicon" vis="SiVertexPassiveVis"/>
+            </module>
+
+            <layer id="0"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin1) / 2" zstart="VertexEndcap_z1 - VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="0*cm" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule1"/>
+            </layer>
+            <layer id="1"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin1) / 2" zstart="VertexEndcap_z1+VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="0*cm" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule2"/>
+            </layer>
+            <layer id="2"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin2) / 2" zstart="VertexEndcap_z2-VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="0*cm" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule3"/>
+            </layer>
+            <layer id="3"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin2) / 2" zstart="VertexEndcap_z2+VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="0*cm" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule4"/>
+            </layer>
+
+            <layer id="4"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin3) / 2" zstart="VertexEndcap_z3-VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="0*cm" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule5"/>
+            </layer>
+            <layer id="5"  vis="SiVertexLayerVis">
+                <ring r="(VertexEndcap_rmax + VertexEndcap_rmin3) / 2" zstart="VertexEndcap_z3+VertexEndcapModuleThickness/2.0" nmodules="(int) VertexEndcapModules" dz="0*cm" phi0="pi/(VertexEndcapModules)" module="SiVertexEndcapModule6"/>
+            </layer>
+
+    </detector>
+        <detector name="VertexVerticalCable" type="TrackerEndcapSupport_o1_v02" reflect="true"  region="VertexEndcapRegion">
+	    <envelope>
+		    <shape type="Assembly"/>
+	    </envelope>
+	    <layer id="1" inner_r="VertexBarrel_r1" inner_z="VertexBarrel_zmax+1*mm" outer_r="Vertex_outer_radius-5*env_safety" vis="SiVertexCableVis">
+		    <slice material="Copper" thickness="0.02*mm" />
+	    </layer>
+        </detector>
+
+    </detectors>
+
+
+    <plugins>
+        <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+            <argument value="VertexEndcap"/>
+            <argument value="dimension=2"/>
+            <argument value="u_x=-1."/>
+            <argument value="v_z=1."/>
+            <argument value="n_y=1."/>
+        </plugin>
+    </plugins>
+
+
+
+
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/YokeBarrel_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/YokeBarrel_o1_v01_02.xml
@@ -1,0 +1,68 @@
+<lccdd>
+    <!--  Definition of global dictionary constants          -->
+    <define>
+        <constant name="YokeBarrel_layers" value="7"/>
+        <constant name="YokeBarrel_layer_thickness" value="10.0*cm + 4.0*cm"/>
+        <constant name="Yoke_cell_size" value="3.0*cm"/>
+
+    </define>
+
+    <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="YokeBarrelVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
+        <vis name="YokeStavesVis"    alpha="1" r="0"    g="0.7"  b="0.3" showDaughters="true" visible="true"/>
+        <vis name="YokeLayerVis"     alpha="1" r="0"    g="1"    b="0.3" showDaughters="true" visible="true"/>
+        <vis name="YokeSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
+        <vis name="YokeAbsorberVis"  alpha="1" r="0.28" g="0.4"  b="0.62" visible="true"/>
+    </display>
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="YokeBarrelCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="Yoke_cell_size" grid_size_y="Yoke_cell_size" />
+            <id>system:5,side:2,layer:9,module:8,stave:4,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+
+
+    <detectors>
+        <detector id="DetID_Yoke_Barrel" name="YokeBarrel" type="GenericCalBarrel_o1_v01" readout="YokeBarrelCollection" vis="YOKEVis" calorimeterType="MUON_BARREL" gap="0.*cm" material="Steel235">
+
+            <comment>Yoke Calorimeter Barrel</comment>
+
+            <type_flags type=" DetType_CALORIMETER + DetType_MUON + DetType_BARREL"/>
+
+
+            <envelope vis="YOKEVis">
+                <shape type="PolyhedraRegular" numsides="YokeBarrel_symmetry"  rmin="YokeBarrel_inner_radius-10*env_safety" rmax="YokeBarrel_outer_radius+10*env_safety" dz="2*YokeBarrel_half_length"  material = "Air" />
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/YokeBarrel_symmetry"/>
+            </envelope>
+
+            <dimensions numsides="(int) YokeBarrel_symmetry" rmin="YokeBarrel_inner_radius" z="YokeBarrel_half_length * 2"/>
+            <staves vis="YokeStavesVis"/>
+
+
+            <layer repeat="(int) YokeBarrel_layers" vis="YokeLayerVis">
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="RPCGasDefault" thickness="0.2*cm" sensitive="yes" vis="YokeSensorVis"/>
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="RPCGasDefault" thickness="0.2*cm" vis="YokeSensorVis"/>
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="1.0*cm" />
+                <slice material="Iron" thickness="17.7*cm" vis="YokeAbsorberVis" radiator="yes"/>
+            </layer>
+
+
+        </detector>
+    </detectors>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/YokeEndcap_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/YokeEndcap_o1_v01_02.xml
@@ -1,0 +1,67 @@
+<lccdd>
+
+    <!--  Definition of the readout segmentation/definition  -->
+    <readouts>
+        <readout name="YokeEndcapCollection">
+            <segmentation type="CartesianGridXY" grid_size_x="Yoke_cell_size" grid_size_y="Yoke_cell_size" />
+            <id>system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16</id>
+        </readout>
+    </readouts>
+
+        <!--  Definition of the used visualization attributes    -->
+    <display>
+        <vis name="YokeEndcapVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
+    </display>
+
+    <!--  Includes for sensitives and support                -->
+    <detectors>
+
+        <detector name="YokeEndcap" type="GenericCalEndcap_o1_v01" id="DetID_Yoke_Endcap" readout="YokeEndcapCollection" vis="YOKEVis" >
+
+            <comment>Encap Yoke</comment>
+
+            <type_flags type=" DetType_CALORIMETER + DetType_MUON + DetType_ENDCAP"/>
+
+            <envelope vis="YOKEVis">
+                <shape type="BooleanShape" operation="Subtraction" material="Air">
+                    <shape type="BooleanShape" operation="Subtraction">
+                        <shape type="PolyhedraRegular"  numsides="YokeEndcap_outer_symmetry" rmin="0" rmax="YokeEndcap_outer_radius+ 10.0*env_safety" dz="2.0*YokeEndcap_max_z+2*env_safety"/>
+                        <shape type="PolyhedraRegular"  numsides="YokeEndcap_outer_symmetry" rmin="0" rmax="YokeEndcap_outer_radius+ 100.0*env_safety" dz="2.0*YokeEndcap_min_z"/>
+                    </shape>
+                    <shape type="Tube"  rmin="0" rmax="YokeEndcap_inner_radius-env_safety" dz="2.0*YokeEndcap_max_z+4*env_safety"/>
+                </shape>
+                <rotation x="0*deg" y="0*deg" z="90*deg-180*deg/YokeEndcap_outer_symmetry"/>
+            </envelope>
+
+            <dimensions nsides_inner="YokeEndcap_outer_symmetry" nsides_outer="YokeEndcap_outer_symmetry" zmin="YokeEndcap_min_z" rmin="YokeEndcap_inner_radius" rmax="YokeEndcap_outer_radius"/>
+            <layer repeat="6" vis="YokeEndcapLayerVis">
+                <slice material="Iron" thickness="21*cm"  vis="YokeAbsorberVis" radiator="yes"/>
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="RPCGasDefault" thickness="0.2*cm" sensitive="yes" vis="YokeSensorVis"/>
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="RPCGasDefault" thickness="0.2*cm" vis="YokeSensorVis"/>
+                <slice material="PyrexGlass" thickness="0.2*cm" />
+                <slice material="Air" thickness="0.35*cm" />
+                <slice material="Aluminium" thickness="0.1*cm" />
+            </layer>
+            <layer repeat="1" vis="YokeEndcapLayerVis">
+                <slice material="Iron" thickness="10.5*cm"  vis="YokeAbsorberVis" radiator="yes"/>
+            </layer>
+        </detector>
+
+    </detectors>
+
+
+
+
+
+
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/elements.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/elements.xml
@@ -1,0 +1,884 @@
+<materials>
+    <element Z="89" formula="Ac" name="Ac" >
+        <atom type="A" unit="g/mol" value="227.028" />
+    </element>
+    <material formula="Ac" name="Actinium" state="solid" >
+        <RL type="X0" unit="cm" value="0.601558" />
+        <NIL type="lambda" unit="cm" value="21.2048" />
+        <D type="density" unit="g/cm3" value="10.07" />
+        <composite n="1" ref="Ac" />
+    </material>
+    <element Z="47" formula="Ag" name="Ag" >
+        <atom type="A" unit="g/mol" value="107.868" />
+    </element>
+    <material formula="Ag" name="Silver" state="solid" >
+        <RL type="X0" unit="cm" value="0.854292" />
+        <NIL type="lambda" unit="cm" value="15.8546" />
+        <D type="density" unit="g/cm3" value="10.5" />
+        <composite n="1" ref="Ag" />
+    </material>
+    <element Z="13" formula="Al" name="Al" >
+        <atom type="A" unit="g/mol" value="26.9815" />
+    </element>
+    <material formula="Al" name="Aluminum" state="solid" >
+        <RL type="X0" unit="cm" value="8.89632" />
+        <NIL type="lambda" unit="cm" value="38.8766" />
+        <D type="density" unit="g/cm3" value="2.699" />
+        <composite n="1" ref="Al" />
+    </material>
+    <element Z="95" formula="Am" name="Am" >
+        <atom type="A" unit="g/mol" value="243.061" />
+    </element>
+    <material formula="Am" name="Americium" state="solid" >
+        <RL type="X0" unit="cm" value="0.42431" />
+        <NIL type="lambda" unit="cm" value="15.9812" />
+        <D type="density" unit="g/cm3" value="13.67" />
+        <composite n="1" ref="Am" />
+    </material>
+    <element Z="18" formula="Ar" name="Ar" >
+        <atom type="A" unit="g/mol" value="39.9477" />
+    </element>
+    <material formula="Ar" name="Argon" state="gas" >
+        <RL type="X0" unit="cm" value="11762.1" />
+        <NIL type="lambda" unit="cm" value="71926" />
+        <D type="density" unit="g/cm3" value="0.00166201" />
+        <composite n="1" ref="Ar" />
+    </material>
+    <element Z="33" formula="As" name="As" >
+        <atom type="A" unit="g/mol" value="74.9216" />
+    </element>
+    <material formula="As" name="Arsenic" state="solid" >
+        <RL type="X0" unit="cm" value="2.0838" />
+        <NIL type="lambda" unit="cm" value="25.7324" />
+        <D type="density" unit="g/cm3" value="5.73" />
+        <composite n="1" ref="As" />
+    </material>
+    <element Z="85" formula="At" name="At" >
+        <atom type="A" unit="g/mol" value="209.987" />
+    </element>
+    <material formula="At" name="Astatine" state="solid" >
+        <RL type="X0" unit="cm" value="0.650799" />
+        <NIL type="lambda" unit="cm" value="22.3202" />
+        <D type="density" unit="g/cm3" value="9.32" />
+        <composite n="1" ref="At" />
+    </material>
+    <element Z="79" formula="Au" name="Au" >
+        <atom type="A" unit="g/mol" value="196.967" />
+    </element>
+    <material formula="Au" name="Gold" state="solid" >
+        <RL type="X0" unit="cm" value="0.334436" />
+        <NIL type="lambda" unit="cm" value="10.5393" />
+        <D type="density" unit="g/cm3" value="19.32" />
+        <composite n="1" ref="Au" />
+    </material>
+    <element Z="5" formula="B" name="B" >
+        <atom type="A" unit="g/mol" value="10.811" />
+    </element>
+    <material formula="B" name="Boron" state="solid" >
+        <RL type="X0" unit="cm" value="22.2307" />
+        <NIL type="lambda" unit="cm" value="32.2793" />
+        <D type="density" unit="g/cm3" value="2.37" />
+        <composite n="1" ref="B" />
+    </material>
+    <element Z="56" formula="Ba" name="Ba" >
+        <atom type="A" unit="g/mol" value="137.327" />
+    </element>
+    <material formula="Ba" name="Barium" state="solid" >
+        <RL type="X0" unit="cm" value="2.37332" />
+        <NIL type="lambda" unit="cm" value="51.6743" />
+        <D type="density" unit="g/cm3" value="3.5" />
+        <composite n="1" ref="Ba" />
+    </material>
+    <element Z="4" formula="Be" name="Be" >
+        <atom type="A" unit="g/mol" value="9.01218" />
+    </element>
+    <material formula="Be" name="Beryllium" state="solid" >
+        <RL type="X0" unit="cm" value="35.276" />
+        <NIL type="lambda" unit="cm" value="39.4488" />
+        <D type="density" unit="g/cm3" value="1.848" />
+        <composite n="1" ref="Be" />
+    </material>
+    <element Z="83" formula="Bi" name="Bi" >
+        <atom type="A" unit="g/mol" value="208.98" />
+    </element>
+    <material formula="Bi" name="Bismuth" state="solid" >
+        <RL type="X0" unit="cm" value="0.645388" />
+        <NIL type="lambda" unit="cm" value="21.3078" />
+        <D type="density" unit="g/cm3" value="9.747" />
+        <composite n="1" ref="Bi" />
+    </material>
+    <element Z="97" formula="Bk" name="Bk" >
+        <atom type="A" unit="g/mol" value="247.07" />
+    </element>
+    <material formula="Bk" name="Berkelium" state="solid" >
+        <RL type="X0" unit="cm" value="0.406479" />
+        <NIL type="lambda" unit="cm" value="15.6902" />
+        <D type="density" unit="g/cm3" value="14" />
+        <composite n="1" ref="Bk" />
+    </material>
+    <element Z="35" formula="Br" name="Br" >
+        <atom type="A" unit="g/mol" value="79.9035" />
+    </element>
+    <material formula="Br" name="Bromine" state="gas" >
+        <RL type="X0" unit="cm" value="1615.12" />
+        <NIL type="lambda" unit="cm" value="21299" />
+        <D type="density" unit="g/cm3" value="0.0070721" />
+        <composite n="1" ref="Br" />
+    </material>
+    <element Z="6" formula="C" name="C" >
+        <atom type="A" unit="g/mol" value="12.0107" />
+    </element>
+    <material formula="C" name="Carbon" state="solid" >
+        <RL type="X0" unit="cm" value="21.3485" />
+        <NIL type="lambda" unit="cm" value="40.1008" />
+        <D type="density" unit="g/cm3" value="2" />
+        <composite n="1" ref="C" />
+    </material>
+    <element Z="20" formula="Ca" name="Ca" >
+        <atom type="A" unit="g/mol" value="40.078" />
+    </element>
+    <material formula="Ca" name="Calcium" state="solid" >
+        <RL type="X0" unit="cm" value="10.4151" />
+        <NIL type="lambda" unit="cm" value="77.3754" />
+        <D type="density" unit="g/cm3" value="1.55" />
+        <composite n="1" ref="Ca" />
+    </material>
+    <element Z="48" formula="Cd" name="Cd" >
+        <atom type="A" unit="g/mol" value="112.411" />
+    </element>
+    <material formula="Cd" name="Cadmium" state="solid" >
+        <RL type="X0" unit="cm" value="1.03994" />
+        <NIL type="lambda" unit="cm" value="19.46" />
+        <D type="density" unit="g/cm3" value="8.65" />
+        <composite n="1" ref="Cd" />
+    </material>
+    <element Z="58" formula="Ce" name="Ce" >
+        <atom type="A" unit="g/mol" value="140.115" />
+    </element>
+    <material formula="Ce" name="Cerium" state="solid" >
+        <RL type="X0" unit="cm" value="1.19506" />
+        <NIL type="lambda" unit="cm" value="27.3227" />
+        <D type="density" unit="g/cm3" value="6.657" />
+        <composite n="1" ref="Ce" />
+    </material>
+    <element Z="98" formula="Cf" name="Cf" >
+        <atom type="A" unit="g/mol" value="251.08" />
+    </element>
+    <material formula="Cf" name="Californium" state="solid" >
+        <RL type="X0" unit="cm" value="0.568328" />
+        <NIL type="lambda" unit="cm" value="22.085" />
+        <D type="density" unit="g/cm3" value="10" />
+        <composite n="1" ref="Cf" />
+    </material>
+    <element Z="17" formula="Cl" name="Cl" >
+        <atom type="A" unit="g/mol" value="35.4526" />
+    </element>
+    <material formula="Cl" name="Chlorine" state="gas" >
+        <RL type="X0" unit="cm" value="6437.34" />
+        <NIL type="lambda" unit="cm" value="38723.9" />
+        <D type="density" unit="g/cm3" value="0.00299473" />
+        <composite n="1" ref="Cl" />
+    </material>
+    <element Z="96" formula="Cm" name="Cm" >
+        <atom type="A" unit="g/mol" value="247.07" />
+    </element>
+    <material formula="Cm" name="Curium" state="solid" >
+        <RL type="X0" unit="cm" value="0.428706" />
+        <NIL type="lambda" unit="cm" value="16.2593" />
+        <D type="density" unit="g/cm3" value="13.51" />
+        <composite n="1" ref="Cm" />
+    </material>
+    <element Z="27" formula="Co" name="Co" >
+        <atom type="A" unit="g/mol" value="58.9332" />
+    </element>
+    <material formula="Co" name="Cobalt" state="solid" >
+        <RL type="X0" unit="cm" value="1.53005" />
+        <NIL type="lambda" unit="cm" value="15.2922" />
+        <D type="density" unit="g/cm3" value="8.9" />
+        <composite n="1" ref="Co" />
+    </material>
+    <element Z="24" formula="Cr" name="Cr" >
+        <atom type="A" unit="g/mol" value="51.9961" />
+    </element>
+    <material formula="Cr" name="Chromium" state="solid" >
+        <RL type="X0" unit="cm" value="2.0814" />
+        <NIL type="lambda" unit="cm" value="18.1933" />
+        <D type="density" unit="g/cm3" value="7.18" />
+        <composite n="1" ref="Cr" />
+    </material>
+    <element Z="55" formula="Cs" name="Cs" >
+        <atom type="A" unit="g/mol" value="132.905" />
+    </element>
+    <material formula="Cs" name="Cesium" state="solid" >
+        <RL type="X0" unit="cm" value="4.4342" />
+        <NIL type="lambda" unit="cm" value="95.317" />
+        <D type="density" unit="g/cm3" value="1.873" />
+        <composite n="1" ref="Cs" />
+    </material>
+    <element Z="29" formula="Cu" name="Cu" >
+        <atom type="A" unit="g/mol" value="63.5456" />
+    </element>
+    <material formula="Cu" name="Copper" state="solid" >
+        <RL type="X0" unit="cm" value="1.43558" />
+        <NIL type="lambda" unit="cm" value="15.5141" />
+        <D type="density" unit="g/cm3" value="8.96" />
+        <composite n="1" ref="Cu" />
+    </material>
+    <element Z="66" formula="Dy" name="Dy" >
+        <atom type="A" unit="g/mol" value="162.497" />
+    </element>
+    <material formula="Dy" name="Dysprosium" state="solid" >
+        <RL type="X0" unit="cm" value="0.85614" />
+        <NIL type="lambda" unit="cm" value="22.2923" />
+        <D type="density" unit="g/cm3" value="8.55" />
+        <composite n="1" ref="Dy" />
+    </material>
+    <element Z="68" formula="Er" name="Er" >
+        <atom type="A" unit="g/mol" value="167.256" />
+    </element>
+    <material formula="Er" name="Erbium" state="solid" >
+        <RL type="X0" unit="cm" value="0.788094" />
+        <NIL type="lambda" unit="cm" value="21.2923" />
+        <D type="density" unit="g/cm3" value="9.066" />
+        <composite n="1" ref="Er" />
+    </material>
+    <element Z="63" formula="Eu" name="Eu" >
+        <atom type="A" unit="g/mol" value="151.964" />
+    </element>
+    <material formula="Eu" name="Europium" state="solid" >
+        <RL type="X0" unit="cm" value="1.41868" />
+        <NIL type="lambda" unit="cm" value="35.6178" />
+        <D type="density" unit="g/cm3" value="5.243" />
+        <composite n="1" ref="Eu" />
+    </material>
+    <element Z="9" formula="F" name="F" >
+        <atom type="A" unit="g/mol" value="18.9984" />
+    </element>
+    <material formula="F" name="Fluorine" state="gas" >
+        <RL type="X0" unit="cm" value="20838.2" />
+        <NIL type="lambda" unit="cm" value="59094.3" />
+        <D type="density" unit="g/cm3" value="0.00158029" />
+        <composite n="1" ref="F" />
+    </material>
+    <element Z="26" formula="Fe" name="Fe" >
+        <atom type="A" unit="g/mol" value="55.8451" />
+    </element>
+    <material formula="Fe" name="Iron" state="solid" >
+        <RL type="X0" unit="cm" value="1.75749" />
+        <NIL type="lambda" unit="cm" value="16.959" />
+        <D type="density" unit="g/cm3" value="7.874" />
+        <composite n="1" ref="Fe" />
+    </material>
+    <element Z="87" formula="Fr" name="Fr" >
+        <atom type="A" unit="g/mol" value="223.02" />
+    </element>
+    <material formula="Fr" name="Francium" state="solid" >
+        <RL type="X0" unit="cm" value="6.18826" />
+        <NIL type="lambda" unit="cm" value="212.263" />
+        <D type="density" unit="g/cm3" value="1" />
+        <composite n="1" ref="Fr" />
+    </material>
+    <element Z="31" formula="Ga" name="Ga" >
+        <atom type="A" unit="g/mol" value="69.7231" />
+    </element>
+    <material formula="Ga" name="Gallium" state="solid" >
+        <RL type="X0" unit="cm" value="2.1128" />
+        <NIL type="lambda" unit="cm" value="24.3351" />
+        <D type="density" unit="g/cm3" value="5.904" />
+        <composite n="1" ref="Ga" />
+    </material>
+    <element Z="64" formula="Gd" name="Gd" >
+        <atom type="A" unit="g/mol" value="157.252" />
+    </element>
+    <material formula="Gd" name="Gadolinium" state="solid" >
+        <RL type="X0" unit="cm" value="0.947208" />
+        <NIL type="lambda" unit="cm" value="23.9377" />
+        <D type="density" unit="g/cm3" value="7.9004" />
+        <composite n="1" ref="Gd" />
+    </material>
+    <element Z="32" formula="Ge" name="Ge" >
+        <atom type="A" unit="g/mol" value="72.6128" />
+    </element>
+    <material formula="Ge" name="Germanium" state="solid" >
+        <RL type="X0" unit="cm" value="2.3013" />
+        <NIL type="lambda" unit="cm" value="27.3344" />
+        <D type="density" unit="g/cm3" value="5.323" />
+        <composite n="1" ref="Ge" />
+    </material>
+    <element Z="1" formula="H" name="H" >
+        <atom type="A" unit="g/mol" value="1.00794" />
+    </element>
+    <material formula="H" name="Hydrogen" state="gas" >
+        <RL type="X0" unit="cm" value="752776" />
+        <NIL type="lambda" unit="cm" value="421239" />
+        <D type="density" unit="g/cm3" value="8.3748e-05" />
+        <composite n="1" ref="H" />
+    </material>
+    <element Z="2" formula="He" name="He" >
+        <atom type="A" unit="g/mol" value="4.00264" />
+    </element>
+    <material formula="He" name="Helium" state="gas" >
+        <RL type="X0" unit="cm" value="567113" />
+        <NIL type="lambda" unit="cm" value="334266" />
+        <D type="density" unit="g/cm3" value="0.000166322" />
+        <composite n="1" ref="He" />
+    </material>
+    <element Z="72" formula="Hf" name="Hf" >
+        <atom type="A" unit="g/mol" value="178.485" />
+    </element>
+    <material formula="Hf" name="Hafnium" state="solid" >
+        <RL type="X0" unit="cm" value="0.517717" />
+        <NIL type="lambda" unit="cm" value="14.7771" />
+        <D type="density" unit="g/cm3" value="13.31" />
+        <composite n="1" ref="Hf" />
+    </material>
+    <element Z="80" formula="Hg" name="Hg" >
+        <atom type="A" unit="g/mol" value="200.599" />
+    </element>
+    <material formula="Hg" name="Mercury" state="solid" >
+        <RL type="X0" unit="cm" value="0.475241" />
+        <NIL type="lambda" unit="cm" value="15.105" />
+        <D type="density" unit="g/cm3" value="13.546" />
+        <composite n="1" ref="Hg" />
+    </material>
+    <element Z="67" formula="Ho" name="Ho" >
+        <atom type="A" unit="g/mol" value="164.93" />
+    </element>
+    <material formula="Ho" name="Holmium" state="solid" >
+        <RL type="X0" unit="cm" value="0.822447" />
+        <NIL type="lambda" unit="cm" value="21.8177" />
+        <D type="density" unit="g/cm3" value="8.795" />
+        <composite n="1" ref="Ho" />
+    </material>
+    <element Z="53" formula="I" name="I" >
+        <atom type="A" unit="g/mol" value="126.904" />
+    </element>
+    <material formula="I" name="Iodine" state="solid" >
+        <RL type="X0" unit="cm" value="1.72016" />
+        <NIL type="lambda" unit="cm" value="35.6583" />
+        <D type="density" unit="g/cm3" value="4.93" />
+        <composite n="1" ref="I" />
+    </material>
+    <element Z="49" formula="In" name="In" >
+        <atom type="A" unit="g/mol" value="114.818" />
+    </element>
+    <material formula="In" name="Indium" state="solid" >
+        <RL type="X0" unit="cm" value="1.21055" />
+        <NIL type="lambda" unit="cm" value="23.2468" />
+        <D type="density" unit="g/cm3" value="7.31" />
+        <composite n="1" ref="In" />
+    </material>
+    <element Z="77" formula="Ir" name="Ir" >
+        <atom type="A" unit="g/mol" value="192.216" />
+    </element>
+    <material formula="Ir" name="Iridium" state="solid" >
+        <RL type="X0" unit="cm" value="0.294142" />
+        <NIL type="lambda" unit="cm" value="9.01616" />
+        <D type="density" unit="g/cm3" value="22.42" />
+        <composite n="1" ref="Ir" />
+    </material>
+    <element Z="19" formula="K" name="K" >
+        <atom type="A" unit="g/mol" value="39.0983" />
+    </element>
+    <material formula="K" name="Potassium" state="solid" >
+        <RL type="X0" unit="cm" value="20.0871" />
+        <NIL type="lambda" unit="cm" value="138.041" />
+        <D type="density" unit="g/cm3" value="0.862" />
+        <composite n="1" ref="K" />
+    </material>
+    <element Z="36" formula="Kr" name="Kr" >
+        <atom type="A" unit="g/mol" value="83.7993" />
+    </element>
+    <material formula="Kr" name="Krypton" state="gas" >
+        <RL type="X0" unit="cm" value="3269.44" />
+        <NIL type="lambda" unit="cm" value="43962.9" />
+        <D type="density" unit="g/cm3" value="0.00347832" />
+        <composite n="1" ref="Kr" />
+    </material>
+    <element Z="57" formula="La" name="La" >
+        <atom type="A" unit="g/mol" value="138.905" />
+    </element>
+    <material formula="La" name="Lanthanum" state="solid" >
+        <RL type="X0" unit="cm" value="1.32238" />
+        <NIL type="lambda" unit="cm" value="29.441" />
+        <D type="density" unit="g/cm3" value="6.154" />
+        <composite n="1" ref="La" />
+    </material>
+    <element Z="3" formula="Li" name="Li" >
+        <atom type="A" unit="g/mol" value="6.94003" />
+    </element>
+    <material formula="Li" name="Lithium" state="solid" >
+        <RL type="X0" unit="cm" value="154.997" />
+        <NIL type="lambda" unit="cm" value="124.305" />
+        <D type="density" unit="g/cm3" value="0.534" />
+        <composite n="1" ref="Li" />
+    </material>
+    <element Z="71" formula="Lu" name="Lu" >
+        <atom type="A" unit="g/mol" value="174.967" />
+    </element>
+    <material formula="Lu" name="Lutetium" state="solid" >
+        <RL type="X0" unit="cm" value="0.703651" />
+        <NIL type="lambda" unit="cm" value="19.8916" />
+        <D type="density" unit="g/cm3" value="9.84" />
+        <composite n="1" ref="Lu" />
+    </material>
+    <element Z="12" formula="Mg" name="Mg" >
+        <atom type="A" unit="g/mol" value="24.305" />
+    </element>
+    <material formula="Mg" name="Magnesium" state="solid" >
+        <RL type="X0" unit="cm" value="14.3859" />
+        <NIL type="lambda" unit="cm" value="58.7589" />
+        <D type="density" unit="g/cm3" value="1.74" />
+        <composite n="1" ref="Mg" />
+    </material>
+    <element Z="25" formula="Mn" name="Mn" >
+        <atom type="A" unit="g/mol" value="54.938" />
+    </element>
+    <material formula="Mn" name="Manganese" state="solid" >
+        <RL type="X0" unit="cm" value="1.96772" />
+        <NIL type="lambda" unit="cm" value="17.8701" />
+        <D type="density" unit="g/cm3" value="7.44" />
+        <composite n="1" ref="Mn" />
+    </material>
+    <element Z="42" formula="Mo" name="Mo" >
+        <atom type="A" unit="g/mol" value="95.9313" />
+    </element>
+    <material formula="Mo" name="Molybdenum" state="solid" >
+        <RL type="X0" unit="cm" value="0.959107" />
+        <NIL type="lambda" unit="cm" value="15.6698" />
+        <D type="density" unit="g/cm3" value="10.22" />
+        <composite n="1" ref="Mo" />
+    </material>
+    <element Z="7" formula="N" name="N" >
+        <atom type="A" unit="g/mol" value="14.0068" />
+    </element>
+    <material formula="N" name="Nitrogen" state="gas" >
+        <RL type="X0" unit="cm" value="32602.2" />
+        <NIL type="lambda" unit="cm" value="72430.3" />
+        <D type="density" unit="g/cm3" value="0.0011652" />
+        <composite n="1" ref="N" />
+    </material>
+    <element Z="11" formula="Na" name="Na" >
+        <atom type="A" unit="g/mol" value="22.9898" />
+    </element>
+    <material formula="Na" name="Sodium" state="solid" >
+        <RL type="X0" unit="cm" value="28.5646" />
+        <NIL type="lambda" unit="cm" value="102.463" />
+        <D type="density" unit="g/cm3" value="0.971" />
+        <composite n="1" ref="Na" />
+    </material>
+    <element Z="41" formula="Nb" name="Nb" >
+        <atom type="A" unit="g/mol" value="92.9064" />
+    </element>
+    <material formula="Nb" name="Niobium" state="solid" >
+        <RL type="X0" unit="cm" value="1.15783" />
+        <NIL type="lambda" unit="cm" value="18.4846" />
+        <D type="density" unit="g/cm3" value="8.57" />
+        <composite n="1" ref="Nb" />
+    </material>
+    <element Z="60" formula="Nd" name="Nd" >
+        <atom type="A" unit="g/mol" value="144.236" />
+    </element>
+    <material formula="Nd" name="Neodymium" state="solid" >
+        <RL type="X0" unit="cm" value="1.11667" />
+        <NIL type="lambda" unit="cm" value="26.6308" />
+        <D type="density" unit="g/cm3" value="6.9" />
+        <composite n="1" ref="Nd" />
+    </material>
+    <element Z="10" formula="Ne" name="Ne" >
+        <atom type="A" unit="g/mol" value="20.18" />
+    </element>
+    <material formula="Ne" name="Neon" state="gas" >
+        <RL type="X0" unit="cm" value="34504.8" />
+        <NIL type="lambda" unit="cm" value="114322" />
+        <D type="density" unit="g/cm3" value="0.000838505" />
+        <composite n="1" ref="Ne" />
+    </material>
+    <element Z="28" formula="Ni" name="Ni" >
+        <atom type="A" unit="g/mol" value="58.6933" />
+    </element>
+    <material formula="Ni" name="Nickel" state="solid" >
+        <RL type="X0" unit="cm" value="1.42422" />
+        <NIL type="lambda" unit="cm" value="15.2265" />
+        <D type="density" unit="g/cm3" value="8.902" />
+        <composite n="1" ref="Ni" />
+    </material>
+    <element Z="93" formula="Np" name="Np" >
+        <atom type="A" unit="g/mol" value="237.048" />
+    </element>
+    <material formula="Np" name="Neptunium" state="solid" >
+        <RL type="X0" unit="cm" value="0.289676" />
+        <NIL type="lambda" unit="cm" value="10.6983" />
+        <D type="density" unit="g/cm3" value="20.25" />
+        <composite n="1" ref="Np" />
+    </material>
+    <element Z="8" formula="O" name="O" >
+        <atom type="A" unit="g/mol" value="15.9994" />
+    </element>
+    <material formula="O" name="Oxygen" state="gas" >
+        <RL type="X0" unit="cm" value="25713.8" />
+        <NIL type="lambda" unit="cm" value="66233.9" />
+        <D type="density" unit="g/cm3" value="0.00133151" />
+        <composite n="1" ref="O" />
+    </material>
+    <element Z="76" formula="Os" name="Os" >
+        <atom type="A" unit="g/mol" value="190.225" />
+    </element>
+    <material formula="Os" name="Osmium" state="solid" >
+        <RL type="X0" unit="cm" value="0.295861" />
+        <NIL type="lambda" unit="cm" value="8.92553" />
+        <D type="density" unit="g/cm3" value="22.57" />
+        <composite n="1" ref="Os" />
+    </material>
+    <element Z="15" formula="P" name="P" >
+        <atom type="A" unit="g/mol" value="30.9738" />
+    </element>
+    <material formula="P" name="Phosphorus" state="solid" >
+        <RL type="X0" unit="cm" value="9.63879" />
+        <NIL type="lambda" unit="cm" value="49.9343" />
+        <D type="density" unit="g/cm3" value="2.2" />
+        <composite n="1" ref="P" />
+    </material>
+    <element Z="91" formula="Pa" name="Pa" >
+        <atom type="A" unit="g/mol" value="231.036" />
+    </element>
+    <material formula="Pa" name="Protactinium" state="solid" >
+        <RL type="X0" unit="cm" value="0.38607" />
+        <NIL type="lambda" unit="cm" value="13.9744" />
+        <D type="density" unit="g/cm3" value="15.37" />
+        <composite n="1" ref="Pa" />
+    </material>
+    <element Z="82" formula="Pb" name="Pb" >
+        <atom type="A" unit="g/mol" value="207.217" />
+    </element>
+    <material formula="Pb" name="Lead" state="solid" >
+        <RL type="X0" unit="cm" value="0.561253" />
+        <NIL type="lambda" unit="cm" value="18.2607" />
+        <D type="density" unit="g/cm3" value="11.35" />
+        <composite n="1" ref="Pb" />
+    </material>
+    <element Z="46" formula="Pd" name="Pd" >
+        <atom type="A" unit="g/mol" value="106.415" />
+    </element>
+    <material formula="Pd" name="Palladium" state="solid" >
+        <RL type="X0" unit="cm" value="0.765717" />
+        <NIL type="lambda" unit="cm" value="13.7482" />
+        <D type="density" unit="g/cm3" value="12.02" />
+        <composite n="1" ref="Pd" />
+    </material>
+    <element Z="61" formula="Pm" name="Pm" >
+        <atom type="A" unit="g/mol" value="144.913" />
+    </element>
+    <material formula="Pm" name="Promethium" state="solid" >
+        <RL type="X0" unit="cm" value="1.04085" />
+        <NIL type="lambda" unit="cm" value="25.4523" />
+        <D type="density" unit="g/cm3" value="7.22" />
+        <composite n="1" ref="Pm" />
+    </material>
+    <element Z="84" formula="Po" name="Po" >
+        <atom type="A" unit="g/mol" value="208.982" />
+    </element>
+    <material formula="Po" name="Polonium" state="solid" >
+        <RL type="X0" unit="cm" value="0.661092" />
+        <NIL type="lambda" unit="cm" value="22.2842" />
+        <D type="density" unit="g/cm3" value="9.32" />
+        <composite n="1" ref="Po" />
+    </material>
+    <element Z="59" formula="Pr" name="Pr" >
+        <atom type="A" unit="g/mol" value="140.908" />
+    </element>
+    <material formula="Pr" name="Praseodymium" state="solid" >
+        <RL type="X0" unit="cm" value="1.1562" />
+        <NIL type="lambda" unit="cm" value="27.1312" />
+        <D type="density" unit="g/cm3" value="6.71" />
+        <composite n="1" ref="Pr" />
+    </material>
+    <element Z="78" formula="Pt" name="Pt" >
+        <atom type="A" unit="g/mol" value="195.078" />
+    </element>
+    <material formula="Pt" name="Platinum" state="solid" >
+        <RL type="X0" unit="cm" value="0.305053" />
+        <NIL type="lambda" unit="cm" value="9.46584" />
+        <D type="density" unit="g/cm3" value="21.45" />
+        <composite n="1" ref="Pt" />
+    </material>
+    <element Z="94" formula="Pu" name="Pu" >
+        <atom type="A" unit="g/mol" value="244.064" />
+    </element>
+    <material formula="Pu" name="Plutonium" state="solid" >
+        <RL type="X0" unit="cm" value="0.298905" />
+        <NIL type="lambda" unit="cm" value="11.0265" />
+        <D type="density" unit="g/cm3" value="19.84" />
+        <composite n="1" ref="Pu" />
+    </material>
+    <element Z="88" formula="Ra" name="Ra" >
+        <atom type="A" unit="g/mol" value="226.025" />
+    </element>
+    <material formula="Ra" name="Radium" state="solid" >
+        <RL type="X0" unit="cm" value="1.22987" />
+        <NIL type="lambda" unit="cm" value="42.6431" />
+        <D type="density" unit="g/cm3" value="5" />
+        <composite n="1" ref="Ra" />
+    </material>
+    <element Z="37" formula="Rb" name="Rb" >
+        <atom type="A" unit="g/mol" value="85.4677" />
+    </element>
+    <material formula="Rb" name="Rubidium" state="solid" >
+        <RL type="X0" unit="cm" value="7.19774" />
+        <NIL type="lambda" unit="cm" value="100.218" />
+        <D type="density" unit="g/cm3" value="1.532" />
+        <composite n="1" ref="Rb" />
+    </material>
+    <element Z="75" formula="Re" name="Re" >
+        <atom type="A" unit="g/mol" value="186.207" />
+    </element>
+    <material formula="Re" name="Rhenium" state="solid" >
+        <RL type="X0" unit="cm" value="0.318283" />
+        <NIL type="lambda" unit="cm" value="9.5153" />
+        <D type="density" unit="g/cm3" value="21.02" />
+        <composite n="1" ref="Re" />
+    </material>
+    <element Z="45" formula="Rh" name="Rh" >
+        <atom type="A" unit="g/mol" value="102.906" />
+    </element>
+    <material formula="Rh" name="Rhodium" state="solid" >
+        <RL type="X0" unit="cm" value="0.746619" />
+        <NIL type="lambda" unit="cm" value="13.2083" />
+        <D type="density" unit="g/cm3" value="12.41" />
+        <composite n="1" ref="Rh" />
+    </material>
+    <element Z="86" formula="Rn" name="Rn" >
+        <atom type="A" unit="g/mol" value="222.018" />
+    </element>
+    <material formula="Rn" name="Radon" state="gas" >
+        <RL type="X0" unit="cm" value="697.777" />
+        <NIL type="lambda" unit="cm" value="23532" />
+        <D type="density" unit="g/cm3" value="0.00900662" />
+        <composite n="1" ref="Rn" />
+    </material>
+    <element Z="44" formula="Ru" name="Ru" >
+        <atom type="A" unit="g/mol" value="101.065" />
+    </element>
+    <material formula="Ru" name="Ruthenium" state="solid" >
+        <RL type="X0" unit="cm" value="0.764067" />
+        <NIL type="lambda" unit="cm" value="13.1426" />
+        <D type="density" unit="g/cm3" value="12.41" />
+        <composite n="1" ref="Ru" />
+    </material>
+    <element Z="16" formula="S" name="S" >
+        <atom type="A" unit="g/mol" value="32.0661" />
+    </element>
+    <material formula="S" name="Sulfur" state="solid" >
+        <RL type="X0" unit="cm" value="9.74829" />
+        <NIL type="lambda" unit="cm" value="55.6738" />
+        <D type="density" unit="g/cm3" value="2" />
+        <composite n="1" ref="S" />
+    </material>
+    <element Z="51" formula="Sb" name="Sb" >
+        <atom type="A" unit="g/mol" value="121.76" />
+    </element>
+    <material formula="Sb" name="Antimony" state="solid" >
+        <RL type="X0" unit="cm" value="1.30401" />
+        <NIL type="lambda" unit="cm" value="25.8925" />
+        <D type="density" unit="g/cm3" value="6.691" />
+        <composite n="1" ref="Sb" />
+    </material>
+    <element Z="21" formula="Sc" name="Sc" >
+        <atom type="A" unit="g/mol" value="44.9559" />
+    </element>
+    <material formula="Sc" name="Scandium" state="solid" >
+        <RL type="X0" unit="cm" value="5.53545" />
+        <NIL type="lambda" unit="cm" value="41.609" />
+        <D type="density" unit="g/cm3" value="2.989" />
+        <composite n="1" ref="Sc" />
+    </material>
+    <element Z="34" formula="Se" name="Se" >
+        <atom type="A" unit="g/mol" value="78.9594" />
+    </element>
+    <material formula="Se" name="Selenium" state="solid" >
+        <RL type="X0" unit="cm" value="2.64625" />
+        <NIL type="lambda" unit="cm" value="33.356" />
+        <D type="density" unit="g/cm3" value="4.5" />
+        <composite n="1" ref="Se" />
+    </material>
+    <element Z="14" formula="Si" name="Si" >
+        <atom type="A" unit="g/mol" value="28.0854" />
+    </element>
+    <material formula="Si" name="Silicon" state="solid" >
+        <RL type="X0" unit="cm" value="9.36607" />
+        <NIL type="lambda" unit="cm" value="45.7531" />
+        <D type="density" unit="g/cm3" value="2.33" />
+        <composite n="1" ref="Si" />
+    </material>
+    <element Z="62" formula="Sm" name="Sm" >
+        <atom type="A" unit="g/mol" value="150.366" />
+    </element>
+    <material formula="Sm" name="Samarium" state="solid" >
+        <RL type="X0" unit="cm" value="1.01524" />
+        <NIL type="lambda" unit="cm" value="24.9892" />
+        <D type="density" unit="g/cm3" value="7.46" />
+        <composite n="1" ref="Sm" />
+    </material>
+    <element Z="50" formula="Sn" name="Sn" >
+        <atom type="A" unit="g/mol" value="118.71" />
+    </element>
+    <material formula="Sn" name="Tin" state="solid" >
+        <RL type="X0" unit="cm" value="1.20637" />
+        <NIL type="lambda" unit="cm" value="23.4931" />
+        <D type="density" unit="g/cm3" value="7.31" />
+        <composite n="1" ref="Sn" />
+    </material>
+    <element Z="38" formula="Sr" name="Sr" >
+        <atom type="A" unit="g/mol" value="87.6166" />
+    </element>
+    <material formula="Sr" name="Strontium" state="solid" >
+        <RL type="X0" unit="cm" value="4.237" />
+        <NIL type="lambda" unit="cm" value="61.0238" />
+        <D type="density" unit="g/cm3" value="2.54" />
+        <composite n="1" ref="Sr" />
+    </material>
+    <element Z="73" formula="Ta" name="Ta" >
+        <atom type="A" unit="g/mol" value="180.948" />
+    </element>
+    <material formula="Ta" name="Tantalum" state="solid" >
+        <RL type="X0" unit="cm" value="0.409392" />
+        <NIL type="lambda" unit="cm" value="11.8846" />
+        <D type="density" unit="g/cm3" value="16.654" />
+        <composite n="1" ref="Ta" />
+    </material>
+    <element Z="65" formula="Tb" name="Tb" >
+        <atom type="A" unit="g/mol" value="158.925" />
+    </element>
+    <material formula="Tb" name="Terbium" state="solid" >
+        <RL type="X0" unit="cm" value="0.893977" />
+        <NIL type="lambda" unit="cm" value="23.0311" />
+        <D type="density" unit="g/cm3" value="8.229" />
+        <composite n="1" ref="Tb" />
+    </material>
+    <element Z="43" formula="Tc" name="Tc" >
+        <atom type="A" unit="g/mol" value="97.9072" />
+    </element>
+    <material formula="Tc" name="Technetium" state="solid" >
+        <RL type="X0" unit="cm" value="0.833149" />
+        <NIL type="lambda" unit="cm" value="14.0185" />
+        <D type="density" unit="g/cm3" value="11.5" />
+        <composite n="1" ref="Tc" />
+    </material>
+    <element Z="52" formula="Te" name="Te" >
+        <atom type="A" unit="g/mol" value="127.603" />
+    </element>
+    <material formula="Te" name="Tellurium" state="solid" >
+        <RL type="X0" unit="cm" value="1.41457" />
+        <NIL type="lambda" unit="cm" value="28.1797" />
+        <D type="density" unit="g/cm3" value="6.24" />
+        <composite n="1" ref="Te" />
+    </material>
+    <element Z="90" formula="Th" name="Th" >
+        <atom type="A" unit="g/mol" value="232.038" />
+    </element>
+    <material formula="Th" name="Thorium" state="solid" >
+        <RL type="X0" unit="cm" value="0.51823" />
+        <NIL type="lambda" unit="cm" value="18.353" />
+        <D type="density" unit="g/cm3" value="11.72" />
+        <composite n="1" ref="Th" />
+    </material>
+    <element Z="22" formula="Ti" name="Ti" >
+        <atom type="A" unit="g/mol" value="47.8667" />
+    </element>
+    <material formula="Ti" name="Titanium" state="solid" >
+        <RL type="X0" unit="cm" value="3.5602" />
+        <NIL type="lambda" unit="cm" value="27.9395" />
+        <D type="density" unit="g/cm3" value="4.54" />
+        <composite n="1" ref="Ti" />
+    </material>
+    <element Z="81" formula="Tl" name="Tl" >
+        <atom type="A" unit="g/mol" value="204.383" />
+    </element>
+    <material formula="Tl" name="Thallium" state="solid" >
+        <RL type="X0" unit="cm" value="0.547665" />
+        <NIL type="lambda" unit="cm" value="17.6129" />
+        <D type="density" unit="g/cm3" value="11.72" />
+        <composite n="1" ref="Tl" />
+    </material>
+    <element Z="69" formula="Tm" name="Tm" >
+        <atom type="A" unit="g/mol" value="168.934" />
+    </element>
+    <material formula="Tm" name="Thulium" state="solid" >
+        <RL type="X0" unit="cm" value="0.754428" />
+        <NIL type="lambda" unit="cm" value="20.7522" />
+        <D type="density" unit="g/cm3" value="9.321" />
+        <composite n="1" ref="Tm" />
+    </material>
+    <element Z="92" formula="U" name="U" >
+        <atom type="A" unit="g/mol" value="238.029" />
+    </element>
+    <material formula="U" name="Uranium" state="solid" >
+        <RL type="X0" unit="cm" value="0.31663" />
+        <NIL type="lambda" unit="cm" value="11.4473" />
+        <D type="density" unit="g/cm3" value="18.95" />
+        <composite n="1" ref="U" />
+    </material>
+    <element Z="23" formula="V" name="V" >
+        <atom type="A" unit="g/mol" value="50.9415" />
+    </element>
+    <material formula="V" name="Vanadium" state="solid" >
+        <RL type="X0" unit="cm" value="2.59285" />
+        <NIL type="lambda" unit="cm" value="21.2187" />
+        <D type="density" unit="g/cm3" value="6.11" />
+        <composite n="1" ref="V" />
+    </material>
+    <element Z="74" formula="W" name="W" >
+        <atom type="A" unit="g/mol" value="183.842" />
+    </element>
+    <material formula="W" name="Tungsten" state="solid" >
+        <RL type="X0" unit="cm" value="0.350418" />
+        <NIL type="lambda" unit="cm" value="10.3057" />
+        <D type="density" unit="g/cm3" value="19.3" />
+        <composite n="1" ref="W" />
+    </material>
+    <element Z="54" formula="Xe" name="Xe" >
+        <atom type="A" unit="g/mol" value="131.292" />
+    </element>
+    <material formula="Xe" name="Xenon" state="gas" >
+        <RL type="X0" unit="cm" value="1546.2" />
+        <NIL type="lambda" unit="cm" value="32477.9" />
+        <D type="density" unit="g/cm3" value="0.00548536" />
+        <composite n="1" ref="Xe" />
+    </material>
+    <element Z="39" formula="Y" name="Y" >
+        <atom type="A" unit="g/mol" value="88.9058" />
+    </element>
+    <material formula="Y" name="Yttrium" state="solid" >
+        <RL type="X0" unit="cm" value="2.32943" />
+        <NIL type="lambda" unit="cm" value="34.9297" />
+        <D type="density" unit="g/cm3" value="4.469" />
+        <composite n="1" ref="Y" />
+    </material>
+    <element Z="70" formula="Yb" name="Yb" >
+        <atom type="A" unit="g/mol" value="173.038" />
+    </element>
+    <material formula="Yb" name="Ytterbium" state="solid" >
+        <RL type="X0" unit="cm" value="1.04332" />
+        <NIL type="lambda" unit="cm" value="28.9843" />
+        <D type="density" unit="g/cm3" value="6.73" />
+        <composite n="1" ref="Yb" />
+    </material>
+    <element Z="30" formula="Zn" name="Zn" >
+        <atom type="A" unit="g/mol" value="65.3955" />
+    </element>
+    <material formula="Zn" name="Zinc" state="solid" >
+        <RL type="X0" unit="cm" value="1.74286" />
+        <NIL type="lambda" unit="cm" value="19.8488" />
+        <D type="density" unit="g/cm3" value="7.133" />
+        <composite n="1" ref="Zn" />
+    </material>
+    <element Z="40" formula="Zr" name="Zr" >
+        <atom type="A" unit="g/mol" value="91.2236" />
+    </element>
+    <material formula="Zr" name="Zirconium" state="solid" >
+        <RL type="X0" unit="cm" value="1.56707" />
+        <NIL type="lambda" unit="cm" value="24.2568" />
+        <D type="density" unit="g/cm3" value="6.506" />
+        <composite n="1" ref="Zr" />
+    </material>
+</materials>

--- a/FCCee/CLD/compact/CLD_o2_v06/materials.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/materials.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<materials>
+
+    <!--
+     Air by weight from
+
+     http://www.engineeringtoolbox.com/air-composition-24_212.html
+     -->
+    <material name="Air">
+      <D type="density" unit="g/cm3" value="0.0012"/>
+      <fraction n="0.754" ref="N"/>
+      <fraction n="0.234" ref="O"/>
+      <fraction n="0.012" ref="Ar"/>
+    </material>
+
+    <material name="Water">
+      <D value="1" unit="g/cm3" />
+      <composite n="2" ref="H" />
+      <composite n="1" ref="O" />
+    </material>
+
+    <!-- We model vacuum just as very thin air -->
+    <material name="Vacuum">
+      <D type="density" unit="g/cm3" value="0.0000000001" />
+      <fraction n="0.754" ref="N"/>
+      <fraction n="0.234" ref="O"/>
+      <fraction n="0.012" ref="Ar"/>
+    </material>
+
+    <material name="Epoxy">
+      <D type="density" value="1.3" unit="g/cm3"/>
+      <composite n="44" ref="H"/>
+      <composite n="15" ref="C"/>
+      <composite n="7" ref="O"/>
+    </material>
+
+    <material name="Quartz">
+      <D type="density" value="2.2" unit="g/cm3"/>
+      <composite n="1" ref="Si"/>
+      <composite n="2" ref="O"/>
+    </material>
+
+    <material name="G10">
+      <D type="density" value="1.7" unit="g/cm3"/>
+      <fraction n="0.08" ref="Cl"/>
+      <fraction n="0.773" ref="Quartz"/>
+      <fraction n="0.147" ref="Epoxy"/>
+    </material>
+
+    <material name="Polystyrene">
+      <D value="1.032" unit="g/cm3"/>
+      <composite n="19" ref="C"/>
+      <composite n="21" ref="H"/>
+    </material>
+
+    <material name="Steel235">
+      <D value="7.85" unit="g/cm3"/>
+      <fraction n="0.998" ref="Fe"/>
+      <fraction n=".002" ref="C"/>
+    </material>
+
+    <material name="SiliconOxide">
+      <D type="density" value="2.65" unit="g/cm3"/>
+      <composite n="1" ref="Si"/>
+      <composite n="2" ref="O"/>
+    </material>
+
+    <material name="BoronOxide">
+      <D type="density" value="2.46" unit="g/cm3"/>
+      <composite n="2" ref="B"/>
+      <composite n="3" ref="O"/>
+    </material>
+
+    <material name="SodiumOxide">
+      <D type="density" value="2.65" unit="g/cm3"/>
+      <composite n="2" ref="Na"/>
+      <composite n="1" ref="O"/>
+    </material>
+
+    <material name="AluminumOxide">
+      <D type="density" value="3.89" unit="g/cm3"/>
+      <composite n="2" ref="Al"/>
+      <composite n="3" ref="O"/>
+    </material>
+
+    <material formula="Al" name="Aluminium" state="solid" >
+      <D type="density" unit="g/cm3" value="2.699" />
+      <composite n="1" ref="Al" />
+    </material>
+
+    <material name="PyrexGlass">
+      <D type="density" value="2.23" unit="g/cm3"/>
+      <fraction n="0.806" ref="SiliconOxide"/>
+      <fraction n="0.130" ref="BoronOxide"/>
+      <fraction n="0.040" ref="SodiumOxide"/>
+      <fraction n="0.023" ref="AluminumOxide"/>
+    </material>
+
+    <material name="CarbonFiber">
+      <D type="density" value="1.5" unit="g/cm3"/>
+      <fraction n="0.65" ref="C"/>
+      <fraction n="0.35" ref="Epoxy"/>
+    </material>
+
+    <material name="CarbonFiber_25D">
+      <D type="density" value="0.375" unit="g/cm3"/>
+      <fraction n="0.60" ref="C"/>
+      <fraction n="0.40" ref="Epoxy"/>
+    </material>
+
+    <material name="Rohacell31">
+      <D type="density" value="0.032" unit="g/cm3"/>
+      <composite n="9" ref="C"/>
+      <composite n="13" ref="H"/>
+      <composite n="2" ref="O"/>
+      <composite n="1" ref="N"/>
+    </material>
+
+    <material name="Rohacell_IG51">
+      <D type="density" value="0.051" unit="g/cm3"/>
+      <composite n="9" ref="C"/>
+      <composite n="13" ref="H"/>
+      <composite n="2" ref="O"/>
+      <composite n="1" ref="N"/>
+    </material>
+
+    <material name="Allcomp_K9">
+      <D type="density" value="0.22" unit="g/cm3"/>
+      <fraction n="0.60" ref="C"/>
+      <fraction n="0.40" ref="Epoxy"/>
+    </material>
+
+    <material name="RPCGasDefault" state="gas">
+      <D type="density" value="0.0037" unit="g/cm3"/>
+      <composite n="209" ref="C"/>
+      <composite n="239" ref="H"/>
+      <composite n="381" ref="F"/>
+    </material>
+
+    <material name="Kapton">
+      <D value="1.43" unit="g/cm3" />
+      <composite n="22" ref="C"/>
+      <composite n="10" ref="H" />
+      <composite n="2" ref="N" />
+      <composite n="5" ref="O" />
+    </material>
+
+    <material name="siPCBMix" state="solid">
+      <MEE unit="eV" value="262.475002085268"/>
+      <D unit="g/cm3" value="5.05076923076923"/>
+      <fraction n="0.014498933901919" ref="Cl"/>
+      <fraction n="0.083477099995865" ref="O"/>
+      <fraction n="0.0654857498400853" ref="Si"/>
+      <fraction n="0.00351122019083304" ref="H"/>
+      <fraction n="0.0142636698452849" ref="C"/>
+      <fraction n="0.818763326226013" ref="Cu"/>
+    </material>
+
+    <material name="GroundOrHVMix" state="solid">
+      <MEE unit="eV" value="259.806022507979"/>
+      <D unit="g/cm3" value="5.19"/>
+      <fraction n="0.00360636223506744" ref="H"/>
+      <fraction n="0.0945480597302505" ref="C"/>
+      <fraction n="0.0100234489402697" ref="N"/>
+      <fraction n="0.0286236705202312" ref="O"/>
+      <fraction n="0.863198458574181" ref="Cu"/>
+    </material>
+
+    <material Z="13" name="G4_Al" state="solid">
+      <MEE unit="eV" value="166"/>
+      <D unit="g/cm3" value="2.699"/>
+      <atom unit="g/mole" value="26.9815"/>
+      <fraction n="1" ref="Al"/>
+    </material>
+
+    <material Z="4" name="G4_Be" state="solid">
+      <MEE unit="eV" value="63.7"/>
+      <D unit="g/cm3" value="1.848"/>
+      <atom unit="g/mole" value="9.01218"/>
+      <fraction n="1" ref="Be"/>
+    </material>
+
+    <material name="TungstenDens24">
+      <D value="17.8" unit="g/cm3"/>
+      <fraction n="0.93" ref="W"/>
+      <fraction n="0.061" ref="Ni"/>
+      <fraction n="0.009" ref="Fe"/>
+    </material>
+
+    <material name="PCB" state="solid">
+      <MEE unit="eV" value="88.255598548367"/>
+      <D unit="g/cm3" value="1.7"/>
+      <fraction n="0.180774" ref="Si"/>
+      <fraction n="0.405633" ref="O"/>
+      <fraction n="0.278042" ref="C"/>
+      <fraction n="0.0684428" ref="H"/>
+      <fraction n="0.0671091" ref="Br"/>
+    </material>
+
+    <material name="SolenoidMixture">
+      <D value="4.38" unit="g/cm3"/>
+      <fraction n="0.666" ref="Al"/>
+      <fraction n="0.166" ref="Cu"/>
+      <fraction n="0.084" ref="Ti"/>
+      <fraction n="0.084" ref="Nb"/>
+    </material>
+
+    <material name="AlBeMet162">
+      <D value="2.1" unit="g/cm3"/>
+      <fraction n="0.38" ref="Al"/>
+      <fraction n="0.62" ref="Be"/>
+    </material>
+
+    <material name="LiquidNDecane">
+      <D value="0.73" unit="g/cm3"/>
+      <composite n="10" ref="C" />
+      <composite n="22" ref="H" />
+    </material>
+
+    <material name="beam" state="gas">
+      <P unit="pascal" value="6.25e-06"/>
+      <MEE unit="eV" value="38.5760755714278"/>
+      <D unit="g/cm3" value="1.7e-14"/>
+      <fraction n="0.36264" ref="H"/>
+      <fraction n="0.36276" ref="N"/>
+      <fraction n="0.117748421296248" ref="C"/>
+      <fraction n="0.156851578703752" ref="O"/>
+    </material>
+
+</materials>

--- a/FCCee/CLD/compact/README.md
+++ b/FCCee/CLD/compact/README.md
@@ -33,8 +33,17 @@ This model is based on `FCCee_o2_v02` from k4geo. It has an updated design of th
 standard design (low-impedance, no HOM absorber); changed Vertex Detector Barrel layers to fit the beampipe contraints (reduced barrel length); fixed
 Overlaps in the Inner and Outer Tracker.
 
+CLD_o2_v06
+----------
+
+This model is based on `CLD_o2_v05` with the following changes: LumiCal outer radius from 112 mm to 115 mm, remove its nose shield, define its z extent in the beampipe reference frame.
 
 CLD_o3_v01
 ----------
 
 This model is based on CLD_o2_v05. The tracker size is reduced to accomodate the ARC detector for PID.
+
+CLD_o4_v01
+----------
+
+This model is based on CLD_o2_v05. The EM calorimeter barrel is replaced by the Noble Liquid ECAL from ALLEGRO. It is used for PandoraPFA development.

--- a/FCCee/CLD/compact/README.md
+++ b/FCCee/CLD/compact/README.md
@@ -36,7 +36,7 @@ Overlaps in the Inner and Outer Tracker.
 CLD_o2_v06
 ----------
 
-This model is based on `CLD_o2_v05` with the following changes: LumiCal outer radius from 112 mm to 115 mm, remove its nose shield, define its z extent in the beampipe reference frame.
+This model is based on `CLD_o2_v05` with the following changes: LumiCal outer radius from 112 mm to 115 mm, define its z extent in the beampipe reference frame.
 
 CLD_o3_v01
 ----------

--- a/detector/fcal/LumiCal_o1_v04_geo.cpp
+++ b/detector/fcal/LumiCal_o1_v04_geo.cpp
@@ -1,0 +1,245 @@
+#include <DD4hep/DetFactoryHelper.h>
+#include "DD4hep/DetType.h"
+#include <XML/Layering.h>
+#include "XML/Utilities.h"
+#include "DDRec/DetectorData.h"
+
+#include <string>
+
+using dd4hep::Assembly;
+using dd4hep::BUILD_ENVELOPE;
+using dd4hep::Box;
+using dd4hep::Cone;
+using dd4hep::DetElement;
+using dd4hep::Detector;
+using dd4hep::DetType;
+using dd4hep::IntersectionSolid;
+using dd4hep::Layering;
+using dd4hep::Layer;
+using dd4hep::Material;
+using dd4hep::PlacedVolume;
+using dd4hep::PolyhedraRegular;
+using dd4hep::Position;
+using dd4hep::Readout;
+using dd4hep::Ref_t;
+using dd4hep::Rotation3D;
+using dd4hep::RotationY;
+using dd4hep::RotationZYX;
+using dd4hep::SensitiveDetector;
+using dd4hep::SubtractionSolid;
+using dd4hep::Transform3D;
+using dd4hep::Translation3D;
+using dd4hep::Trapezoid;
+using dd4hep::Tube;
+using dd4hep::Volume;
+using dd4hep::_toString;
+using dd4hep::UnionSolid;
+using dd4hep::IntersectionSolid;
+using dd4hep::Segmentation;
+
+using dd4hep::rec::LayeredCalorimeterData;
+
+// workaround for DD4hep v00-14 (and older) 
+#ifndef DD4HEP_VERSION_GE
+#define DD4HEP_VERSION_GE(a,b) 0 
+#endif
+
+static Ref_t create_detector(Detector& theDetector,
+                             xml_h element,
+                             SensitiveDetector sens) {
+    
+    std::cout << __PRETTY_FUNCTION__  << std::endl;
+    std::cout << "Here is my LumiCal"  << std::endl;
+    std::cout << " and this is the sensitive detector: " << &sens  << std::endl;
+    sens.setType("calorimeter");
+    //Materials
+    Material air = theDetector.air();
+    
+    //Access to the XML File
+    xml_det_t     xmlLumiCal    = element;
+    const std::string detName   = xmlLumiCal.nameStr();
+    
+    DetElement sdet ( detName, xmlLumiCal.id() );
+    
+    // --- create an envelope volume and position it into the world ---------------------
+    
+    Volume envelope = dd4hep::xml::createPlacedEnvelope( theDetector, element , sdet ) ;
+    DetElement lumiCalDE_1(sdet,"Calorimeter1",1);
+    DetElement lumiCalDE_2(sdet,"Calorimeter2",2);
+
+    sdet.setTypeFlag( DetType::CALORIMETER |  DetType::ENDCAP  | DetType::ELECTROMAGNETIC |  DetType::FORWARD ) ;
+
+    if( theDetector.buildType() == BUILD_ENVELOPE ) return sdet ;
+    
+    //-----------------------------------------------------------------------------------
+    
+    dd4hep::xml::Dimension dimensions =  xmlLumiCal.dimensions();
+    
+    //LumiCal Dimensions
+    const double lcalInnerR = dimensions.inner_r();
+    const double lcalOuterR = dimensions.outer_r();
+    const double lcalInnerZ = dimensions.inner_z();
+    const double lcalThickness = Layering(xmlLumiCal).totalThickness();
+    const double lcalCentreZ = lcalInnerZ+lcalThickness*0.5;
+    
+    double LumiCal_cell_size      = theDetector.constant<double>("LumiCal_cell_size");
+    //========== fill data for reconstruction ============================
+    LayeredCalorimeterData* caloData = new LayeredCalorimeterData ;
+    caloData->layoutType = LayeredCalorimeterData::EndcapLayout ;
+    caloData->inner_symmetry = 0  ; // hardcoded tube
+    caloData->outer_symmetry = 0  ; 
+    caloData->phi0 = 0 ;
+    
+    /// extent of the calorimeter in the r-z-plane [ rmin, rmax, zmin, zmax ] in mm.
+    caloData->extent[0] = lcalInnerR ;
+    caloData->extent[1] = lcalOuterR ;
+    caloData->extent[2] = lcalInnerZ ;
+    caloData->extent[3] = lcalInnerZ + lcalThickness ;
+    
+    // counter for the current layer to be placed
+    int thisLayerId = 0;
+    
+    //Parameters we have to know about
+    dd4hep::xml::Component xmlParameter = xmlLumiCal.child(_Unicode(parameter));
+    const double fullCrossingAngle  = xmlParameter.attr< double >(_Unicode(crossingangle));
+    std::cout << " The crossing angle is: " << fullCrossingAngle << " radian"  << std::endl;
+    
+    
+    //Envelope to place the layers in
+    Tube envelopeTube (lcalInnerR, lcalOuterR, lcalThickness*0.5 );
+    Volume     envelopeVol(detName+"_module",envelopeTube,air);
+    envelopeVol.setVisAttributes(theDetector,xmlLumiCal.visStr());
+    
+    ////////////////////////////////////////////////////////////////////////////////
+    // Create all the layers
+    ////////////////////////////////////////////////////////////////////////////////
+    
+    //Loop over all the layer (repeat=NN) sections
+    //This is the starting point to place all layers, we need this when we have more than one layer block
+    double referencePosition = -lcalThickness*0.5;
+    for(dd4hep::xml::Collection_t coll(xmlLumiCal,_U(layer)); coll; ++coll)  {
+        dd4hep::xml::Component xmlLayer(coll); //we know this thing is a layer
+        
+        
+        //This just calculates the total size of a single layer
+        //Why no convenience function for this?
+        double layerThickness = 0;
+        for(dd4hep::xml::Collection_t l(xmlLayer,_U(slice)); l; ++l)
+            layerThickness += xml_comp_t(l).thickness();
+        
+        std::cout << "Total Length "    << lcalThickness/dd4hep::cm  << " cm" << std::endl;
+        std::cout << "Layer Thickness " << layerThickness/dd4hep::cm << " cm" << std::endl;
+        
+        //Loop for repeat=NN
+        for(int i=0, repeat=xmlLayer.repeat(); i<repeat; ++i)  {
+            
+            std::string layer_name = detName + dd4hep::xml::_toString(thisLayerId,"_layer%d");
+            Tube layer_base(lcalInnerR,lcalOuterR,layerThickness*0.5);
+            
+            Volume layer_vol(layer_name,layer_base,air);
+            
+            
+            int sliceID=0;
+            double inThisLayerPosition = -layerThickness*0.5;
+            
+            double nRadiationLengths=0.;
+            double nInteractionLengths=0.;
+            double thickness_sum=0;
+            
+            LayeredCalorimeterData::Layer caloLayer ;
+            
+            for(dd4hep::xml::Collection_t collSlice(xmlLayer,_U(slice)); collSlice; ++collSlice)  {
+                dd4hep::xml::Component compSlice = collSlice;
+                const double      slice_thickness = compSlice.thickness();
+                const std::string sliceName = layer_name + dd4hep::xml::_toString(sliceID,"slice%d");
+                Material   slice_material  = theDetector.material(compSlice.materialStr());
+                
+                Tube sliceBase(lcalInnerR,lcalOuterR,slice_thickness/2);
+                
+                Volume slice_vol (sliceName,sliceBase,slice_material);
+                
+                nRadiationLengths += slice_thickness/(2.*slice_material.radLength());
+                nInteractionLengths += slice_thickness/(2.*slice_material.intLength());
+                thickness_sum += slice_thickness/2;
+                
+                if ( compSlice.isSensitive() )  {
+
+ #if DD4HEP_VERSION_GE( 0, 15 )
+                   //Store "inner" quantities
+                    caloLayer.inner_nRadiationLengths = nRadiationLengths;
+                    caloLayer.inner_nInteractionLengths = nInteractionLengths;
+                    caloLayer.inner_thickness = thickness_sum;
+                    //Store scintillator thickness
+                    caloLayer.sensitive_thickness = slice_thickness;
+#endif                    
+                    //Reset counters to measure "outside" quantitites
+                    nRadiationLengths=0.;
+                    nInteractionLengths=0.;
+                    thickness_sum = 0.;
+                    slice_vol.setSensitiveDetector(sens);
+                }
+                
+                nRadiationLengths += slice_thickness/(2.*slice_material.radLength());
+                nInteractionLengths += slice_thickness/(2.*slice_material.intLength());
+                thickness_sum += slice_thickness/2;
+                
+                slice_vol.setAttributes(theDetector,compSlice.regionStr(),compSlice.limitsStr(),compSlice.visStr());
+                layer_vol.placeVolume(slice_vol,Position(0,0,inThisLayerPosition+slice_thickness*0.5));
+                    
+                inThisLayerPosition += slice_thickness;
+                ++sliceID;
+            }//For all slices in this layer
+            
+            //-----------------------------------------------------------------------------------------
+            
+            ///Needs to be innermost face distance
+            caloLayer.distance = lcalCentreZ + referencePosition;
+
+#if DD4HEP_VERSION_GE( 0, 15 )
+            caloLayer.outer_nRadiationLengths = nRadiationLengths;
+            caloLayer.outer_nInteractionLengths = nInteractionLengths;
+            caloLayer.outer_thickness = thickness_sum;
+#endif            
+            
+            caloLayer.cellSize0 = LumiCal_cell_size ;
+            caloLayer.cellSize1 = LumiCal_cell_size ;
+            
+            caloData->layers.push_back( caloLayer ) ;
+            //-----------------------------------------------------------------------------------------
+            
+            //Why are we doing this for each layer, this just needs to be done once and then placed multiple times
+            //Do we need unique IDs for each piece?
+            layer_vol.setVisAttributes(theDetector,xmlLayer.visStr());
+            
+            Position layer_pos(0,0,referencePosition+0.5*layerThickness);
+            referencePosition += layerThickness;
+            PlacedVolume pv = envelopeVol.placeVolume(layer_vol,layer_pos);
+            pv.addPhysVolID("layer",thisLayerId);
+            
+            ++thisLayerId;
+            
+        }//for all layers
+        
+    }// for all layer collections
+    
+    const Position bcForwardPos (std::sin(0.5*fullCrossingAngle)*lcalCentreZ, 0.,  std::cos(0.5*fullCrossingAngle)*lcalCentreZ);
+    const Position bcBackwardPos(std::sin(0.5*fullCrossingAngle)*lcalCentreZ, 0., -std::cos(0.5*fullCrossingAngle)*lcalCentreZ);
+    const Rotation3D bcForwardRot ( RotationY(fullCrossingAngle*0.5 ) );
+    const Rotation3D bcBackwardRot( RotationZYX ( (M_PI), (M_PI-fullCrossingAngle*0.5), (0.0)));
+    
+    PlacedVolume pv =
+    envelope.placeVolume(envelopeVol, Transform3D( bcForwardRot, bcForwardPos ) );
+    pv.addPhysVolID("barrel", 1);
+    lumiCalDE_1.setPlacement(pv);
+
+    PlacedVolume pv2 =
+    envelope.placeVolume(envelopeVol, Transform3D( bcBackwardRot, bcBackwardPos ) );
+    pv2.addPhysVolID("barrel", 2);
+    lumiCalDE_2.setPlacement(pv2);
+    
+    sdet.addExtension< LayeredCalorimeterData >( caloData ) ;
+    
+    return sdet;
+}
+                                               
+DECLARE_DETELEMENT(LumiCal_o1_v04,create_detector)


### PR DESCRIPTION

BEGINRELEASENOTES
- Update FCCee lumiCal:  LumiCal outer radius from 112 mm to 115 mm, define its z extent in the beampipe reference frame.

ENDRELEASENOTES

Once we are happy, I will apply the same changes to IDEA and ALLEGRO. 

I attach the diffs of the files I touched for review convenience: 

[diff_LumiCal_o1_v01_geo.txt](https://github.com/key4hep/k4geo/files/14450800/diff_LumiCal_o1_v01_geo.txt)
[diff_CLD_o2_v05.txt](https://github.com/key4hep/k4geo/files/14450801/diff_CLD_o2_v05.txt)
[diff_LumiCal_o3_v02_03.txt](https://github.com/key4hep/k4geo/files/14450802/diff_LumiCal_o3_v02_03.txt)
