### PR TITLE
Fix CLD endcap radius calculation for CED

### DIFF
--- a/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
@@ -184,11 +184,11 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             
             Box mod_shape(m_vol.solid());
             
-             if(r - mod_shape->GetDZ()<innerR)
-                 innerR= r- mod_shape->GetDZ();
+             if(r < innerR)
+                 innerR = r;
              
-             if(r + mod_shape->GetDZ()>outerR)
-                 outerR = r + mod_shape->GetDZ();
+             if(r + 2*mod_shape->GetDY() > outerR)
+                 outerR = r + 2*mod_shape->GetDY();
                  
             sumZ+=zstart;
             


### PR DESCRIPTION
The radius calculation was very broken, the radius supplied by the xml is already the inner radius and the Y half-length instead of the Z half-length needs to be used, Z is just the thickness of the modules... Thankfully this was only used for the event display, the placement of the modules seems to be correct :)

BEGINRELEASENOTES
- Fixed CLD endcap radius calculation for CED

ENDRELEASENOTES

fixes #355 

before: check issue above

after:
![image](https://github.com/user-attachments/assets/4828adbd-85fd-4985-ab8c-ffe2f592404a)

