### PR TITLE
Improvements to vertex/silicon wrapper

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o1_v03/SiliconWrapper_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/SiliconWrapper_o1_v03.xml
@@ -68,6 +68,19 @@
             <constant name="SiWr_distance_two_sides"    value="SiWr_Sensitive_Thickness+SiWr_support_CarbonFiber_thickness+SiWr_Cooling_thickness"/>    <!-- Distance between sensor modules along thickness when having alternating modules in front and in the back -->
 
         <!-- Silicon wrapper barrel parameters -->
+
+            <!-- Simplified silicon wrapper barrel  -->
+            <constant name="SiWrB_nModules1" value="1"/> <!-- Length of SiWr_half_length = 2400 mm -> Let's take 131 modules with 130 SiWr_mod_overlap gaps (131*42.2+130*-5.4 = 4826.2 mm)-->
+            <constant name="SiWrB_z" value="SiWrB_half_length"/>
+
+            <!-- Complex silicon wrapper barrel -->
+            <!-- <constant name="SiWrB_nModules1" value="floor((2*SiWrB_half_length - SiWr_mod_overlap)/(SiWr_mod_z + SiWr_mod_overlap))"/> -->
+            <!-- <constant name="SiWrB_z" value="(SiWrB_nModules1*SiWr_mod_z+(SiWrB_nModules1-1)*SiWr_mod_overlap)/2.0"/> -->
+
+            <!-- Other silicon wrapper barrel parameters -->
+            <constant name="SiWrB_nModules2" value="SiWrB_nModules1"/> <!-- Same number of modules so that gaps in r-phi in layer 1 can be filled by layer 2-->
+            <constant name="SiWrB_phiOffset2" value="2*pi/SiWrB_nModules2/2."/> <!-- Same number of modules so that gaps in r-phi in layer 1 can be filled by layer 2, offset of half a tile width -->
+
             <constant name="SiWrB_r1" value="SiWrB_inner_radius"/>
             <constant name="SiWrB_r2" value="SiWrB_r1 + 2.0*cm"/>
 
@@ -75,25 +88,29 @@
             <constant name="SiWrB_Staves1" value="floor(2.*pi*SiWrB_inner_radius/(SiWr_mod_rphi+SiWrB_Distance_between_staves))"/> <!-- Circumference of 2*pi*SiWrB_inner_radius divided by width of stave and space between. Floor to get to integer number, 151 -->
             <constant name="SiWrB_Staves2" value="SiWrB_Staves1"/> <!-- Use same number of staves for second layer -->
 
-            <constant name="SiWrB_nModules1" value="floor((2*SiWrB_half_length - SiWr_mod_overlap)/(SiWr_mod_z + SiWr_mod_overlap))"/> <!-- Length of SiWr_half_length = 2400 mm -> Let's take 131 modules with 130 SiWr_mod_overlap gaps (131*42.2+130*-5.4 = 4826.2 mm)-->
-            <constant name="SiWrB_nModules2" value="SiWrB_nModules1"/> <!-- Same number of modules so that gaps in r-phi in layer 1 can be filled by layer 2-->
-            <constant name="SiWrB_phiOffset2" value="2*pi/SiWrB_nModules2/2."/> <!-- Same number of modules so that gaps in r-phi in layer 1 can be filled by layer 2, offset of half a tile width -->
-        
-            <constant name="SiWrB_z" value="(SiWrB_nModules1*SiWr_mod_z+(SiWrB_nModules1-1)*SiWr_mod_overlap)/2.0"/>
-
             <constant name="SiWrB_offset1" value="0.0*mm"/>
             <constant name="SiWrB_offset2" value="0.0*mm"/>
 
 
         <!-- Silicon wrapper disks parameters -->
-            <constant name="SiWrD_tile_nmodules"        value="6"/>
-            <constant name="SiWrD_double_tile_nmodules" value="12"/>
-            <constant name="SiWrD_half_tile_nmodules"   value="3"/>
 
