### PR TITLE
Fix field types

### DIFF
--- a/detector/other/FieldMapBrBz.cpp
+++ b/detector/other/FieldMapBrBz.cpp
@@ -38,6 +38,7 @@ namespace {
 }
 
 FieldMapBrBz::FieldMapBrBz() {
+  field_type = CartesianField::MAGNETIC;
   type = CartesianField::MAGNETIC;
 } //ctor
 

--- a/detector/other/FieldMapXYZ.cpp
+++ b/detector/other/FieldMapXYZ.cpp
@@ -40,6 +40,7 @@ namespace {
 }
 
 FieldMapXYZ::FieldMapXYZ() {
+  field_type = CartesianField::MAGNETIC;
   type = CartesianField::MAGNETIC;
 } //ctor
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,9 +15,9 @@ ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh
   ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../ILD/compact/ILD_l5_v02/ILD_l5_v02.xml --runType=batch -G -N=1 --outputFile=testILD_l5_v02.slcio )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
-SET( test_name "test_ILD_s5_v02" )
+SET( test_name "test_ILD_s5_v08" )
 ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
-  ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../ILD/compact/ILD_s5_v02/ILD_s5_v02.xml --runType=batch -G -N=1 --outputFile=testILD_s5_v02.slcio )
+  ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../ILD/compact/ILD_s5_v08/ILD_s5_v08.xml --runType=batch -G -N=1 --outputFile=testILD_s5_v08.slcio )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
 SET( test_name "test_ILD_l5_v09" )


### PR DESCRIPTION
BEGINRELEASENOTES
- FieldMapXYZ, FieldMapBrBz: adapt to variable rename from DD4hep, fix "OverlayedField   ERROR add: Attempt to add an unknown field type.", fixes #384

ENDRELEASENOTES