### PR TITLE
Add `print_overlaps` util

### DIFF
--- a/utils/print_overlaps.py
+++ b/utils/print_overlaps.py
@@ -1,0 +1,18 @@
+from argparse import ArgumentParser
+import re
+
+
+def main():
+    parser = ArgumentParser(description="Printout overlaps from overlap dump file")
+    parser.add_argument("filename")
+    args = parser.parse_args()
+
+    pattern = re.compile(r".+\ G4Exception-START\ .+(\n.+)+\ G4Exception-END\ .+")
+    with open(args.filename) as file:
+        matches = pattern.finditer(file.read())
+        for match in matches:
+            print(match.group())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

BEGINRELEASENOTES
- Added `print_overlaps` util to printout all overlaps from an overlap dump file

ENDRELEASENOTES

prints out all `G4Exception-START / G4Exception-END` blocks in the give file. For people like me that can't remember how to do this with one magic `grep` line...