### PR TITLE
CLD_o2_v07: Fix lumi cal back shield, change envelopes to assemblies

### DIFF
--- a/FCCee/CLD/compact/CLD_o2_v07/LumiCal_o3_v02_05.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/LumiCal_o3_v02_05.xml
@@ -21,17 +21,13 @@
         <detector name="LumiCal" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCal" readout="LumiCalCollection" insideTrackingVolume="false" >
 
             <envelope vis="LCALVis">
-                <shape type="BooleanShape" operation="union" material="Air">
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz_prime"/>
+                <shape type="Assembly" >
+                    <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz_prime" >
                         <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
                         <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
                         <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
                     </shape>
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz_prime"/>
+                    <shape type="Tube"  rmin="LumiCal_inner_radius" rmax="LumiCal_outer_radius" dz="LumiCal_dz_prime" >
                         <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
                         <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
                         <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
@@ -64,17 +60,13 @@
         <detector name="LumiCalInstrumentation" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCalInstrumentation" readout="LumiCalCollection" insideTrackingVolume="false" >
 
             <envelope vis="LCALInstrVis">
-                <shape type="BooleanShape" operation="union" material="Air">
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz_prime"/>
+                <shape type="Assembly">
+                    <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz_prime">
                         <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
                         <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
                         <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
                     </shape>
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz_prime"/>
+                    <shape type="Tube"  rmin="LumiCal_Instr_inner_radius" rmax="LumiCal_Instr_outer_radius" dz="LumiCal_dz_prime">
                         <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
                         <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
                         <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
@@ -106,17 +98,13 @@
         <detector name="LumiCalCooling" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCalCooling" readout="LumiCalCollection" insideTrackingVolume="false" >
 
             <envelope vis="LCALCoolVis">
-                <shape type="BooleanShape" operation="union" material="Air">
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz_prime"/>
+                <shape type="Assembly">
+                    <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz_prime">
                         <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
                         <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="LumiCal_min_z+LumiCal_dz"/>
                         <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
                     </shape>
-                    <shape type="BooleanShape" operation="Intersection">
-                        <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-                        <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz_prime"/>
+                    <shape type="Tube"  rmin="LumiCal_Cool_inner_radius" rmax="LumiCal_Cool_outer_radius" dz="LumiCal_dz_prime">
                         <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
                         <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_min_z+LumiCal_dz)" y="0" z="-(LumiCal_min_z+LumiCal_dz)"/>
                         <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>

--- a/FCCee/CLD/compact/CLD_o2_v07/LumiCal_o3_v02_05.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/LumiCal_o3_v02_05.xml
@@ -146,21 +146,16 @@
    <detector name="LumiCalBackShield" type="LumiCal_o1_v01" vis="SeeThrough" id="DetID_LumiCalBackShield"  readout="LumiCalCollection" insideTrackingVolume="false" >
 
      <envelope vis="LCALShieldVis">
-       <shape type="BooleanShape" operation="union" material="Air">
-
-         <shape type="BooleanShape" operation="Intersection">
-           <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-           <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz_prime"/>
-           <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
-           <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="LumiCal_max_z+LumiCal_shield_dz"/>
-           <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
+       <shape type="Assembly">
+           <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz_prime">
+               <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+               <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="LumiCal_max_z+LumiCal_shield_dz"/>
+               <rotation x="0" y="0.5*abs(CrossingAngle)" z="0"/>
          </shape>
-         <shape type="BooleanShape" operation="Intersection">
-           <shape type="Box"  dx="world_side" dy="world_side" dz="world_side"/>
-           <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz_prime"/>
-           <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
-           <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="-(LumiCal_max_z+LumiCal_shield_dz)"/>
-           <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
+         <shape type="Tube"  rmin="LumiCal_Shield_inner_radius" rmax="LumiCal_Shield_outer_radius" dz="LumiCal_shield_dz_prime">
+               <!-- Center the tube on the outgoing beampipe and rotate it so that it is aligned -->
+               <position x="tan(0.5*abs(CrossingAngle))*(LumiCal_max_z+LumiCal_shield_dz)" y="0" z="-(LumiCal_max_z+LumiCal_shield_dz)"/>
+               <rotation x="0" y="-0.5*abs(CrossingAngle)" z="0"/>
          </shape>
 
        </shape>


### PR DESCRIPTION
BEGINRELEASENOTES
- CLD_o2_v07: change LumiCal envelopes from boolean of boolean to assembly, fixes #306, speeds up overlap check (of LumiCal only) with /geometry/test/resolution 300000 down to 13s instead of 3m10s

ENDRELEASENOTES