### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/detector/calorimeter/ECalEndcap_Turbine_o1_v01_geo.cpp
+++ b/detector/calorimeter/ECalEndcap_Turbine_o1_v01_geo.cpp
@@ -112,9 +112,9 @@ namespace det {
     float LArgapi = nobleLiquidElem.attr<float>(_Unicode(gap));
     
     bool sameNUnitCells = genericBladeElem.attr<bool>(_Unicode(sameNUnitCells));
-    char* nUnitCellsStrArr = (char*)genericBladeElem.attr<std::string>(_Unicode(nUnitCells)).c_str();
-    char* nUnitCellsCStr = strtok(nUnitCellsStrArr, " ");   
-    int nUnitCells;
+    auto nUnitCellsStrArr = genericBladeElem.attr<std::string>(_Unicode(nUnitCells));
+    char* nUnitCellsCStr = strtok(const_cast<char*>(nUnitCellsStrArr.c_str()), " ");
+    int nUnitCells = 0;
     if (!sameNUnitCells) {
       for (unsigned i = 0; i < iWheel; i++) {
 	nUnitCellsCStr = strtok(NULL, " ");
@@ -162,7 +162,6 @@ namespace det {
     float LArgapo = delrPhiGapOnly*TMath::Sin(BladeAngle);
     //    LArgapo *= 2.;
     
-    dd4hep::Solid absBlade;
     float riLayer = ri;
 
     std::vector<dd4hep::Volume> claddingLayerVols;
@@ -578,7 +577,6 @@ namespace det {
   double ri = rmin;
 
   float supportTubeThickness=supportTubeElem.thickness();
-  unsigned iSupportTube = 0;
 
   for (unsigned iWheel = 0; iWheel < nWheels; iWheel++) {
    
@@ -600,7 +598,6 @@ namespace det {
     ri = ro;
     ro *= radiusRatio;
     if (ro > rmax) ro = rmax;
-    iSupportTube++;
   }
 
 

--- a/detectorSegmentations/include/detectorSegmentations/GridDRcalo_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridDRcalo_k4geo.h
@@ -18,12 +18,12 @@ public:
   virtual ~GridDRcalo_k4geo() override;
 
   //  Determine the global(local) position based on the cell ID.
-  virtual Vector3D position(const CellID& aCellID) const;
+  virtual Vector3D position(const CellID& aCellID) const override;
   Vector3D localPosition(const CellID& aCellID) const;
   Vector3D localPosition(int numx, int numy, int x_, int y_) const;
 
   virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                        const VolumeID& aVolumeID) const;
+                        const VolumeID& aVolumeID) const override;
 
   VolumeID setVolumeID(int numEta, int numPhi) const;
   CellID setCellID(int numEta, int numPhi, int x, int y) const;

--- a/plugins/DRCaloFastSimModel.h
+++ b/plugins/DRCaloFastSimModel.h
@@ -5,7 +5,11 @@ struct FastFiberData
 {
 public:
   FastFiberData(G4int, G4double, G4double, G4double, G4ThreeVector, G4ThreeVector, G4ThreeVector, G4int status = G4OpBoundaryProcessStatus::Undefined);
-  ~FastFiberData() {}
+  FastFiberData& operator=(const FastFiberData& theData) = default;
+  
+  FastFiberData(const FastFiberData& theData) = default;
+  ~FastFiberData() = default;
+
 
   void reset();
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a few compiler warnings

ENDRELEASENOTES

I have enabled `-Werror` for the Key4hep CI so that warnings will now be promoted to errors. In k4geo warnings are introduced in PRs all the time, so this will make CI fail if that is the case. Because there are already some, this PR is going to be necessary to pass CI.