-            <constant name="SiWrD_tile_length"          value="SiWrD_tile_nmodules*SiWr_mod_z+(SiWrD_tile_nmodules-1)*SiWr_mod_overlap"/>          <!-- Six modules. Tile length = 6*42.2-5*5.2 = 227.2 mm -->
-            <constant name="SiWrD_double_tile_length"   value="SiWrD_double_tile_nmodules*SiWr_mod_z+(SiWrD_double_tile_nmodules-1)*SiWr_mod_overlap"/> <!-- Double tile with 12 modules. Tile length = 12*42.2-11*5.2 = 454.4 mm -->
-            <constant name="SiWrD_half_tile_length"     value="SiWrD_half_tile_nmodules*SiWr_mod_z+(SiWrD_half_tile_nmodules-1)*SiWr_mod_overlap"/> <!-- Half tile with 3 modules. Tile length = 3*42.2-2*5.2 = 116.2 mm -->
+            <!-- Complex silicon wrapper disk -->
+            <!-- <constant name="SiWrD_tile_nmodules"        value="6"/> -->
+            <!-- <constant name="SiWrD_double_tile_nmodules" value="12"/> -->
+            <!-- <constant name="SiWrD_half_tile_nmodules"   value="3"/> -->
+            <!-- <constant name="SiWrD_tile_length"          value="SiWrD_tile_nmodules*SiWr_mod_z+(SiWrD_tile_nmodules-1)*SiWr_mod_overlap"/>  -->
+            <!-- <constant name="SiWrD_double_tile_length"   value="SiWrD_double_tile_nmodules*SiWr_mod_z+(SiWrD_double_tile_nmodules-1)*SiWr_mod_overlap"/> -->
+            <!-- <constant name="SiWrD_half_tile_length"     value="SiWrD_half_tile_nmodules*SiWr_mod_z+(SiWrD_half_tile_nmodules-1)*SiWr_mod_overlap"/> -->
 
+            <!-- Simplified silicon wrapper disks -->
+            <constant name="SiWrD_tile_nmodules"        value="2"/>
+            <constant name="SiWrD_double_tile_nmodules" value="4"/>
+            <constant name="SiWrD_half_tile_nmodules"   value="1"/>
+            <constant name="SiWrD_tile_length"          value="3.*SiWrD_tile_nmodules*SiWr_mod_z+(3.*SiWrD_tile_nmodules-1)*SiWr_mod_overlap"/> 
+            <constant name="SiWrD_double_tile_length"   value="3.*SiWrD_double_tile_nmodules*SiWr_mod_z+(3.*SiWrD_double_tile_nmodules-1)*SiWr_mod_overlap"/>
+            <constant name="SiWrD_half_tile_length"     value="3.*SiWrD_half_tile_nmodules*SiWr_mod_z+(3.*SiWrD_half_tile_nmodules-1)*SiWr_mod_overlap"/>
+
+            <!-- Other silicon wrapper disks parameters -->
             <constant name="SiWrD_tile_spacing_row"     value="1.0*mm"/>
             <constant name="SiWrD_tile_spacing_column"  value="1.0*mm"/>
 
@@ -118,14 +135,6 @@
             <constant name="SiWrD_layer2_offset3" value="SiWrD_rmin2-15.0*mm"/> 
             <constant name="SiWrD_layer2_offset4" value="SiWrD_rmin2-3.0*mm"/> 
             <constant name="SiWrD_layer2_offset5" value="SiWrD_rmin2"/> 
-
-        <!-- Simplified silicon wrapper parameters -->
-            <constant name="SiWrB_nModules1" value="1"/> <!-- Length of SiWr_half_length = 2400 mm -> Let's take 131 modules with 130 SiWr_mod_overlap gaps (131*42.2+130*-5.4 = 4826.2 mm)-->
-            <constant name="SiWrB_nModules2" value="SiWrB_nModules1"/> <!-- Same number of modules so that gaps in r-phi in layer 1 can be filled by layer 2-->
-
-            <constant name="SiWrD_tile_nmodules"        value="2"/>
-            <constant name="SiWrD_double_tile_nmodules" value="4"/>
-            <constant name="SiWrD_half_tile_nmodules"   value="1"/>
     </define>        
 
 
@@ -164,12 +173,6 @@
                     <component thickness="SiWr_flex_Glue_thickness"      width="SiWr_flex_width" offset="+SiWr_mod_rphi/2.-SiWr_flex_width/2." r="SiWr_flex_Aluminium_thickness+SiWr_flex_Kapton_thickness"   material="GlueEcobond45" vis="SiWrCableVis"/>
                 </components> 
 
