### PR TITLE
Fix event display for tracker endcap in CEDViewer

### DIFF
--- a/detector/tracker/SiTrackerEndcap_o2_v01ext_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v01ext_geo.cpp
@@ -136,8 +136,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
       sumZ += zstart;
       r = r + mod_shape->GetDY();
 
+      petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
+
       for(int k=0; k<nmodules; ++k) {
-        petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
         string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
         double x = -r*std::cos(phi);
         double y = -r*std::sin(phi);

--- a/detector/tracker/SiTrackerEndcap_o2_v01ext_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v01ext_geo.cpp
@@ -111,6 +111,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
     int l_id    = x_layer.id();
     int mod_num = 0;
     int ring_num = 0;
+    int petal_num = 0;
 
     double sumZ(0.), innerR(1e100), outerR(0.);
 
@@ -136,6 +137,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
       r = r + mod_shape->GetDY();
 
       for(int k=0; k<nmodules; ++k) {
+        petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
         string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
         double x = -r*std::cos(phi);
         double y = -r*std::sin(phi);
@@ -173,7 +175,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
     thisLayer.zPosition = sumZ/ring_num; // average z
     thisLayer.distanceSensitive = innerR;
     thisLayer.lengthSensitive = outerR - innerR;
-    thisLayer.petalNumber = ring_num; // number of rings in petalNumber, needed for tracking
+    thisLayer.petalNumber = petal_num;
+    thisLayer.sensorsPerPetal = ring_num; // number of rings in petalNumber, needed for tracking
     zDiskPetalsData->layers.push_back(thisLayer);
 
   }

--- a/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
@@ -156,9 +156,10 @@ static Ref_t create_detector(Detector& theDetector,xml_h e,SensitiveDetector sen
 	outerR=r+mod_shape->GetDZ();
       sumZ+=zstart;
       r=r+mod_shape->GetDY();
-      
+
+      petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
+
       for(int k=0;k<nmodules;++k){
-        petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
 	string m_base=_toString(l_id,"layer%d")+_toString(mod_num,"_module%d")+_toString(k,"_sensor%d");
 	double x=-r*std::cos(phi);
 	double y=-r*std::sin(phi);

--- a/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
@@ -126,6 +126,7 @@ static Ref_t create_detector(Detector& theDetector,xml_h e,SensitiveDetector sen
     int l_id=x_layer.id();
     int mod_num=0;
     int ring_num=0;
+    int petal_num=0;
     double sumZ(0.),innerR(1e100),outerR(0.);
     //loop only to count the number of rings in a disk - it is then needed for looking for neighborous when you are in a "border" cell
     int nrings = 0;
@@ -157,6 +158,7 @@ static Ref_t create_detector(Detector& theDetector,xml_h e,SensitiveDetector sen
       r=r+mod_shape->GetDY();
       
       for(int k=0;k<nmodules;++k){
+        petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
 	string m_base=_toString(l_id,"layer%d")+_toString(mod_num,"_module%d")+_toString(k,"_sensor%d");
 	double x=-r*std::cos(phi);
 	double y=-r*std::sin(phi);
@@ -247,7 +249,8 @@ static Ref_t create_detector(Detector& theDetector,xml_h e,SensitiveDetector sen
     thisLayer.zPosition=sumZ/ring_num; // average z
     thisLayer.distanceSensitive=innerR;
     thisLayer.lengthSensitive=outerR - innerR;
-    thisLayer.petalNumber=ring_num; // number of rings in petalNumber, needed for tracking
+    thisLayer.petalNumber=petal_num;
+    thisLayer.sensorsPerPetal=ring_num; // number of rings in petalNumber, needed for tracking
     zDiskPetalsData->layers.push_back(thisLayer);
   }
   

--- a/detector/tracker/TrackerEndcap_o1_v04_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v04_geo.cpp
@@ -123,6 +123,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
         int l_id    = x_layer.id();
         int mod_num = 0;
         int ring_no=0;
+        int petal_num = 0;
         //Cannot handle rings in ZDiskPetalsData, calculate approximate petal quantities
         double sumZ(0.), innerR(1e100),outerR(0.);
 
@@ -159,6 +160,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
+                petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
+
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);
@@ -199,7 +202,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             thisLayer.zPosition= sumZ/ring_no; //calc average z
             thisLayer.distanceSensitive   = innerR ; 
             thisLayer.lengthSensitive   = outerR-innerR;
-            thisLayer.petalNumber   = ring_no ; //Store the number of rings in petalNumber needed for tracking
+            thisLayer.petalNumber = petal_num;
+            thisLayer.sensorsPerPetal   = ring_no ; //Store the number of rings in petalNumber needed for tracking
 
             //this assumes there is a constant sensitive thickness even though
             //the layer could have different modules with different thicknesses

--- a/detector/tracker/TrackerEndcap_o1_v04_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v04_geo.cpp
@@ -152,16 +152,15 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
                  outerR = r + mod_shape->GetDZ();
                  
             sumZ+=zstart;
-            
-            
+
+            petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
+
             //NOTE: As in the barrel, what we call "module" in the xml is like a single trapezoidal wafer
             //For reasons of bit conservation in the encoding and to be more similar to the ILD geometry
             //A module has to be something that consists of many "sensors" (wafers) 
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
-                petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
-
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);

--- a/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
@@ -174,6 +174,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
                  
             sumZ+=zstart;
             
+            petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
             
             //NOTE: As in the barrel, what we call "module" in the xml is like a single trapezoidal wafer
             //For reasons of bit conservation in the encoding and to be more similar to the ILD geometry
@@ -181,8 +182,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
-                petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
-
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);

--- a/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
@@ -138,6 +138,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
         int l_id    = x_layer.id();
         int mod_num = 0;
         int ring_no=0;
+        int petal_num=0;
         //Cannot handle rings in ZDiskPetalsData, calculate approximate petal quantities
         double sumZ(0.), innerR(1e100),outerR(0.);
 
@@ -180,6 +181,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
+                petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
+
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);
@@ -288,7 +291,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             thisLayer.zPosition= sumZ/ring_no; //calc average z
             thisLayer.distanceSensitive   = innerR ; 
             thisLayer.lengthSensitive   = outerR-innerR;
-            thisLayer.petalNumber   = ring_no ; //Store the number of rings in petalNumber needed for tracking
+            thisLayer.petalNumber = petal_num;
+            thisLayer.sensorsPerPetal   = ring_no ; //Store the number of rings in petalNumber needed for tracking
 
             //this assumes there is a constant sensitive thickness even though
             //the layer could have different modules with different thicknesses

--- a/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
@@ -156,15 +156,15 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             sumZ+=zstart;
             
             r=r+mod_shape->GetDY();
-            
+
+            petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
+
             //NOTE: As in the barrel, what we call "module" in the xml is like a single trapezoidal wafer
             //For reasons of bit conservation in the encoding and to be more similar to the ILD geometry
             //A module has to be something that consists of many "sensors" (wafers) 
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
-                petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
-
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);

--- a/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
@@ -206,7 +206,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             thisLayer.distanceSensitive   = innerR ; 
             thisLayer.lengthSensitive   = outerR-innerR;
             thisLayer.petalNumber = petal_num;
-            thisLayer.sensersPerPetal   = ring_no ; //Store the number of rings in petalNumber needed for tracking
+            thisLayer.sensorsPerPetal   = ring_no ; //Store the number of rings in petalNumber needed for tracking
 
             //this assumes there is a constant sensitive thickness even though
             //the layer could have different modules with different thicknesses

--- a/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
@@ -163,7 +163,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
-                thisLayer.petalNumber   = ring_no ; //Store the number of rings in petalNumber needed for tracking
+                petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
 
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 

--- a/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
@@ -125,6 +125,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
         int l_id    = x_layer.id();
         int mod_num = 0;
         int ring_no=0;
+        int petal_num = 0;
         //Cannot handle rings in ZDiskPetalsData, calculate approximate petal quantities
         double sumZ(0.), innerR(1e100),outerR(0.);
         double sensitiveThickness(0.0);
@@ -162,6 +163,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
+                thisLayer.petalNumber   = ring_no ; //Store the number of rings in petalNumber needed for tracking
+
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);
@@ -202,7 +205,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             thisLayer.zPosition= sumZ/ring_no; //calc average z
             thisLayer.distanceSensitive   = innerR ; 
             thisLayer.lengthSensitive   = outerR-innerR;
