### PR TITLE
[FCCeeMDI] Use absolute path to import CAD files

### DIFF
--- a/FCCee/MDI/compact/MDI_o1_v01/Beampipe_CADimport_o1_v02.xml
+++ b/FCCee/MDI/compact/MDI_o1_v01/Beampipe_CADimport_o1_v02.xml
@@ -19,7 +19,7 @@
 
     <detector name="Beampipe_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="./stl_files/Pipe_240430/AlBeMet162_30042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/AlBeMet162_30042024.stl"
 	       unit="mm" material="AlBeMet162">
 	  <volume id="0" name="s1" vis="AlBeMet_vis" material="AlBeMet162"> 
 	    <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -31,7 +31,7 @@
 
     <detector name="Beampipe_crotch_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="./stl_files/Pipe_240430/Copper_pipe_28092023.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Copper_pipe_28092023.stl"
                unit="mm" material="Copper">
           <volume id="0" name="s1" vis="CopperCooling_vis" material="Cu">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -44,7 +44,7 @@
 
     <detector name="Gold_STL" type="DD4hep_TestShape_Creator">
       <check>
-	<shape type="CAD_MultiVolume" ref="./stl_files/Pipe_240430/Gold_19042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Gold_19042024.stl"
 	       unit="mm" material="Gold">
           <volume id="0" name="s1" vis="Gold_vis" material="Au">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -57,7 +57,7 @@
     
     <detector name="Paraffin_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="./stl_files/Pipe_240430/Paraffine_19042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Paraffine_19042024.stl"
 	       unit="mm" material="LiquidNDecane">
           <volume id="0" name="s1" vis="Paraffin_vis" material="LiquidNDecane">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -69,7 +69,7 @@
 
     <detector name="Water_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="./stl_files/Pipe_240430/Water_30042024.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Water_30042024.stl"
                unit="mm" material="Water">
           <volume id="0" name="s1" vis="Water_vis" material="Water">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>
@@ -81,7 +81,7 @@
 
     <detector name="Tungsten_STL" type="DD4hep_TestShape_Creator">
       <check>
-        <shape type="CAD_MultiVolume" ref="./stl_files/Pipe_240430/Tungsten_mask_02102023.stl"
+        <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/MDI/compact/MDI_o1_v01/stl_files/Pipe_240430/Tungsten_mask_02102023.stl"
                unit="mm" material="Tungsten">
           <volume id="0" name="s1" vis="Tungsten_vis" material="W">
             <position x="0*cm"  y="0*cm"  z="0*cm"/>


### PR DESCRIPTION

BEGINRELEASENOTES
- [FCCeeMDI] Use absolute path to import CAD files

ENDRELEASENOTES

It looks like, when importing CAD file with `<shape type="CAD_MultiVolume" ref="path_to_stl_file" unit="mm" material="LiquidNDecane">`, the path is relative to where the ddsim command is launched