### PR TITLE
[IDEA Pre-shower] Adopting IDEA muon system builder for pre-shower

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml
@@ -60,6 +60,9 @@
   <!-- Import Endcap plate absorber -->
   <include ref="EndPlateAbsorber_o1_v01.xml"/>
 
+  <!-- Import Endcap pre-shower -->
+  <include ref="Preshower_o1_v01.xml"/>
+
   <!-- Import fiber-based dual-readout calorimeter -->
   <!-- (uncomment the following line to effectively include it) -->
   <!--  <include ref="FiberDualReadoutCalo_o1_v01.xml"/> -->

--- a/FCCee/IDEA/compact/IDEA_o1_v03/Preshower_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/Preshower_o1_v01.xml
@@ -3,7 +3,7 @@
 
   <info name="pre-shower"
 	title=" detailed version of IDEA pre-shower system for FCC-ee"
-	author="Mahmoud Ali, mahmoud.ali@cern.ch"
+	author="Nitika Nitika & Mahmoud Ali, mahmoud.ali@cern.ch"
 	url="no"
 	status="development"
 	version="2.0">

--- a/FCCee/IDEA/compact/IDEA_o1_v03/Preshower_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/Preshower_o1_v01.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+
+  <info name="pre-shower"
+	title=" detailed version of IDEA pre-shower system for FCC-ee"
+	author="Mahmoud Ali, mahmoud.ali@cern.ch"
+	url="no"
+	status="development"
+	version="2.0">
+    <comment> It depends on the factory: muonSystemMuRWELL_o1_v01 </comment>
+  </info>
+
+  <define>
+     <!---                            Muon System Parameters                       -->
+     <!-- %%%%%%                      microRWELL chamber different layers thicknesses                %%%%%% -->
+       <constant name = "G10_FR4Thick"                          value = "1.6*mm"/>
+       <constant name = "CuThick"                               value = "0.035*mm"/>
+       <constant name = "GasLayerThick"                         value = "6*mm"/>
+       <constant name = "Cu2Thick"                              value = "0.005*mm"/>
+       <constant name = "KaptonThick"                           value = "0.05*mm"/>
+       <constant name = "CarnonFiberThick"                      value = "0.0001*mm"/>
+       <constant name = "CarbonFiber2Thick"                     value = "0.1*mm"/>
+       <constant name = "SiThick"                               value = "1.6*mm"/>
+       <constant name = "mRWELLTotalThickness"                  value = "G10_FR4Thick+CuThick+GasLayerThick+Cu2Thick+KaptonThick+CarnonFiberThick+CuThick+CarbonFiber2Thick+CuThick+SiThick"/> <!-- This sequense is the current order of mRWELL (total 10 slices) -->
+
+       <constant name = "mRWELLYLength"                         value = "250*mm"/>
+       <constant name = "mRWELLZLength"                         value = "250*mm"/>
+
+       <constant name = "overlapingY"                           value = "5*mm"/> <!-- the common distance between mRWELL chambers in Y direction -->
+       <constant name = "overlapingZ"                           value = "5*mm"/> <!-- the common distance between mRWELL chambers in Z direction -->
+       <constant name = "clearance"                             value = "1*mm"/> <!-- it's a small distance to be used to avoid overlapping between the different volumes ~ 1 mm -->
+     <!-- %%%%%%                      Iron yoke thickness                %%%%%% -->
+      <constant name = "YokeThickness"                          value = "300*mm"/>  
+  </define>   
+
+  <readouts>
+    <readout name="PreshowerSystemCollection">
+     <segmentation type="CartesianGridYZ" grid_size_y="1.2*mm" grid_size_z="1.2*mm"/>   <!-- Depending on strip pitch 1.4 mm  -->
+     <id>system:5,type:2,layer:4,chamber:15,slice:1,y:-10,z:-10</id> <!-- The bit field is divided into 2^5 systems(IDEA sub-detectors), 2^4 layers(Muon System layers"barrel and endcap layers"), 2^11 chambers(the number of muRWELL chambers in every layer), 2^1 slice(number of sensitive layers inside every chambers), and 2^10 y&z strips in every sensitive layer-->
+  </readout>
+  </readouts>   
+
+  <detectors>
+    <!-- mRWELL envelope -->
+    <detector name="Preshower" type="muonSystemMuRWELL_o1_v01" id="33" readout="PreshowerSystemCollection">
+      <dimensions x="mRWELLTotalThickness/2.0" y="mRWELLYLength" z="mRWELLZLength" x_offset="0*mm" y_offset="0*mm" z_offset="0*mm" material="Air"/>
+      <sensitive type="tracker"/>
+
+      <!-- Specify the detector parameters and the overlap /// if you want exclude any component, e.g: endcap, just put endcapDetectorParameters=0   // radius is put in the middle, so its not the inner neither the outer -->
+      <generalParameters numSides="32" overlapY="overlapingY" overlapZ="overlapingZ" clearance="clearance"/>
+      <Barrel numDetectorLayers ="1"  rmin="2440*mm" length="5100*mm" numYokes="0" yoke_Thickness="0*mm" yoke_Material="G4_Fe"/> 
+      <Endcap numDetectorLayers="1"  rmin="390*mm" rmax="2430*mm" z_offset="2550*mm" numYokes="0" yoke_Thickness="0*mm" yoke_Material="G4_Fe" />
+
+      <!-- mRWELL chamber -->
+      <!-- note: all thicknesses are half-lengths -->
+      <slice x="G10_FR4Thick/2.0" material="G10_FR4" vis="G10_FR4_vis" />
+      <slice x="CuThick/2.0" material="G4_Cu" vis="Cu_vis" />
+      <slice x="GasLayerThick/2.0" material="ARCO2CF4" sensitive="true" vis="Sensitive_vis" />
+      <slice x="Cu2Thick/2.0" material="G4_Cu" vis="Cu_vis" />
+      <slice x="KaptonThick/2.0" material="Kapton" vis="Kapton_vis" />
+      <slice x="CarnonFiberThick/2.0" material="CarbonFiber" vis="CarbonFiber_vis" />
+      <slice x="CuThick/2.0" material="G4_Cu" vis="Cu_vis" />
+      <slice x="CarbonFiber2Thick/2.0" material="CarbonFiber" vis="CarbonFiber_vis" />
+      <slice x="CuThick/2.0" material="G4_Cu" vis="Cu_vis" />
+      <slice x="SiThick/2.0" material="G4_Si" vis="Si_vis" />
+    </detector>
+  </detectors>
+
+</lccdd>

