### PR TITLE
[IDEA] Fix overlaps with DR-Calo and between SiliconWrapper and endplate absorbers

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o1_v03/DectDimensions_IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/DectDimensions_IDEA_o1_v03.xml
@@ -234,12 +234,12 @@
     <!-- Muon System Parameters-->
     <constant name = "numberOfSides"                              value = "8"/>        <!-- The number of sides of the muon system e.g (Octagon, Hexagon, ...)--> 
                                                 <!-- Barrel -->
-    <constant name = "BarrelFirstLayerRadius"                     value = "4500*mm"/>  <!-- 1st Barrel microRWELL detector inner radius-> its the start point of thicknesses of the microRWELL material. In our case the shape is Polygon, so the radius is in the middle of the polygon side. -->
-    <constant name = "BarrelLength"                               value = "9000*mm"/> <!--Barrel detector length, in the description of the detctor we always use the half-length -->      
+    <constant name = "BarrelFirstLayerRadius"                     value = "4530*mm"/>  <!-- 1st Barrel microRWELL detector inner radius-> its the start point of thicknesses of the microRWELL material. In our case the shape is Polygon, so the radius is in the middle of the polygon side. -->
+    <constant name = "BarrelLength"                               value = "9060*mm"/> <!--Barrel detector length, in the description of the detctor we always use the half-length -->      
                                                 <!-- Endcap -->
-    <constant name = "EndcapFirstLayerZOffset"                     value = "4500*mm"/>  <!-- 1st Endcap microRWELL detector inner ZOffset-> its the start point of thicknesses of the microRWELL volume -->
+    <constant name = "EndcapFirstLayerZOffset"                     value = "4530*mm"/>  <!-- 1st Endcap microRWELL detector inner ZOffset-> its the start point of thicknesses of the microRWELL volume -->
     <constant name = "EndcapLayersInnerRadius"                    value = "700*mm"/> <!--Endcap detector inner radius, its the start point of thicknesses of the detector material ** it applies for both detector layers and yoke-->
-    <constant name = "EndcapLayersOuterRadius"                    value = "5320*mm"/> <!--Endcap detector outer radius, its the end point of thicknesses of the detector material ** it applies for both detector layers and yoke-->
+    <constant name = "EndcapLayersOuterRadius"                    value = "5350*mm"/> <!--Endcap detector outer radius, its the end point of thicknesses of the detector material ** it applies for both detector layers and yoke-->
     <!-- End of Muon system Parameters-->
   </define>
   

--- a/FCCee/IDEA/compact/IDEA_o1_v03/DectDimensions_IDEA_o1_v03.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/DectDimensions_IDEA_o1_v03.xml
@@ -116,7 +116,7 @@
     
     <constant name="Solenoid_inner_radius" value="2100*mm"/>
     <constant name="Solenoid_outer_radius" value="2400*mm"/>
-    <constant name="Solenoid_half_length" value="2500*mm"/>
+    <constant name="Solenoid_half_length" value="2380*mm"/>
     <constant name="Solenoid_Coil_half_length" value="Solenoid_half_length-200*mm"/>
     <constant name="Solenoid_Coil_radius" value="Solenoid_inner_radius+200*mm"/>
 
@@ -132,8 +132,8 @@
 
     <!-- These are lead plates that we put in the endcap to have the same material budget (from solenoid) as in the barrel-->
     <constant name="EndPlateAbsorber_inner_radius" value="380*mm"/>
-    <constant name="EndPlateAbsorber_outer_radius" value="2090*mm"/>
-    <constant name="EndPlateAbsorber_z_min" value="2490*mm"/>
+    <constant name="EndPlateAbsorber_outer_radius" value="2030*mm"/>
+    <constant name="EndPlateAbsorber_z_min" value="2350*mm"/>
     <constant name="EndPlateAbsorber_z_half_length" value="4.209/2.0*mm"/>
     
     <constant name="YokeBarrel_inner_radius" value="4479*mm"/>
@@ -209,12 +209,12 @@
     <!-- Pre-shower Parameters-->
     <constant name = "psNumSides"                              value = "32"/>        <!-- The number of sides of the pre-shower --> 
                                                 <!-- Barrel -->