-                <!-- Simplified flexes. Assume they only consist of Aluminium (pessimistic) -->
-<!--                <components name="flexes" r="0.0*mm" length="SiWrB_z">
-                    <component thickness="SiWr_flex_Aluminium_thickness+SiWr_flex_Kapton_thickness+SiWr_flex_Glue_thickness" width="SiWr_flex_width" offset="-SiWr_mod_rphi/2.+SiWr_flex_width/2." r="0.0*mm" material="Al" vis="SiWrCableVis"/>
-                    <component thickness="SiWr_flex_Aluminium_thickness+SiWr_flex_Kapton_thickness+SiWr_flex_Glue_thickness" width="SiWr_flex_width" offset="+SiWr_mod_rphi/2.-SiWr_flex_width/2." r="0.0*mm" material="Al" vis="SiWrCableVis"/>
-                </components>                
--->
                 <!-- Two ATLASPix3-sized sensors, but with only one periphery region each. Detailed -->
 <!--                <sensor r="SiWr_flex_thickness" thickness="SiWr_Sensitive_Thickness" material="Silicon">
                     <component sensitive="True" ymin="-SiWr_mod_z/2.+SiWr_mod_z_periphery" ymax="SiWr_mod_z/2." xmin="-SiWr_mod_rphi/2." xmax="-SiWr_mod_quad_spacing/2." vis="SiWrSensitiveVis"/> <!~~ Left quad ~~>
@@ -218,13 +221,7 @@
                     <component thickness="SiWr_flex_Kapton_thickness"    width="SiWr_flex_width" offset="+SiWr_flex_width/2.+SiWr_mod_quad_spacing/2." r="SiWr_flex_Aluminium_thickness"                               material="KaptonVtx" vis="SiWrCableVis"/>
                     <component thickness="SiWr_flex_Glue_thickness"      width="SiWr_flex_width" offset="+SiWr_flex_width/2.+SiWr_mod_quad_spacing/2." r="SiWr_flex_Aluminium_thickness+SiWr_flex_Kapton_thickness"   material="GlueEcobond45" vis="SiWrCableVis"/>
                 </components> 
-
-                <!-- Simplified flexes. Just assume they consist only of Aluminium (pessimistic) -->
-<!--                <components name="flex_leftQuads" r="SiWr_flex_thickness+SiWr_Sensitive_Thickness+SiWr_support_CarbonFiber_thickness+SiWr_Cooling_thickness+SiWr_Sensitive_Thickness" length="SiWrB_z">
-                    <component thickness="SiWr_flex_Aluminium_thickness+SiWr_flex_Kapton_thickness+SiWr_flex_Glue_thickness" width="SiWr_flex_width" offset="-SiWr_flex_width/2.-SiWr_mod_quad_spacing/2." r="0.0*mm" material="Al" vis="SiWrCableVis"/>
-                    <component thickness="SiWr_flex_Aluminium_thickness+SiWr_flex_Kapton_thickness+SiWr_flex_Glue_thickness" width="SiWr_flex_width" offset="+SiWr_flex_width/2.+SiWr_mod_quad_spacing/2." r="0.0*mm" material="Al" vis="SiWrCableVis"/>
-                </components>
--->            </stave>
+            </stave>
 
             <!-- Here we construct the barrel -->
             <layer nLadders="SiWrB_Staves1" r="SiWrB_r1" offset="SiWrB_offset1" id="0" nmodules="SiWrB_nModules1" name="SiWrStave" step="SiWr_mod_overlap" motherVolLength="2.*SiWrB_z" motherVolThickness="SiWrB_r2-SiWrB_r1"              phi0="0.0*rad"/>
@@ -819,14 +816,6 @@
 
     <!-- Plugin needed for the surfaces-->
     <plugins>
-       <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
-            <argument value="SiWrB"/> 
-            <argument value="dimension=2"/>
-            <argument value="u_y=1."/>
-            <argument value="v_z=1."/>
-            <argument value="n_x=1."/>
-        </plugin>
-
         <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
             <argument value="SiWrD"/> 
             <argument value="dimension=2"/>

