### PR TITLE
ILD models: apply Tracker_limits to the volume inside of beampipe and MDI

### DIFF
--- a/ILD/compact/ILD_common_v02/Beampipe_o1_v01_01.xml
+++ b/ILD/compact/ILD_common_v02/Beampipe_o1_v01_01.xml
@@ -3,6 +3,7 @@
   <detectors>        
 
 
+<!-- detector name="Tube" type="DD4hep_Beampipe_o1_v01" limits="Tracker_limits" vis="BeamPipeVis" id="ILDDetID_NOTUSED" -->
 <detector name="Tube" type="DD4hep_Beampipe_o1_v01" vis="BeamPipeVis" id="ILDDetID_NOTUSED">
 
   <envelope vis="BlueVis">
@@ -151,6 +152,7 @@
 
 </detector>
 
+<!-- detector name="QD0_cryostat" type="TubeSupport_o1_v01" limits="Tracker_limits" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true" -->
 <detector name="QD0_cryostat" type="TubeSupport_o1_v01" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true">
 
   <envelope vis="BlueVis">
@@ -183,6 +185,7 @@
 
 </detector>
 
+<!-- detector name="QD0_support" type="BoxSupport_o1_v01" limits="Tracker_limits" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true" -->
 <detector name="QD0_support" type="BoxSupport_o1_v01" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true">
 
   <envelope vis="BlueVis">

--- a/ILD/compact/ILD_common_v02/Beampipe_o1_v01_01.xml
+++ b/ILD/compact/ILD_common_v02/Beampipe_o1_v01_01.xml
@@ -3,8 +3,7 @@
   <detectors>        
 
 
-<!-- detector name="Tube" type="DD4hep_Beampipe_o1_v01" limits="Tracker_limits" vis="BeamPipeVis" id="ILDDetID_NOTUSED" -->
-<detector name="Tube" type="DD4hep_Beampipe_o1_v01" vis="BeamPipeVis" id="ILDDetID_NOTUSED">
+<detector name="Tube" type="DD4hep_Beampipe_o1_v01" limits="Tracker_limits" vis="BeamPipeVis" id="ILDDetID_NOTUSED">
 
   <envelope vis="BlueVis">
     <shape type="Assembly"/>
@@ -152,8 +151,7 @@
 
 </detector>
 
-<!-- detector name="QD0_cryostat" type="TubeSupport_o1_v01" limits="Tracker_limits" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true" -->
-<detector name="QD0_cryostat" type="TubeSupport_o1_v01" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true">
+<detector name="QD0_cryostat" type="TubeSupport_o1_v01" limits="Tracker_limits" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true">
 
   <envelope vis="BlueVis">
     <shape type="Assembly"/>
@@ -185,8 +183,7 @@
 
 </detector>
 
-<!-- detector name="QD0_support" type="BoxSupport_o1_v01" limits="Tracker_limits" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true" -->
-<detector name="QD0_support" type="BoxSupport_o1_v01" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true">
+<detector name="QD0_support" type="BoxSupport_o1_v01" limits="Tracker_limits" vis="BeamPipeVis" id="ILDDetID_NOTUSED" reflect="true">
 
   <envelope vis="BlueVis">
     <shape type="Assembly"/>


### PR DESCRIPTION
BEGINRELEASENOTES
- For ILD models only: apply the same step limits as defined for the tracker ("Tracker_limits", currently 5mm) inside the beampipe volume and MDI region. This is important for tracking of low momentum particles  (eg beamstrahlung pairs) especially in non-uniform fields. Should have no noticeable effect in other situations.
ENDRELEASENOTES