-    <constant name = "psBarrelFirstLayerRadius"                     value = "2440*mm"/>  <!-- 1st Barrel microRWELL detector inner radius-> its the start point of thicknesses of the microRWELL material. In our case the shape is Polygon, so the radius is in the middle of the polygon side. -->
-    <constant name = "psBarrelLength"                               value = "5100*mm"/> <!--Barrel detector length, in the description of the detctor we always use the half-length -->      
+    <constant name = "psBarrelFirstLayerRadius"                     value = "2420*mm"/>  <!-- 1st Barrel microRWELL detector inner radius-> its the start point of thicknesses of the microRWELL material. In our case the shape is Polygon, so the radius is in the middle of the polygon side. -->
+    <constant name = "psBarrelLength"                               value = "4900*mm"/> <!--Barrel detector length, in the description of the detctor we always use the half-length -->      
                                                 <!-- Endcap -->
-    <constant name = "psEndcapFirstLayerZOffset"                     value = "2550*mm"/>  <!-- 1st Endcap microRWELL detector inner ZOffset-> its the start point of thicknesses of the microRWELL volume -->
+    <constant name = "psEndcapFirstLayerZOffset"                     value = "2400*mm"/>  <!-- 1st Endcap microRWELL detector inner ZOffset-> its the start point of thicknesses of the microRWELL volume -->
     <constant name = "psEndcapLayersInnerRadius"                    value = "390*mm"/> <!--Endcap detector inner radius, its the start point of thicknesses of the detector material ** it applies for both detector layers and yoke-->
-    <constant name = "psEndcapLayersOuterRadius"                    value = "2430*mm"/> <!--Endcap detector outer radius, its the end point of thicknesses of the detector material ** it applies for both detector layers and yoke-->
+    <constant name = "psEndcapLayersOuterRadius"                    value = "2420*mm"/> <!--Endcap detector outer radius, its the end point of thicknesses of the detector material ** it applies for both detector layers and yoke-->
     <!-- End of Pre-shower Parameters-->
 
     <!-- Fiber dual-readout calorimeter tower dim-->

--- a/detector/muonSystem/muonSystemMuRWELL_o1_v01.cpp
+++ b/detector/muonSystem/muonSystemMuRWELL_o1_v01.cpp
@@ -309,24 +309,27 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
             for (int chamberIndex = 0; chamberIndex < (numChambersInRectangle + 1); chamberIndex++) {
 
             std::stringstream barrelNameStream;
-            barrelNameStream << "MuRWELL_Barrel_" << barrelIdCounter++;            
-            std::string BarrelChamberName = barrelNameStream.str();
+            barrelNameStream << "-MuRWELL_Barrel_" << barrelIdCounter++;            
+            std::string BarrelChamberName = name + barrelNameStream.str();
 
             dd4hep::Box envelope(dimensions.x(), dimensions.y(), remainderZ *  dimensions.z());
             dd4hep::Volume envVolume(BarrelChamberName, envelope, lcdd.material(dimensions.materialStr())); 
             
             double rectangleRemainderY;
+            double rectangleRemainderREnvYPos;
             if (numChambersInRectangle == 0){
               rectangleRemainderY = std::abs(std::fmod((2 * rectangleEnvY - clearance), (2 * dimensions.y() - clearance))) / (2 * dimensions.y());
+              rectangleRemainderREnvYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + rectangleRemainderY * dimensions.y() + clearance/20;
             }else {
               rectangleRemainderY = std::fmod(2 * (rectangleEnvY - clearance), (2 * dimensions.y() - overlapY)) / (2 * dimensions.y());
+              rectangleRemainderREnvYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + rectangleRemainderY * dimensions.y() + 1.5 * clearance;
             }
 
             dd4hep::Box rectangleRemainderYEnvelope(dimensions.x(), rectangleRemainderY * dimensions.y(), remainderZ *  dimensions.z());
             dd4hep::Volume rectangleRemainderYEnvVolume(BarrelChamberName + "rectangleRemainderY", rectangleRemainderYEnvelope, lcdd.material(dimensions.materialStr()));          
 
             double envYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + dimensions.y() + clearance/20.0 ; // found that the positioning of the chambers inside the rectangle had an overlap with the mother volume ~ 45 um.
-            double rectangleRemainderREnvYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + rectangleRemainderY * dimensions.y() + clearance/20.0;
+            //double rectangleRemainderREnvYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + rectangleRemainderY * dimensions.y() + 1.5 * clearance;
           
             double zRotation;
             double rectangleRemainderZRotation;
@@ -335,7 +338,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
               rectangleRemainderZRotation = 0.0;
             } else {
               zRotation = std::atan(dimensions.x() / (dimensions.y() - (2 * overlapY)));
-              rectangleRemainderZRotation = std::atan(dimensions.x() / (rectangleRemainderY * dimensions.y() - (2 * overlapY))); // Y and Z are reversed in local remainder
+              rectangleRemainderZRotation = std::atan(dimensions.x() / (rectangleRemainderY * dimensions.y() - overlapY * 1.5)); // Y and Z are reversed in local remainder
             }
              
             dd4hep::RotationZ chamberRotation(zRotation); 