--- a/FCCee/IDEA/compact/IDEA_o1_v03/VertexComplete_IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/VertexComplete_IDEA_o1_v03.xml
@@ -1735,7 +1735,7 @@
         <!-- Vertex inner barrel support structure and cooling cones imported via DDCAD. Disabled because of overlaps within and with Vertex detector -->
        <!-- <detector id="DetID_NOTUSED" name="VTXIB_Support_PEEK" type="DD4hep_TestShape_Creator">
             <check>
-                <shape type="CAD_MultiVolume" ref="VertexSupport_PEEK_o1_v03.stl" material="PEEK" unit="mm">
+                <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/IDEA/IDEA_o1_v03/stl_files/VertexSupport_PEEK_o1_v03.stl" material="PEEK" unit="mm">
                     <volume id="0"  name="Body1" material="PEEK" vis="VTXPEEKVis"/>
                 </shape>
                 <rotation x="180.0*deg" y="0" z="0"/>
@@ -1744,7 +1744,7 @@
 
         <detector id="DetID_NOTUSED" name="VTXIB_Support_CarbonFiber" type="DD4hep_TestShape_Creator">
             <check>
-                <shape type="CAD_MultiVolume" ref="VertexSupport_CarbonFiber_o1_v03.stl" material="CarbonFiberVtx" unit="mm">
+                <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/IDEA/IDEA_o1_v03/stl_files/VertexSupport_CarbonFiber_o1_v03.stl" material="CarbonFiberVtx" unit="mm">
                     <volume id="1"  name="Body1" material="CarbonFiberVtx" vis="VTXSupportVis"/>
                 </shape>
                 <rotation x="180.0*deg" y="0" z="0"/>
@@ -1753,7 +1753,7 @@
 
          <detector id="DetID_NOTUSED" name="VTXIB_CoolingCones" type="DD4hep_TestShape_Creator">
             <check>
-                <shape type="CAD_MultiVolume" ref="VertexCoolingCones_o1_v03.stl" material="CarbonFiberVtx" unit="mm">
+                <shape type="CAD_MultiVolume" ref="${K4GEO}/FCCee/IDEA/IDEA_o1_v03/stl_files/VertexCoolingCones_o1_v03.stl" material="CarbonFiberVtx" unit="mm">
                     <volume id="2"  name="Body1" material="CarbonFiberVtx" vis="VTXSupportVis"/>
                 </shape>
                 <rotation x="0" y="0" z="0"/>

--- a/detector/tracker/VertexBarrel_detailed_o1_v02_geo.cpp
+++ b/detector/tracker/VertexBarrel_detailed_o1_v02_geo.cpp
@@ -14,6 +14,7 @@
 //
 //====================================================================
 #include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/Printout.h"
 #include "XML/Utilities.h"
 #include "XMLHandlerDB.h"
 #include <exception>
@@ -38,6 +39,8 @@ using dd4hep::Translation3D;
 using dd4hep::Volume;
 using dd4hep::getAttrOrDefault;
 using dd4hep::_toString;
+using dd4hep::DEBUG;
+using dd4hep::INFO;
 
 using dd4hep::rec::volSurfaceList;
 using dd4hep::rec::Vector3D;
@@ -287,19 +290,19 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
             }
             sensor.width  = *max_element(sensor.xmax.begin(), sensor.xmax.end()) - *min_element(sensor.xmin.begin(), sensor.xmin.end());
             sensor.length = *max_element(sensor.ymax.begin(), sensor.ymax.end()) - *min_element(sensor.ymin.begin(), sensor.ymin.end());
-            cout << det_name << ": Module: " << sensor.name << ", sensor width: " << to_string(sensor.width)  << ", sensor length: " << to_string(sensor.length) << endl;
+            printout(DEBUG, det_name, "Module: " + sensor.name + ", sensor width: " + to_string(sensor.width) + ", sensor length: " + to_string(sensor.length) ) ;
             m.sensorsVec.push_back(sensor);
         }
 
         stave_information_list.push_back(m);
-        cout << "Read stave information of stave " << m.name << endl;
+        printout(DEBUG, det_name, "Read stave information of stave " + m.name) ;
     }
 
     int iModule_tot = 0;
 
     //=========  loop over layer elements in xml  ======================================
 
