### PR TITLE
Change an unset variable by a header name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ set(FILES_DEPENDINGON_DCH_INFO_H "DriftChamber_o1_v02.cpp" )
 
 if(NOT DCH_INFO_H_EXIST)
     list(FILTER sources EXCLUDE REGEX "${FILES_DEPENDINGON_DCH_INFO_H}")
-    message(WARNING "Subdetector ${FILES_DEPENDINGON_DCH_INFO_H} will not be built because header file ${DCH_INFO_H} was not found")
+    message(WARNING "Subdetector ${FILES_DEPENDINGON_DCH_INFO_H} will not be built because header file DDRec/DCH_info.h was not found")
 endif()
 
 file(GLOB G4sources


### PR DESCRIPTION
since otherwise the message doesn't tell you which header is missing and you have to check the CMakeLists.txt

BEGINRELEASENOTES
- CMake: fix printout for missing header file, by printing the actual missing file

ENDRELEASENOTES