@@ -450,24 +453,27 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
           for (int chamberIndex = 0; chamberIndex < (numChambersInRectangle + 1); chamberIndex++) {
 
             std::stringstream barrelNameStream;
-            barrelNameStream << "MuRWELL_Barrel_" << barrelIdCounter++;            
-            std::string BarrelChamberName = barrelNameStream.str();
+            barrelNameStream << "-MuRWELL_Barrel_" << barrelIdCounter++;            
+            std::string BarrelChamberName = name + barrelNameStream.str();
 
             dd4hep::Box envelope(dimensions.x(), dimensions.y(), dimensions.z());
             dd4hep::Volume envVolume(BarrelChamberName, envelope, lcdd.material(dimensions.materialStr())); 
 
             double rectangleRemainderY;
+            double rectangleRemainderREnvYPos;
             if (numChambersInRectangle == 0){
               rectangleRemainderY = std::abs(std::fmod((2 * rectangleEnvY - clearance), (2 * dimensions.y() - clearance))) / (2 * dimensions.y());
+              rectangleRemainderREnvYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + rectangleRemainderY * dimensions.y() + clearance/20;
             }else {
               rectangleRemainderY = std::fmod(2 * (rectangleEnvY - clearance), (2 * dimensions.y() - overlapY)) / (2 * dimensions.y());
+              rectangleRemainderREnvYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + rectangleRemainderY * dimensions.y() + 1.5 * clearance;
             }
 
             dd4hep::Box rectangleRemainderYEnvelope(dimensions.x(), rectangleRemainderY * dimensions.y(), dimensions.z());
             dd4hep::Volume rectangleRemainderYEnvVolume(BarrelChamberName + "rectangleRemainderY", rectangleRemainderYEnvelope, lcdd.material(dimensions.materialStr()));          
 
             double envYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + dimensions.y() + clearance/20.0 ; // found that the positioning of the chambers inside the rectangle had an overlap with the mother volume ~ 45 um.
-            double rectangleRemainderREnvYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + rectangleRemainderY * dimensions.y() + clearance/20.0;
+            //double rectangleRemainderREnvYPos = (chamberIndex * 2 * dimensions.y()) - (overlapY * chamberIndex) + dimensions.y_offset() - rectangleEnvY + rectangleRemainderY * dimensions.y() + 1.5 * clearance;
           
             double zRotation;
             double rectangleRemainderZRotation;
@@ -476,7 +482,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
               rectangleRemainderZRotation = 0.0;
             } else {
               zRotation = std::atan(dimensions.x() / (dimensions.y() - (2 * overlapY)));
-              rectangleRemainderZRotation = std::atan(dimensions.x() / (rectangleRemainderY * dimensions.y() - (2 * overlapY))); // Y and Z are reversed in local remainder
+              rectangleRemainderZRotation = std::atan(dimensions.x() / (rectangleRemainderY * dimensions.y() - overlapY * 1.5)); // Y and Z are reversed in local remainder
             }
 
             dd4hep::RotationZ chamberRotation(zRotation);
@@ -826,8 +832,8 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd,
           for (int chamberIndex = 0; chamberIndex < (numChambersInRectangle + 1); chamberIndex++) {
             
           std::stringstream endcapNameStream;
-          endcapNameStream << "MuRWELL_Endcap_" << endcapIdCounter++;
-          std::string EndcapChamberName = endcapNameStream.str();
+          endcapNameStream << "-MuRWELL_Endcap_" << endcapIdCounter++;
+          std::string EndcapChamberName = name + endcapNameStream.str();
 
           dd4hep::Box envelope;
           if (rectangle == numRectangles) {


### PR DESCRIPTION
BEGINRELEASENOTES
- IDEA_o1_v03: Moving IDEA muon system starting point in both barrel (rmin) and endcap (z-offset) 30 mm, backwards to avoid overlapping with Dual readout calorimeter.
  - The change including also updating chamber names to distinguish between muon chambers and pre shower chamber, since they are using the same uURWELL chamber.
  - Change dimensions of solenoid/endplate and move the pre-shower to avoid overlaps with dual readout calorimeter

ENDRELEASENOTES
I made sure that the overlap check for the muon system is clean.