-    cout << "Building " << det_name << " barrel detector " << det_name << "..." << endl;
+    printout(INFO, det_name, "Building of detector ...");
     for(xml_coll_t c(e, _U(layer) ); c; ++c)  {
 
         xml_comp_t x_layer( c );
@@ -537,6 +540,8 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
     pv.addPhysVolID( "system", x_det.id() ).addPhysVolID("side",0 )  ;
 
     sdet.setAttributes(theDetector,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
+
+    printout(INFO, det_name, "Building of detector successfully completed");
 
     return sdet;
 }

--- a/detector/tracker/VertexEndcap_detailed_o1_v02_geo.cpp
+++ b/detector/tracker/VertexEndcap_detailed_o1_v02_geo.cpp
@@ -41,6 +41,8 @@ using dd4hep::_toString;
 using dd4hep::getAttrOrDefault;
 using dd4hep::Box;
 using dd4hep::Tube;
+using dd4hep::DEBUG;
+using dd4hep::INFO;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens)  {
     xml_det_t   x_det     = e;
@@ -192,13 +194,14 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
         }
         m.sensor_width  = *max_element(m.sensor_xmax.begin(), m.sensor_xmax.end()) - *min_element(m.sensor_xmin.begin(), m.sensor_xmin.end());
         m.sensor_length = *max_element(m.sensor_ymax.begin(), m.sensor_ymax.end()) - *min_element(m.sensor_ymin.begin(), m.sensor_ymin.end());
-        cout << det_name << "Module: " << m.name << ", sensor width: " << to_string(m.sensor_width)  << ", sensor length: " << to_string(m.sensor_length) << endl;
+        printout(DEBUG, det_name, "Module: " + m.name + ", sensor width: " + to_string(m.sensor_width) + ", sensor length: " + to_string(m.sensor_length) );
         module_information_list.push_back(m);
     }
    
     vector<int> sides = {1};
     if(reflect){sides.push_back(-1);}
- 
+
+    printout(INFO, det_name, "Building of detector ...");
     for(auto & side : sides){
         string side_name = det_name + _toString(side,"_side%d");
 
@@ -416,10 +419,11 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
         side_assembly->GetShape()->ComputeBBox();       
     }
     
-    cout << "Built disks detector:" << det_name << endl;
     sdet.setAttributes(theDetector,envelope,x_det.regionStr(),x_det.limitsStr(),x_det.visStr());
     pv.addPhysVolID("system", x_det.id());
 
+    printout(INFO, det_name, "Building of detector successfully completed.");
+ 
     return sdet;
 }
 

--- a/utils/material_plots.py
+++ b/utils/material_plots.py
@@ -34,11 +34,8 @@ def main():
             material = material.replace("66D","")
             material = material.replace("Vtx","")
 
