### PR TITLE
Delete an unused string

### DIFF
--- a/detector/calorimeter/CaloEndcapDiscs_o1_v01_geo.cpp
+++ b/detector/calorimeter/CaloEndcapDiscs_o1_v01_geo.cpp
@@ -4,7 +4,6 @@
 #define endmsg std::endl
 #define lLog std::cout
 namespace MSG {
-const std::string ERROR = " Error: ";
 const std::string DEBUG = " Debug: ";
 const std::string INFO  = " Info: ";
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove a warning by deleting an unused string

ENDRELEASENOTES