--- a/detector/muonSystem/muonSystemMuRWELL_o1_v01.cpp
+++ b/detector/muonSystem/muonSystemMuRWELL_o1_v01.cpp
@@ -135,7 +135,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
 
   dd4hep::PolyhedraRegular  BarrelEnvWithoutLastLayer(numSides, radius, barrelRMax, barrelLength);
   dd4hep::PolyhedraRegular  BarrelLastLayerEnv(numSides, (barrelRMax - 2 * detectorVolumeThickness), barrelRMax, barreltotalLength);
-  std::string barrelName = dd4hep::xml::_toString(0, "MS-Barrel%d");
+  std::string barrelName = name + "-Barrel" + std::to_string(0);
 
   dd4hep::Position barrelUnionPos(0.0 , 0.0, 0.0);  
   dd4hep::Rotation3D barrelUnionRot(dd4hep::RotationY(0.0 * dd4hep::degree));
@@ -147,7 +147,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
   dd4hep::Position barrelTrans(0., 0., 0.);
   dd4hep::PlacedVolume barrelPhys = detectorVolume.placeVolume(BarrelVolume, dd4hep::Transform3D(dd4hep::RotationZ(0.), barrelTrans));
   barrelPhys.addPhysVolID("type", 0); 
-  dd4hep::DetElement BarrelDE(detElement, "MSBarrelDE" , 0);
+  dd4hep::DetElement BarrelDE(detElement, name +"-BarrelDE" , 0);
   BarrelDE.setPlacement(barrelPhys);
   BarrelVolume.setVisAttributes(lcdd.visAttributes("no_vis"));
 
@@ -166,7 +166,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
   }
 
   dd4hep::PolyhedraRegular  BarrelDetectorLayer(numSides, barrelLayerRMin, barrelLayerRMax, barrelLayerLength);
