### PR TITLE
new cmake option to download the beampipe STL files from the web eos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,25 +214,25 @@ if(INSTALL_BEAMPIPE_STL_FILES)
     set(OUTPUT_DIR "${CMAKE_BINARY_DIR}/${STL_PATH}")
     file(MAKE_DIRECTORY ${OUTPUT_DIR})
 
-    set(FILES_DOWNLOADED)
-
     foreach(STL_FILE ${STL_FILES})
         set(FULL_URL "${FCC_URL}/${STL_PATH}/${STL_FILE}")
         message(DEBUG "Downloading file ${FULL_URL}")
         set(OUTPUT_FILE "${OUTPUT_DIR}/${STL_FILE}")
 
-        # Download the file
-        file(DOWNLOAD ${FULL_URL} ${OUTPUT_FILE}
-          SHOW_PROGRESS
-          STATUS download_status)
+        if(EXISTS "${OUTPUT_FILE}")
+          message(STATUS "File ${STL_FILE} already exists. Skipping download.")
+        else()
+          # Download the file
+          file(DOWNLOAD ${FULL_URL} ${OUTPUT_FILE}
+            SHOW_PROGRESS
+            STATUS download_status)
 
-        list(GET download_status 0 status_code)
-        if(NOT status_code EQUAL 0)
-            list(GET download_status 1 error_message)
-            message(FATAL_ERROR "Failed to download file: ${error_message}")
+          list(GET download_status 0 status_code)
+          if(NOT status_code EQUAL 0)
+              list(GET download_status 1 error_message)
+              message(FATAL_ERROR "Failed to download file: ${error_message}")
+          endif()
         endif()
-        list(APPEND FILES_DOWNLOADED "${FULL_URL}")
-
     endforeach()
 
     file(MAKE_DIRECTORY share/k4geo/FCCee)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 option(BUILD_TESTING "Enable and build tests" ON)
 option(INSTALL_COMPACT_FILES "Copy compact files to install area" OFF)
+option(INSTALL_BEAMPIPE_STL_FILES "Download CAD files for building the detailed beampipe" OFF)
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -194,3 +195,47 @@ write_basic_package_version_file(
 install(FILES ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/k4geoConfig.cmake
               ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/k4geoConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_CMAKEDIR} )
+
+if(INSTALL_BEAMPIPE_STL_FILES)
+
+    set(STL_FILES
+          "AlBeMet162_30042024.stl"
+          "Copper_pipe_28092023.stl"
+          "Gold_19042024.stl"
+          "Paraffine_19042024.stl"
+          "Tungsten_mask_02102023.stl"
+          "Water_30042024.stl"
+        )
+    # Set main FCC url
+    set(FCC_URL "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco")
+    set(STL_PATH "MDI/MDI_o1_v01/stl_files/Pipe_240430")
+
+    # Set the output directory where the file will be placed
+    set(OUTPUT_DIR "${CMAKE_BINARY_DIR}/${STL_PATH}")
+    file(MAKE_DIRECTORY ${OUTPUT_DIR})
+
+    set(FILES_DOWNLOADED)
+
+    foreach(STL_FILE ${STL_FILES})
+        set(FULL_URL "${FCC_URL}/${STL_PATH}/${STL_FILE}")
+        message(DEBUG "Downloading file ${FULL_URL}")
+        set(OUTPUT_FILE "${OUTPUT_DIR}/${STL_FILE}")
+
+        # Download the file
+        file(DOWNLOAD ${FULL_URL} ${OUTPUT_FILE}
+          SHOW_PROGRESS
+          STATUS download_status)
+
+        list(GET download_status 0 status_code)
+        if(NOT status_code EQUAL 0)
+            list(GET download_status 1 error_message)
+            message(FATAL_ERROR "Failed to download file: ${error_message}")
+        endif()
+        list(APPEND FILES_DOWNLOADED "${FULL_URL}")
+
+    endforeach()
+
+    file(MAKE_DIRECTORY share/k4geo/FCCee)
+    INSTALL(DIRECTORY ${OUTPUT_DIR} DESTINATION share/k4geo/FCCee/MDI/compact/MDI_o1_v01/stl_files )
+
+endif()

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml
@@ -34,6 +34,8 @@
   <include ref="../../../MDI/compact/MDI_o1_v00/Beampipe_o4_v05.xml" />
   <include ref="../../../MDI/compact/MDI_o1_v00/BeamInstrumentation_o1_v01.xml" />
   