-            thisLayer.petalNumber   = ring_no ; //Store the number of rings in petalNumber needed for tracking
+            thisLayer.petalNumber = petal_num;
+            thisLayer.sensersPerPetal   = ring_no ; //Store the number of rings in petalNumber needed for tracking
 
             //this assumes there is a constant sensitive thickness even though
             //the layer could have different modules with different thicknesses

--- a/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
@@ -177,14 +177,15 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             sumZ+=zstart;
             
             r=r+mod_shape->GetDY();
+
+            petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
             
             //NOTE: As in the barrel, what we call "module" in the xml is like a single trapezoidal wafer
             //For reasons of bit conservation in the encoding and to be more similar to the ILD geometry
             //A module has to be something that consists of many "sensors" (wafers) 
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
-            
+
             for(int k=0; k<nmodules; ++k) {
-                petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);

--- a/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
@@ -140,6 +140,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
         int l_id    = x_layer.id();
         int mod_num = 0;
         int ring_no=0;
+        int petal_num = 0;
         //Cannot handle rings in ZDiskPetalsData, calculate approximate petal quantities
         double sumZ(0.), innerR(1e100),outerR(0.);
         double sensitiveThickness(0.0);
@@ -183,6 +184,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
+                petal_num = nmodules;  // store the module number of this ring for nPetals in ZDiskPetalsData
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);
@@ -292,7 +294,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             thisLayer.zPosition= sumZ/ring_no; //calc average z
             thisLayer.distanceSensitive   = innerR ; 
             thisLayer.lengthSensitive   = outerR-innerR;