-  std::string barrelDetectorName = dd4hep::xml::_toString(numBarrelLayer +1, "MS-BarrelDetectorLayer%d");
+  std::string barrelDetectorName = name + "-BarrelDetectorLayer" + std::to_string(numBarrelLayer + 1);
   dd4hep::Volume BarrelDetectorLayerVolume(barrelDetectorName, BarrelDetectorLayer, mat);
 
   // sideLength and sideLength2 are the lengths of the parallel sides of the trapezoid.
@@ -524,7 +524,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
   dd4hep::Position detectorLayerTrans(0., 0., 0.);
   dd4hep::PlacedVolume detectorLayerPhys = BarrelVolume.placeVolume(BarrelDetectorLayerVolume, dd4hep::Transform3D(dd4hep::RotationZ(0.), detectorLayerTrans));
   detectorLayerPhys.addPhysVolID("layer", numBarrelLayer+1); 
-  dd4hep::DetElement BarrelDetectorLayerDE(BarrelDE, "MSBarrel_DetectorLayerDE_" + std::to_string(numBarrelLayer+1), numBarrelLayer+1);
+  dd4hep::DetElement BarrelDetectorLayerDE(BarrelDE, name + "-Barrel_DetectorLayerDE_" + std::to_string(numBarrelLayer+1), numBarrelLayer+1);
   BarrelDetectorLayerDE.setPlacement(detectorLayerPhys);
   BarrelDetectorLayerVolume.setVisAttributes(lcdd.visAttributes("no_vis")); 
 
@@ -539,7 +539,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
     double barrelRadiatorLayerRMid = (barrelRadiatorLayerRMin + barrelRadiatorLayerRMax)/2.0;
 
     dd4hep::PolyhedraRegular  BarrelRadiatorLayer(numSides, barrelRadiatorLayerRMin, barrelRadiatorLayerRMax, barrelLength);
-    std::string barrelRadiatorEnvName = dd4hep::xml::_toString(numBarrelRadiatorLayer +1, "MS-BarrelRadiatorLayer%d");
+    std::string barrelRadiatorEnvName = name + "-BarrelRadiatorLayer" + std::to_string(numBarrelRadiatorLayer + 1);
     dd4hep::Volume BarrelRadiatorLayerVolume(barrelRadiatorEnvName , BarrelRadiatorLayer, mat);
 
     double barrelRadiatorSideLength = 2 * (barrelRadiatorLayerRMid - barrelRadiatorThickness/2.0)* std::tan(shapeAngle_radians);
