### PR TITLE
Fix the CI badge and add a zenodo badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # lcgeo (Lepton Collider Geometry)
-[![Build](https://github.com/iLCSoft/lcgeo/actions/workflows/linux.yml/badge.svg)](https://github.com/iLCSoft/lcgeo/actions/workflows/linux.yml)
+[![DOI](https://zenodo.org/badge/60772160.svg)](https://doi.org/10.5281/zenodo.596333)
+[![Key4hep build](https://github.com/key4hep/k4geo/actions/workflows/key4hep-build.yaml/badge.svg)](https://github.com/key4hep/k4geo/actions/workflows/key4hep-build.yaml)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/12359/badge.svg)](https://scan.coverity.com/projects/ilcsoft-lcgeo)
 
 Implementation of Lepton Collider detector models in DD4hep.


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the CI badge and add a zenodo badge to the README

ENDRELEASENOTES

The zenodo badge points to the Concept DOI (although the svg for the badge shows the Version DOI for v00-21)