### PR TITLE
Improve check for a header file from DD4hep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,14 @@ if(NOT K4GEO_USE_LCIO)
   message(STATUS "Use of LCIO is DISABLED, some detectors that depend on LCIO will not be built: ${lcio_sources}")
 endif()
 
+if(${DD4hep_VERSION} VERSION_LESS 1.29)
+  set(FILES_DEPENDINGON_DCH_INFO_H "DriftChamber_o1_v02.cpp" )
+  list(FILTER sources EXCLUDE REGEX "${FILES_DEPENDINGON_DCH_INFO_H}")
+  message(WARNING [[Subdetector ${FILES_DEPENDINGON_DCH_INFO_H} will not be built
+                    because the current version of DD4hep does not ship with
+                    the header file DDRec/DCH_info.h]])
+endif()
+
 find_package(EDM4HEP)
 file(GLOB G4sources
   ./plugins/TPCSDAction.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if(NOT K4GEO_USE_LCIO)
   message(STATUS "Use of LCIO is DISABLED, some detectors that depend on LCIO will not be built: ${lcio_sources}")
 endif()
 
-if(${DD4hep_VERSION} VERSION_LESS 1.29)
+if(${DD4hep_VERSION} VERSION_LESS 1.29 OR NOT TARGET DD4hep::DDRec)
   set(FILES_DEPENDINGON_DCH_INFO_H "DriftChamber_o1_v02.cpp" )
   list(FILTER sources EXCLUDE REGEX "${FILES_DEPENDINGON_DCH_INFO_H}")
   message(WARNING [[Subdetector ${FILES_DEPENDINGON_DCH_INFO_H} will not be built

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,7 @@ endif()
 if(${DD4hep_VERSION} VERSION_LESS 1.29)
   set(FILES_DEPENDINGON_DCH_INFO_H "DriftChamber_o1_v02.cpp" )
   list(FILTER sources EXCLUDE REGEX "${FILES_DEPENDINGON_DCH_INFO_H}")
-  message(WARNING [[Subdetector ${FILES_DEPENDINGON_DCH_INFO_H} will not be built
-                    because the current version of DD4hep does not ship with
-                    the header file DDRec/DCH_info.h]])
+  message(WARNING "Subdetector ${FILES_DEPENDINGON_DCH_INFO_H} will not be built because the current version of DD4hep does not ship with the header file DDRec/DCH_info.h")
 endif()
 
 find_package(EDM4HEP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if(NOT K4GEO_USE_LCIO)
   message(STATUS "Use of LCIO is DISABLED, some detectors that depend on LCIO will not be built: ${lcio_sources}")
 endif()
 
-if(${DD4hep_VERSION} VERSION_LESS 1.29 OR NOT TARGET DD4hep::DDRec)
+if(${DD4hep_VERSION} VERSION_LESS 1.29)
   set(FILES_DEPENDINGON_DCH_INFO_H "DriftChamber_o1_v02.cpp" )
   list(FILTER sources EXCLUDE REGEX "${FILES_DEPENDINGON_DCH_INFO_H}")
   message(WARNING [[Subdetector ${FILES_DEPENDINGON_DCH_INFO_H} will not be built

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,17 +97,6 @@ if(NOT K4GEO_USE_LCIO)
   message(STATUS "Use of LCIO is DISABLED, some detectors that depend on LCIO will not be built: ${lcio_sources}")
 endif()
 
-include(CheckIncludeFileCXX)
-set(CMAKE_REQUIRED_LIBRARIES DD4hep::DDRec)
-CHECK_INCLUDE_FILE_CXX(DDRec/DCH_info.h DCH_INFO_H_EXIST)
-set(CMAKE_REQUIRED_LIBRARIES)
-set(FILES_DEPENDINGON_DCH_INFO_H "DriftChamber_o1_v02.cpp" )
-
-if(NOT DCH_INFO_H_EXIST)
-    list(FILTER sources EXCLUDE REGEX "${FILES_DEPENDINGON_DCH_INFO_H}")
-    message(WARNING "Subdetector ${FILES_DEPENDINGON_DCH_INFO_H} will not be built because header file DDRec/DCH_info.h was not found")
-endif()
-
 find_package(EDM4HEP)
 file(GLOB G4sources
   ./plugins/TPCSDAction.cpp


### PR DESCRIPTION
BEGINRELEASENOTES
- Improve the check for DCH_info.h from DD4hep. It was added in version 1.29 so if the version is below that don't use it.

ENDRELEASENOTES

Also CMake hangs for a while on that check, maybe it's checking a lot of paths. Since DDRec is in the defaults and always built in the stack, I think it's fine not to check for this or if needed to check for DDRec. Eventually the list of files that depend on this header file will be wrong.