@@ -548,7 +548,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
     for (int side = 0; side < numSides; ++side) {
       int sideID = (numBarrelRadiatorLayer + 1) * 100 + (side +1);  // to differentiated with the same side in different layers.
       dd4hep::Trapezoid barrelRadiatorEnvelope(barrelLength/2.0, barrelLength/2.0, barrelRadiatorSideLength/2.0, barrelRadiatorSideLength2/2.0, barrelRadiatorThickness/2.0);
-      std::string barrelRadiatorEnvelopeName = dd4hep::xml::_toString(sideID, "MSBarrelRadiatorSide%d");
+      std::string barrelRadiatorEnvelopeName = name + "-BarrelRadiatorSide" + std::to_string(sideID);
       dd4hep::Volume barrelRadiatorEnvVol(barrelRadiatorEnvelopeName, barrelRadiatorEnvelope, mat);
 
       double angle_degrees = shapeAngle * side; // Calculate the angle for each side
@@ -589,7 +589,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
 
     dd4hep::Position radiatorLayerTrans(0., 0., 0.);
     dd4hep::PlacedVolume radiatorLayerPhys = BarrelVolume.placeVolume(BarrelRadiatorLayerVolume, dd4hep::Transform3D(dd4hep::RotationZ(0.), radiatorLayerTrans));
-    dd4hep::DetElement BarrelRadiatorLayerDE(BarrelDE, "MSBarrel_RadiatorLayerDE_" + std::to_string(numBarrelRadiatorLayer+1), numBarrelRadiatorLayer+1);
+    dd4hep::DetElement BarrelRadiatorLayerDE(BarrelDE, name + "-Barrel_RadiatorLayerDE_" + std::to_string(numBarrelRadiatorLayer+1), numBarrelRadiatorLayer+1);
     BarrelRadiatorLayerDE.setPlacement(radiatorLayerPhys);
     BarrelRadiatorLayerVolume.setVisAttributes(lcdd.visAttributes("no_vis")); 
 
@@ -609,12 +609,12 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
     if (endcapType == 0) {
         continue; // Skip the iteration when endcapType is 0
     }
-    EndcapName = dd4hep::xml::_toString(endcapType, "MS-Endcap%d");
+    EndcapName = name + "-Endcap" + std::to_string(endcapType);
     endcapVolume = dd4hep::Volume(EndcapName, EndcapEnv, mat);
     endcapTrans = dd4hep::Position(0., 0., endcapType * endcapOffset);
     endcapPhys = detectorVolume.placeVolume(endcapVolume, dd4hep::Transform3D(dd4hep::RotationZ(0.), endcapTrans));
     endcapPhys.addPhysVolID("type", endcapType);
-    EndcapDE = dd4hep::DetElement(detElement, "MSEndcapDE_" + std::to_string(endcapType) , endcapType);
+    EndcapDE = dd4hep::DetElement(detElement, name + "EndcapDE_" + std::to_string(endcapType) , endcapType);
     EndcapDE.setPlacement(endcapPhys);
     endcapVolume.setVisAttributes(lcdd.visAttributes("no_vis"));
 
@@ -629,7 +629,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
     dd4hep::PolyhedraRegular  endcapDetectorEnvelope(numSides, endcapDetectorLayerInnerRadius, endcapDetectorLayerOuterRadius, 2 * detectorVolumeThickness);
 
     endcapLayerZOffset = - EndcaptotalLength/2.0 + detectorVolumeThickness + numEndcapLayer * (2 * detectorVolumeThickness) + numEndcapLayer * endcapRadiatorThickness;  // Automation of inner Z-Offset of different layers, taking into account that every detector layer is followed by a yoke(radiator) layer
-    endcapDetectorEnvelopeName = dd4hep::xml::_toString(numEndcapLayer+1, "MS-EndcapDetectorLayer%d");
+    endcapDetectorEnvelopeName = name + "-EndcapDetectorLayer" + std::to_string(numEndcapLayer + 1);
     endcapDetectorEnvZPos = endcapLayerZOffset; 
 
 
@@ -886,7 +886,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
     double endcapRadiatorLayerZOffset = - EndcaptotalLength/2.0 + (endcapRadiatorThickness/2.0) + (numEndcapRadiatorLayer +1) * (2 * detectorVolumeThickness) + numEndcapRadiatorLayer * endcapRadiatorThickness;  // Automation of inner Z-Offset of different layers, taking into account that every detector layer is followed by a yoke(radiator) layer
 
     dd4hep::PolyhedraRegular  endcapRadiatorEnvelope(numSides, endcapRadiatorLayerInnerRadius, endcapRadiatorLayerOuterRadius, endcapRadiatorThickness);
-    std::string endcapRadiatorEnvelopeName = dd4hep::xml::_toString(numEndcapRadiatorLayer+1, "MS-EndcapRadiatorLayer%d");
+    std::string endcapRadiatorEnvelopeName = name + "-EndcapRadiatorLayer" + std::to_string(numEndcapRadiatorLayer + 1);
     dd4hep::Volume endcapRadiatorEnvVol(endcapRadiatorEnvelopeName, endcapRadiatorEnvelope, mat);
 
     double endcapRadiatorEnvXPos = 0.0 ; 


### PR DESCRIPTION

BEGINRELEASENOTES
- Generalizing the muon system builder to adopt pre-shower description, the changes include:
     - Making the variable names more general, not specific only for muon system.
     - Changing the detector side's volume thicknesses in case there is only one chambers row in the side (like the pre-shower case), and it's in general it is the case for any -almost- circular shape for the detector. 
     - Disallowing the overlap rotation in case of single chamber side.
- Overall, the changes make the builder more general to adopt different cases with different structures (polyhedron & cylinder of chambers).

ENDRELEASENOTES