### PR TITLE
Add aliases for the detectorCommon and detectorSegmentations libraries

### DIFF
--- a/detectorCommon/CMakeLists.txt
+++ b/detectorCommon/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 file(GLOB sources src/*.cpp)
 add_dd4hep_plugin(detectorCommon SHARED ${sources})
+add_library(k4geo::detectorCommon ALIAS detectorCommon)
 target_link_libraries(detectorCommon DD4hep::DDCore DD4hep::DDG4 detectorSegmentations)
 target_include_directories(detectorCommon
     PUBLIC

--- a/detectorSegmentations/CMakeLists.txt
+++ b/detectorSegmentations/CMakeLists.txt
@@ -5,6 +5,7 @@
 file(GLOB sources src/*.cpp)
 
 add_library(detectorSegmentations SHARED ${sources} )
+add_library(k4geo::detectorSegmentations ALIAS detectorSegmentations)
 dd4hep_generate_rootmap(detectorSegmentationsPlugin)
 target_link_libraries(detectorSegmentations DD4hep::DDCore)
 target_include_directories(detectorSegmentations


### PR DESCRIPTION
similarly to how we do it in other places like EDM4hep: https://github.com/key4hep/EDM4hep/blob/d409c530466c28ace19af865c56cec8911d8b369/edm4hep/CMakeLists.txt#L15

BEGINRELEASENOTES
- Add aliases for the detectorCommon and detectorSegmentations libraries

ENDRELEASENOTES