+  <!-- In order to use the CAD beampipe, build k4geo with the following CMake option: 
+  cmake -D INSTALL_BEAMPIPE_STL_FILES=ON which will download the files needed -->
   <!-- engineered CAD model of the beam pipe -->
   <!-- <include ref="../../../MDI/compact/MDI_o1_v01/Beampipe_CADimport_o1_v02.xml" /> -->
   <!-- <include ref="../../../MDI/compact/MDI_o1_v01/BeamInstrumentation_o1_v01.xml"/> -->

--- a/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
@@ -37,7 +37,10 @@
   <!-- shape based model of the beam pipe -->
   <include ref="../../../MDI/compact/MDI_o1_v00/Beampipe_o4_v05.xml" />
   <include ref="../../../MDI/compact/MDI_o1_v00/BeamInstrumentation_o1_v01.xml" />
+  
   <!-- engineered CAD model of the beam pipe -->
+  <!-- In order to use the CAD beampipe, build k4geo with the following CMake option: 
+  cmake -D INSTALL_BEAMPIPE_STL_FILES=ON which will download the files needed -->
   <!-- <include ref="../../../MDI/compact/MDI_o1_v01/Beampipe_CADimport_o1_v02.xml" /> -->
   <!-- <include ref="../../../MDI/compact/MDI_o1_v01/BeamInstrumentation_o1_v01.xml"/> -->
   <include ref="LumiCal_o1_v01.xml"/>

--- a/FCCee/MDI/compact/README.md
+++ b/FCCee/MDI/compact/README.md
@@ -5,9 +5,10 @@ aciarma - 08/07/24
 -- BeamInstrumentation_o1_v01.xml : compensating and screening solenoids
 -- HOMAbsorber.xml : old model of the HOM absorbers. Not needed anymore with new low impedance beam pipe.
 
-- MDI_o1_v01 (STL FILES NOT IN THIS REPO!!! WILL BE ADDED LATER)
+- MDI_o1_v01
 -- Beampipe_CADimport_o1_v02.xml : import CAD models for engineered beam pipe (by F. Fransesini/INFN-LNF)
-These .stl files are hosted [here](https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/MDI/MDI_o1_v01/)
+These .stl files are hosted [here](https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/MDI/MDI_o1_v01/).
+The CMake option `INSTALL_BEAMPIPE_STL_FILES=ON` downloads these STL.
 -- stl_files/Pipe_240430
     ├── AlBeMet162_30042024.stl    : central and elliptoconical chambers, with cooling manifolds 
     ├── Copper_pipe_28092023.stl   : low impedance beam pipe separation region


### PR DESCRIPTION
BEGINRELEASENOTES
- New CMake option `INSTALL_BEAMPIPE_STL_FILES` can be used to download the STL (CAD model) beam pipe files from the web EOS 

ENDRELEASENOTES

Introduction: the new beampipe is based on CAD models, but the STL files that contain the description are too big (36MB total) to be part of the git repository. For that reason, in the previous PR https://github.com/key4hep/k4geo/pull/344, the CAD files were removed.

Goal of this PR: this PR introduces an option in the CMake to download these files and place them in the proper output directory. 

I was not sure if it makes sense to download and the files if the compact files are not going to be installed as well. What do you think  @BrieucF @andresailer @aciarma ?

Also, maybe the cmake code is not very clean. I do not like that if the `INSTALL_BEAMPIPE_STL_FILES` flag is changed, one has to recompile the whole k4geo. Do you know if by creating a custom command that behavior can be prevented?