-            if material == "Air": continue
-            if material == "Tungsten": continue
-            if material == "Copper": continue
-            if material == "beam": continue
-            if material in ["LiquidNDecane", "AlBeMet162", "Gold"]:
+            # Ignore materials used in beam pipe as vertex material budget does not work without beam pipe. You can add more materials to ignore here
+            if material in ["Air","Tungsten","Copper","beam","LiquidNDecane", "AlBeMet162", "Gold"]:
                 continue
             if material not in histDict.keys():
                 histDict[material] = {

--- a/utils/material_plots.py
+++ b/utils/material_plots.py
@@ -14,7 +14,9 @@ def main():
     parser.add_argument('--angleMax', dest='angleMax', default=6, type=float, help="maximum eta/theta/cosTheta")
     parser.add_argument('--angleDef', dest='angleDef', default="eta", type=str, help="angle definition to use: eta, theta, cosTheta or thetaRad, default: eta")
     parser.add_argument('--angleBinning', "-b", dest='angleBinning', default=0.05, type=float, help="eta/theta/cosTheta/thetaRad bin width")
-    parser.add_argument('--x0max', "-x", dest='x0max', default=0.0, type=float, help="Max of x0")                                                                                                                                                
+    parser.add_argument('--x0max', "-x", dest='x0max', default=0.0, type=float, help="Max of x0")
+    parser.add_argument('--removeMatsSubstrings', dest='removeMatsSubstrings', nargs='+', default=[], help="Substrings to be removed from materials strings (e.g. '66D' for reduced density materials)")
+    parser.add_argument('--ignoreMats', "-i", dest='ignoreMats', nargs='+', default=[], help="List of materials that should be ignored")
     args = parser.parse_args()
 
     f = ROOT.TFile.Open(args.fname, "read")
@@ -30,13 +32,14 @@ def main():
         for i in range(nMat):
             material = entry.material.at(i)
 
-            # If you need to replace some string in the material, add that here
-            material = material.replace("66D","")
-            material = material.replace("Vtx","")
+            # Removing substrings from materials
+            for substring in args.removeMatsSubstrings:
+                material = material.replace(substring,"")
 
-            # Ignore materials used in beam pipe as vertex material budget does not work without beam pipe. You can add more materials to ignore here
-            if material in ["Air","Tungsten","Copper","beam","LiquidNDecane", "AlBeMet162", "Gold"]:
+            # Ignore certain materials if specified
+            if material in args.ignoreMats:
                 continue
+
             if material not in histDict.keys():
                 histDict[material] = {
                     "x0": ROOT.TH1F("", "", (int)((args.angleMax-args.angleMin) / args.angleBinning), args.angleMin, args.angleMax),

--- a/utils/material_plots_2D.py
+++ b/utils/material_plots_2D.py
@@ -17,6 +17,7 @@ def main():
     parser.add_argument('--angleBinning', "-b", dest='angleBinning', default=0.05, type=float, help="eta/theta/cosTheta bin width")
     parser.add_argument('--nPhiBins', dest='nPhiBins', default=100, type=int, help="number of bins in phi")
     parser.add_argument('--x0max', "-x", dest='x0max', default=0.0, type=float, help="Max of x0")                                                                                                                                                
+    parser.add_argument('--ignoreMats', "-i", dest='ignoreMats', nargs='+', default=[], help="List of materials that should be ignored")
     args = parser.parse_args()
 
     ROOT.gStyle.SetNumberContours(100)
@@ -36,9 +37,10 @@ def main():
 
         entry_x0, entry_lambda, entry_depth = 0.0, 0.0, 0.0
         for i in range(nMat):
-            # Ignore materials used in beam pipe as vertex material budget does not work without beam pipe. You can add more materials to ignore here
-            if entry.material.at(i) in ["Air","Tungsten","Copper","beam","LiquidNDecane", "AlBeMet162", "Gold"]:
+            # Ignore certain materials if specified
+            if entry.material.at(i) in args.ignoreMats:
                 continue
+
             entry_x0        += entry.nX0.at(i)*100.0
             entry_lambda    += entry.nLambda.at(i)
             entry_depth     += entry.matDepth.at(i)

--- a/utils/material_plots_2D.py
+++ b/utils/material_plots_2D.py
@@ -36,8 +36,9 @@ def main():
 
         entry_x0, entry_lambda, entry_depth = 0.0, 0.0, 0.0
         for i in range(nMat):
-            if entry.material.at(i) == "Air": continue
-
+            # Ignore materials used in beam pipe as vertex material budget does not work without beam pipe. You can add more materials to ignore here
+            if entry.material.at(i) in ["Air","Tungsten","Copper","beam","LiquidNDecane", "AlBeMet162", "Gold"]:
+                continue
             entry_x0        += entry.nX0.at(i)*100.0
             entry_lambda    += entry.nLambda.at(i)
             entry_depth     += entry.matDepth.at(i)


### PR DESCRIPTION
BEGINRELEASENOTES
- No more warnings in silicon wrapper
- Improvements in vertex builder printouts
- Adding all materials of beam pipe also to material_plots_2D.py, as without having the beam pipe enabled, the vertex material budget estimation will fail.
- Changed paths to .stl files in vertex to use https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/IDEA/IDEA_o1_v03/STL_FILES/ (still commented out due to overlaps)
ENDRELEASENOTES

@BrieucF: As you requested I fixed the warnings in the silicon wrapper.

P.s:
I don't know how to squash all the commits, sorry that this is such a mess