### PR TITLE
Make TPC  have detector ID 4 and use consistent tracker cell ID

### DIFF
--- a/ILD/compact/ILD_l5_v11/FCCdefs.xml
+++ b/ILD/compact/ILD_l5_v11/FCCdefs.xml
@@ -104,6 +104,6 @@
 
   <constant name="InnerTracker_outer_radius" value="top_TPC_inner_radius-5*mm" />
 
-  <constant name="GlobalTrackerReadoutID" type="string" value="system:5,side:-2,layer:6,module:11,sensor:8"/>
+  <constant name="GlobalTrackerReadoutID" type="string" value="system:5,side:-2,layer:9,module:8,sensor:8"/>
 
 </define>

--- a/ILD/compact/ILD_l5_v11/basic_defs.xml
+++ b/ILD/compact/ILD_l5_v11/basic_defs.xml
@@ -8,14 +8,14 @@
   <constant name="ILDDetID_NOTUSED"      value="  0"/>
 
 
-  <constant name="ILDDetID_TPC"          value="  5"/>
+  <constant name="ILDDetID_TPC"          value="  4"/>
   <constant name="ILDDetID_SET"          value="  6"/>
 
 <!-- from FCC -->
   <constant name="DetID_VXD_Barrel"        value="1"/>
   <constant name="DetID_VXD_Endcap"        value="2"/>
   <constant name="DetID_IT_Barrel"         value="3"/>
-  <constant name="DetID_IT_Endcap"         value="4"/>
+  <constant name="DetID_IT_Endcap"         value="5"/>
   <constant name="DetID_LumiCalNoseShield"       value="14"/> <!-- to avoid clash "22"/ -->
   <constant name="DetID_LumiCal"                 value="15"/>
   <constant name="DetID_LumiCalInstrumentation"  value="16"/>


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the TPC have detector ID 4 and use a consistent cellID for all tracking detectors in `ILD_l5_v11` in order to make tracking code run again

ENDRELEASENOTES

@Victor-Schwan @danieljeans these are some minor fixes that are necessary. Clupatra really wants the TPC to have detector ID 4 and some other tracking code also requires a consistent cellID encoding scheme throughout the detector. We switched to the ILD one here for the CLD bits as well.