-            thisLayer.petalNumber   = ring_no ; //Store the number of rings in petalNumber needed for tracking
+            thisLayer.petalNumber = petal_num;
+            thisLayer.sensorsPerPetal = ring_no; // number of rings in petalNumber, needed for tracking
 
             //this assumes there is a constant sensitive thickness even though
             //the layer could have different modules with different thicknesses

--- a/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
@@ -156,6 +156,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
         int l_id    = x_layer.id();
         int mod_num = 0;
         int ring_no=0;
+	int petal_num=0;
         //Cannot handle rings in ZDiskPetalsData, calculate approximate petal quantities
         double sumZ(0.), innerR(1e100),outerR(0.);
         double sensitiveThickness(0.0);
@@ -199,6 +200,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
+	        petal_num = nmodules ;  // store the module number of this ring for nPetals in ZDiskPetalsData
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);
@@ -308,7 +310,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             thisLayer.zPosition= sumZ/ring_no; //calc average z
             thisLayer.distanceSensitive   = innerR ; 
             thisLayer.lengthSensitive   = outerR-innerR;
-            thisLayer.petalNumber   = ring_no ; //Store the number of rings in petalNumber needed for tracking
+            thisLayer.petalNumber      = petal_num ;  // module number is the number of petals - needed for CED event display
+            thisLayer.sensorsPerPetal  = ring_no ; //Store the number of rings as sensors per petal - needed for tracking
 
             //this assumes there is a constant sensitive thickness even though
             //the layer could have different modules with different thicknesses

--- a/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
@@ -193,14 +193,15 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             sumZ+=zstart;
             
             r=r+mod_shape->GetDY();
-            
+
+	        petal_num = nmodules ;  // store the module number of this ring for nPetals in ZDiskPetalsData
+
             //NOTE: As in the barrel, what we call "module" in the xml is like a single trapezoidal wafer
             //For reasons of bit conservation in the encoding and to be more similar to the ILD geometry
             //A module has to be something that consists of many "sensors" (wafers) 
             //We chose to do it so one phi-ring is one module. i.e. Modules have constant R
             
             for(int k=0; k<nmodules; ++k) {
-	        petal_num = nmodules ;  // store the module number of this ring for nPetals in ZDiskPetalsData
                 string m_base = _toString(l_id,"layer%d") + _toString(mod_num,"_module%d") + _toString(k,"_sensor%d");
                 
                 double x = -r*std::cos(phi);


### PR DESCRIPTION
BEGINRELEASENOTES
- fix CED event display for CLIC like detectors using TrackerEndcap_o2_v0x_geo 
       -  fix nPetals in ZDiskPetalsData (for CEDViewer) to use nmodules (e.g. 48 ) rather than nrings
       -  store the number of rings in  `ZDiskPetalsData::sensorsPerPetal`     

ENDRELEASENOTES