### PR TITLE
Segmented Crystal ECAL (SCEPCal) addition

### DIFF
--- a/detector/calorimeter/SCEPCalConstructor.cpp
+++ b/detector/calorimeter/SCEPCalConstructor.cpp
@@ -1,0 +1,577 @@
+//===============================
+// Author: Wonyong Chung
+//         Princeton University
+//===============================
+
+#include "detectorSegmentations/SCEPCalSegmentationHandle.h"
+#include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/DetectorTools.h"
+#include "DD4hep/Printout.h"
+#include "DD4hep/Detector.h"
+#include "DDRec/DetectorData.h"
+#include "TGeoTrd2.h"
+#include <bitset>
+
+using dd4hep::Transform3D;
+using dd4hep::RotationZYX;
+using dd4hep::RotationY;
+using ROOT::Math::RotationZ;
+using dd4hep::Rotation3D;
+using dd4hep::Position;
+
+static dd4hep::Ref_t
+create_detector_SCEPCal(dd4hep::Detector &theDetector,xml_h xmlElement,dd4hep::SensitiveDetector sens) {
+  xml_det_t  detectorXML                 =xmlElement;
+  xml_comp_t dimXML                      =detectorXML.child(_Unicode(dim));
+  xml_comp_t timingXML                   =detectorXML.child(_Unicode(timing));
+  xml_comp_t barrelXML                   =detectorXML.child(_Unicode(barrel));
+  xml_comp_t endcapXML                   =detectorXML.child(_Unicode(endcap));
+  xml_comp_t projFXML                    =detectorXML.child(_Unicode(projF));
+  xml_comp_t projRXML                    =detectorXML.child(_Unicode(projR));
+  xml_comp_t crystalFXML                 =detectorXML.child(_Unicode(crystalF));
+  xml_comp_t crystalRXML                 =detectorXML.child(_Unicode(crystalR));
+  xml_comp_t timingTrXML                 =detectorXML.child(_Unicode(timingLayerTr));
+  xml_comp_t timingLgXML                 =detectorXML.child(_Unicode(timingLayerLg));
+  xml_comp_t sipmLgXML                   =detectorXML.child(_Unicode(sipmLg));
+  xml_comp_t sipmTrXML                   =detectorXML.child(_Unicode(sipmTr));
+  xml_comp_t instXML                     =detectorXML.child(_Unicode(inst));
+  xml_comp_t timingAssemblyGlobalVisXML  =detectorXML.child(_Unicode(timingAssemblyGlobalVis));
+  xml_comp_t barrelAssemblyGlobalVisXML  =detectorXML.child(_Unicode(barrelAssemblyGlobalVis));
+  xml_comp_t endcapAssemblyGlobalVisXML  =detectorXML.child(_Unicode(endcapAssemblyGlobalVis));
+  xml_comp_t scepcalAssemblyXML          =detectorXML.child(_Unicode(scepcalAssembly));
+  dd4hep::Material crystalFMat           =theDetector.material(crystalFXML.materialStr());
+  dd4hep::Material crystalRMat           =theDetector.material(crystalRXML.materialStr());
+  dd4hep::Material timingTrMat           =theDetector.material(timingTrXML.materialStr());
+  dd4hep::Material timingLgMat           =theDetector.material(timingLgXML.materialStr());
+  dd4hep::Material sipmLgMat             =theDetector.material(sipmLgXML.materialStr());
+  dd4hep::Material sipmTrMat             =theDetector.material(sipmTrXML.materialStr());
+  dd4hep::Material instMat               =theDetector.material(instXML.materialStr());
+  const double  EBz                      =dimXML.attr<double>(_Unicode(barrelHalfZ));
+  const double  Rin                      =dimXML.attr<double>(_Unicode(barrelInnerR));
+  const double  nomfw                    =dimXML.attr<double>(_Unicode(crystalFaceWidthNominal));
+  const double  Fdz                      =dimXML.attr<double>(_Unicode(crystalFlength));
+  const double  Rdz                      =dimXML.attr<double>(_Unicode(crystalRlength));
+  const double  nomth                    =dimXML.attr<double>(_Unicode(crystalTimingThicknessNominal));
+  const double  sipmth                   =dimXML.attr<double>(_Unicode(sipmThickness));
+  const int     PHI_SEGMENTS             =dimXML.attr<int>(_Unicode(phiSegments));
+  const int     N_PROJECTIVE_FILL        =dimXML.attr<int>(_Unicode(projectiveFill));
+  const bool    CONSTRUCT_TIMING         =timingXML.attr<bool>(_Unicode(construct));
+  const int     TIMING_PHI_START         =timingXML.attr<int>(_Unicode(phistart));
+  const int     TIMING_PHI_END           =timingXML.attr<int>(_Unicode(phiend));
+  const bool    CONSTRUCT_BARREL         =barrelXML.attr<bool>(_Unicode(construct));
+  const int     BARREL_PHI_START         =barrelXML.attr<int>(_Unicode(phistart));
+  const int     BARREL_PHI_END           =barrelXML.attr<int>(_Unicode(phiend));
+  const bool    CONSTRUCT_ENDCAP         =endcapXML.attr<bool>(_Unicode(construct));
+  const int     ENDCAP_PHI_START         =endcapXML.attr<int>(_Unicode(phistart));
+  const int     ENDCAP_PHI_END           =endcapXML.attr<int>(_Unicode(phiend));
+  const int     ENDCAP_THETA_START       =endcapXML.attr<int>(_Unicode(thetastart));
+  const double  D_PHI_GLOBAL             =2*M_PI/PHI_SEGMENTS;
+  const double  PROJECTIVE_GAP           =(N_PROJECTIVE_FILL*nomfw)/2;
+  double        THETA_SIZE_BARREL        =atan(EBz/Rin);
+  double        THETA_SIZE_ENDCAP        =atan(Rin/EBz);
+  int           N_THETA_BARREL           =2*floor(EBz/nomfw);
+  int           N_THETA_ENDCAP           =floor(Rin/nomfw);
+  double        D_THETA_BARREL           =(M_PI-2*THETA_SIZE_ENDCAP)/(N_THETA_BARREL);
+  double        D_THETA_ENDCAP           =THETA_SIZE_ENDCAP/N_THETA_ENDCAP;
+  int           N_PHI_BARREL_CRYSTAL     =floor(2*M_PI*Rin/(PHI_SEGMENTS*nomfw));
+  double        D_PHI_BARREL_CRYSTAL     =D_PHI_GLOBAL/N_PHI_BARREL_CRYSTAL;
+  double        thC_end                  =THETA_SIZE_ENDCAP+D_THETA_BARREL/2;
+  double        r0slice_end              =Rin/sin(thC_end);
+  double        z0slice_end              =r0slice_end*cos(thC_end)+PROJECTIVE_GAP;
+  double        y0slice_end              =r0slice_end*tan(D_THETA_BARREL/2.);
+  double        slice_front_jut          =y0slice_end*sin(M_PI/2-thC_end);
+  double        slice_side_jut           =y0slice_end*cos(M_PI/2-thC_end);
+  double        z1slice                  =Rin-slice_front_jut;
+  double        z2slice                  =Rin+Fdz+Rdz+slice_front_jut;
+  double        zheight_slice            =(z2slice-z1slice)/2;
+  double        y1slice                  =z1slice*tan(M_PI/2-THETA_SIZE_ENDCAP)+PROJECTIVE_GAP;
+  double        y2slice                  =z2slice*tan(M_PI/2-THETA_SIZE_ENDCAP)+PROJECTIVE_GAP;
+  double        rT                       =z1slice-2*nomth;
+  double        wT                       =rT *tan(D_PHI_GLOBAL/2);
+  int           nTiles                   =ceil(y1slice/wT);
+  double        lT                       =2*y1slice/nTiles;
+  int           nCy                      =floor(lT/nomth);
+  double        actY                     =lT/nCy;
+  double        actX                     =2*wT/nCy;
+  double        r2slice_end              =r0slice_end+Fdz+Rdz;
+  double        z2slice_end              =r2slice_end*cos(thC_end)+PROJECTIVE_GAP;
+  double        Rin2slice_end            =r2slice_end*sin(thC_end);
+  double        y2slice_end              =r2slice_end*tan(D_THETA_BARREL/2.);
+  double        slice_front_jut2         =y2slice_end*sin(M_PI/2-thC_end);
+  double        slice_side_jut2          =y2slice_end*cos(M_PI/2-thC_end);
+  double        barrelSlice_z1           =z0slice_end+slice_side_jut;
+  double        barrelSlice_z2           =y2slice;
+  double        barrelSlice_rmin2        =Rin2slice_end-slice_front_jut2;
+  double        thCEnd                   =THETA_SIZE_ENDCAP-D_THETA_ENDCAP/2;
+  double        thCBeg                   =D_THETA_ENDCAP/2+ENDCAP_THETA_START*D_THETA_ENDCAP;
+  double        r0eEnd                   =EBz/cos(thCEnd);
+  double        r2eEnd                   =r0eEnd+Fdz+Rdz;
+  double        y2eEnd                   =r2eEnd*tan(D_THETA_ENDCAP/2.);
+  double        r0eBeg                   =EBz/cos(thCBeg);
+  double        r2eBeg                   =r0eBeg+Fdz+Rdz;
+  double        y2eBeg                   =r2eBeg*tan(D_THETA_ENDCAP/2.);
+  double        aEnd                     =r0eEnd/cos(D_THETA_ENDCAP/2);
+  double        bEnd                     =sqrt(r2eEnd*r2eEnd+y2eEnd*y2eEnd);
+  double        z1End                    =aEnd*cos(thCEnd+D_THETA_ENDCAP/2);
+  double        z2End                    =bEnd*cos(thCEnd-D_THETA_ENDCAP/2);
+  double        aBeg                     =r0eBeg/cos(D_THETA_ENDCAP/2);
+  double        bBeg                     =sqrt(r2eBeg*r2eBeg+y2eBeg*y2eBeg);
+  double        z1Beg                    =aBeg*cos(thCBeg+D_THETA_ENDCAP/2);
+  double        z2Beg                    =bBeg*cos(thCBeg-D_THETA_ENDCAP/2);
+  double        z1rmaxE                  =z1End*tan(thCEnd+D_THETA_ENDCAP/2);
+  double        z2rmaxE                  =z2Beg*tan(thCEnd+D_THETA_ENDCAP/2);
+  double        z1rminB                  =z1End*tan(thCBeg-D_THETA_ENDCAP/2);
+  double        z2rminB                  =z2Beg*tan(thCBeg-D_THETA_ENDCAP/2);
+
+  std::cout                                                         << std::endl;
+  std::cout << "=GEOMETRY INPUTS="                                  << std::endl;
+  std::cout << "BARREL_HALF_Z:        " << EBz                      << std::endl;
+  std::cout << "BARREL_INNER_R:       " << Rin                      << std::endl;
+  std::cout << "PHI_SEGMENTS:         " << PHI_SEGMENTS             << std::endl;
+  std::cout << "N_PROJECTIVE_FILL:    " << N_PROJECTIVE_FILL        << std::endl;
+  std::cout << "F_CRYSTAL_LENGTH:     " << Fdz                      << std::endl;
+  std::cout << "R_CRYSTAL_LENGTH:     " << Rdz                      << std::endl;
+  std::cout << "XTAL_FACE_NOM:        " << nomfw                    << std::endl;
+  std::cout << "TIMING_THICK_NOM:     " << nomth                    << std::endl;
+  std::cout << "SIPM_THICKNESS:       " << sipmth                   << std::endl;
+  std::cout                                                         << std::endl;
+  std::cout << "=CONTROL="                                          << std::endl;
+  std::cout << "CONSTRUCT_TIMING:     " << CONSTRUCT_TIMING         << std::endl;
+  std::cout << "CONSTRUCT_BARREL:     " << CONSTRUCT_BARREL         << std::endl;
+  std::cout << "CONSTRUCT_ENDCAP:     " << CONSTRUCT_ENDCAP         << std::endl;
+  std::cout << "BARREL_PHI_START:     " << BARREL_PHI_START         << std::endl;
+  std::cout << "BARREL_PHI_END  :     " << BARREL_PHI_END           << std::endl;
+  std::cout << "ENDCAP_PHI_START:     " << ENDCAP_PHI_START         << std::endl;
+  std::cout << "ENDCAP_PHI_END  :     " << ENDCAP_PHI_END           << std::endl;
+  std::cout << "ENDCAP_THETA_START:   " << ENDCAP_THETA_START       << std::endl;
+  std::cout                                                         << std::endl;
+  std::cout << "=CALCULATED PARAMETERS="                            << std::endl;
+  std::cout << "D_PHI_GLOBAL:         " << D_PHI_GLOBAL             << std::endl;
+  std::cout << "PROJECTIVE_GAP:       " << PROJECTIVE_GAP           << std::endl;
+  std::cout                                                         << std::endl;
+  std::cout << "=PROJECTIVE LAYER="                                 << std::endl;
+  std::cout << "THETA_SIZE_BARREL:    " << THETA_SIZE_BARREL        << std::endl;
+  std::cout << "N_THETA_BARREL:       " << N_THETA_BARREL           << std::endl;
+  std::cout << "D_THETA_BARREL:       " << D_THETA_BARREL           << std::endl;
+  std::cout << "THETA_SIZE_ENDCAP:    " << THETA_SIZE_ENDCAP        << std::endl;
+  std::cout << "N_THETA_ENDCAP:       " << N_THETA_ENDCAP           << std::endl;
+  std::cout << "D_THETA_ENDCAP:       " << D_THETA_ENDCAP           << std::endl;
+  std::cout << "N_PHI_BARREL_CRYSTAL: " << N_PHI_BARREL_CRYSTAL     << std::endl;
+  std::cout << "D_PHI_BARREL_CRYSTAL: " << D_PHI_BARREL_CRYSTAL     << std::endl;
+  std::cout                                                         << std::endl;
+  std::cout << "=TIMING LAYER="                                     << std::endl;
+  std::cout << "N_TILES:              " << nTiles                   << std::endl;
+  std::cout << "N_XTALS_TILE:         " << nCy                      << std::endl;
+  std::cout << "LENGTH_TILE:          " << lT                       << std::endl;
+  std::cout << "WIDTH_TILE:           " << 2*wT                     << std::endl;
+  std::cout << "ACTUAL_X:             " << actX                     << std::endl;
+  std::cout << "ACTUAL_Y:             " << actY                     << std::endl;
+  std::cout                                                         << std::endl;
+
+  dd4hep::DetElement ScepcalDetElement(detectorXML.nameStr(),detectorXML.id());
+  dd4hep::Volume experimentalHall=theDetector.pickMotherVolume(ScepcalDetElement);
+  dd4hep::xml::Dimension sdType=detectorXML.child(_Unicode(sensitive));
+  sens.setType(sdType.typeStr());
+  dd4hep::Readout readout=sens.readout();
+  dd4hep::Segmentation geomseg=readout.segmentation();
+  dd4hep::Segmentation* _geoSeg=&geomseg;
+  auto segmentation=dynamic_cast<dd4hep::DDSegmentation::SCEPCalSegmentation *>(_geoSeg->segmentation());
+  segmentation->setGeomParams(Fdz,Rdz,nomfw,nomth,EBz,Rin,sipmth,PHI_SEGMENTS,N_PROJECTIVE_FILL);
+
+  std::vector<double> zTimingPolyhedra   ={-barrelSlice_z1,barrelSlice_z1};
+  std::vector<double> rminTimingPolyhedra={rT,rT,};
+  std::vector<double> rmaxTimingPolyhedra={z1slice,z1slice};
+  std::vector<double> zBarrelPolyhedra   ={-barrelSlice_z2,-barrelSlice_z1,barrelSlice_z1,barrelSlice_z2};
+  std::vector<double> rminBarrelPolyhedra={z2slice,z1slice,z1slice,z2slice};
+  std::vector<double> rmaxBarrelPolyhedra={z2slice,z2slice,z2slice,z2slice};
+  std::vector<double> zEndcapPolyhedra   ={z1End+PROJECTIVE_GAP,z2Beg+PROJECTIVE_GAP};
+  std::vector<double> rminEndcapPolyhedra={z1rminB,z2rminB};
+  std::vector<double> rmaxEndcapPolyhedra={z1rmaxE,z2rmaxE};
+  std::vector<double> zEndcap1Polyhedra   ={-(z2Beg+PROJECTIVE_GAP),-(z1End+PROJECTIVE_GAP)};
+  std::vector<double> rminEndcap1Polyhedra={z2rminB,z1rminB};
+  std::vector<double> rmaxEndcap1Polyhedra={z2rmaxE,z1rmaxE};
+
+  dd4hep::Polyhedra timingAssemblyShape(PHI_SEGMENTS,D_PHI_GLOBAL/2,2*M_PI,zTimingPolyhedra,rminTimingPolyhedra,rmaxTimingPolyhedra);
+  dd4hep::Volume    timingAssemblyVol("timingAssemblyVol",timingAssemblyShape,theDetector.material("Vacuum"));
+  timingAssemblyVol.setVisAttributes(theDetector,timingAssemblyGlobalVisXML.visStr());
+  dd4hep::Polyhedra barrelAssemblyShape(PHI_SEGMENTS,D_PHI_GLOBAL/2,2*M_PI,zBarrelPolyhedra,rminBarrelPolyhedra,rmaxBarrelPolyhedra);
+  dd4hep::Volume    barrelAssemblyVol("barrelAssemblyVol",barrelAssemblyShape,theDetector.material("Vacuum"));
+  barrelAssemblyVol.setVisAttributes(theDetector,barrelAssemblyGlobalVisXML.visStr());
+  dd4hep::Polyhedra endcapAssemblyShape(PHI_SEGMENTS,D_PHI_GLOBAL/2,2*M_PI,zEndcapPolyhedra,rminEndcapPolyhedra,rmaxEndcapPolyhedra);
+  dd4hep::Volume    endcapAssemblyVol("endcapAssemblyVol",endcapAssemblyShape,theDetector.material("Vacuum"));
+  endcapAssemblyVol.setVisAttributes(theDetector,endcapAssemblyGlobalVisXML.visStr());
+  dd4hep::Polyhedra endcap1AssemblyShape(PHI_SEGMENTS,D_PHI_GLOBAL/2,2*M_PI,zEndcap1Polyhedra,rminEndcap1Polyhedra,rmaxEndcap1Polyhedra);
+  dd4hep::Volume    endcap1AssemblyVol("endcap1AssemblyVol",endcap1AssemblyShape,theDetector.material("Vacuum"));
+  endcap1AssemblyVol.setVisAttributes(theDetector,endcapAssemblyGlobalVisXML.visStr());
+  auto timingAssemblyVolId  =segmentation->setVolumeID(3,0,0,0);
+  int  timingAssemblyVolId32=segmentation->getFirst32bits(timingAssemblyVolId);
+  auto barrelAssemblyVolId  =segmentation->setVolumeID(1,0,0,0);
+  int  barrelAssemblyVolId32=segmentation->getFirst32bits(barrelAssemblyVolId);
+  auto endcapAssemblyVolId  =segmentation->setVolumeID(2,0,0,0);
+  int  endcapAssemblyVolId32=segmentation->getFirst32bits(endcapAssemblyVolId);
+  auto endcap1AssemblyVolId  =segmentation->setVolumeID(2,1,0,0);
+  int  endcap1AssemblyVolId32=segmentation->getFirst32bits(endcap1AssemblyVolId);
+  dd4hep::PlacedVolume timingPlacedVol =experimentalHall.placeVolume(timingAssemblyVol,timingAssemblyVolId32);
+  dd4hep::PlacedVolume barrelPlacedVol =experimentalHall.placeVolume(barrelAssemblyVol,barrelAssemblyVolId32);
+  dd4hep::PlacedVolume endcapPlacedVol =experimentalHall.placeVolume(endcapAssemblyVol,endcapAssemblyVolId32);
+  dd4hep::PlacedVolume endcap1PlacedVol=experimentalHall.placeVolume(endcap1AssemblyVol,endcap1AssemblyVolId32);
+
+  ScepcalDetElement.setPlacement(barrelPlacedVol);
+
+  int numCrystalsBarrel = 0;
+  int numCrystalsEndcap = 0;
+  int numCrystalsTiming = 0;
+
+  for (int iPhi=CONSTRUCT_BARREL? BARREL_PHI_START:BARREL_PHI_END;iPhi<BARREL_PHI_END;iPhi++) {
+    double phiEnvBarrel=iPhi*D_PHI_GLOBAL;
+    
+    dd4hep::Box timingPhiAssemblyShape(nomth,wT,y1slice);
+    dd4hep::Volume timingPhiAssemblyVolume("timingPhiAssembly",timingPhiAssemblyShape,theDetector.material("Vacuum"));
+    timingPhiAssemblyVolume.setVisAttributes(theDetector,scepcalAssemblyXML.visStr());
+    RotationZ rotZPhi(phiEnvBarrel);
+    double rTimingAssembly=rT+nomth;
+    Position dispTimingAssembly(rTimingAssembly*cos(phiEnvBarrel),rTimingAssembly*sin(phiEnvBarrel),0);
+    dd4hep::PlacedVolume timingPhiAssemblyPlacedVol=timingAssemblyVol.placeVolume(timingPhiAssemblyVolume,Transform3D(rotZPhi,dispTimingAssembly));
+
+    dd4hep::Box timingCrystalLg(nomth/2,actX/2,lT/2-sipmth);
+    dd4hep::Box timingCrystalTr(nomth/2,wT-sipmth,actY/2);
+    dd4hep::Volume timingCrystalLgVol("TimingCrystalLg",timingCrystalLg,timingLgMat);
+    dd4hep::Volume timingCrystalTrVol("TimingCrystalTr",timingCrystalTr,timingTrMat);
+    timingCrystalLgVol.setVisAttributes(theDetector,timingLgXML.visStr());
+    timingCrystalTrVol.setVisAttributes(theDetector,timingTrXML.visStr());
+    timingCrystalLgVol.setSensitiveDetector(sens);
+    timingCrystalTrVol.setSensitiveDetector(sens);
+    dd4hep::Box sipmBoxLg(nomth/2,actX/2,sipmth/2);
+    dd4hep::Box sipmBoxTr(nomth/2,sipmth/2,actY/2);
+    dd4hep::Volume sipmBoxLgVol("sipmBoxLg",sipmBoxLg,sipmLgMat);
+    dd4hep::Volume sipmBoxTrVol("sipmBoxTr",sipmBoxTr,sipmTrMat);
+    sipmBoxLgVol.setVisAttributes(theDetector,sipmLgXML.visStr());
+    sipmBoxTrVol.setVisAttributes(theDetector,sipmTrXML.visStr());
+    sipmBoxLgVol.setSensitiveDetector(sens);
+    sipmBoxTrVol.setSensitiveDetector(sens);
+
+    for (int nTile=CONSTRUCT_TIMING? 0:nTiles;nTile<nTiles;nTile++) {
+      dd4hep::Box tileAssemblyShape(nomth,wT,lT/2);
+      dd4hep::Volume tileAssemblyVolume("tileAssembly",tileAssemblyShape,theDetector.material("Vacuum"));
+      tileAssemblyVolume.setVisAttributes(theDetector,scepcalAssemblyXML.visStr());
+      Position dispTileAssembly(0,0,-y1slice+nTile*lT+lT/2);
+      dd4hep::PlacedVolume tileAssemblyPlacedVol=timingPhiAssemblyVolume.placeVolume(tileAssemblyVolume,dispTileAssembly);
+
+      for (int nC=0;nC<nCy;nC++) {
+        int phiEnvBarrelSign=iPhi%2==0? 1:-1;
+        int sign            =nTile%2==0? 1:-1;
+        Position dispLg(sign*phiEnvBarrelSign*(nomth/2),-wT+actX/2+ nC*actX,0);
+        Position dispTr(sign*phiEnvBarrelSign*(-nomth/2),0,-lT/2+actY/2+nC*actY);
+        Position dispSipmLg(0,0,lT/2-sipmth/2);
+        Position dispSipmTr(0,wT-sipmth/2,0);
+
+        auto timingLgId64=segmentation->setVolumeID(3,nTile*nCy+nC ,iPhi,3);
+        auto timingTrId64=segmentation->setVolumeID(3,nTile*nCy+nC ,iPhi,6);
+        int  timingLgId32=segmentation->getFirst32bits(timingLgId64);
+        int  timingTrId32=segmentation->getFirst32bits(timingTrId64);
+        dd4hep::PlacedVolume timingLgp=tileAssemblyVolume.placeVolume(timingCrystalLgVol,timingLgId32,dispLg);
+        dd4hep::PlacedVolume timingTrp=tileAssemblyVolume.placeVolume(timingCrystalTrVol,timingTrId32,dispTr);
+        timingLgp.addPhysVolID("system",3);
+        timingLgp.addPhysVolID("eta",nTile*nCy+nC);
+        timingLgp.addPhysVolID("phi",iPhi);
+        timingLgp.addPhysVolID("depth",3);
+        timingTrp.addPhysVolID("system",3);
+        timingTrp.addPhysVolID("eta",nTile*nCy+nC);
+        timingTrp.addPhysVolID("phi",iPhi);
+        timingTrp.addPhysVolID("depth",6);
+        auto sipmLgId64_1=segmentation->setVolumeID(3,nTile*nCy+nC ,iPhi,4);
+        auto sipmLgId64_2=segmentation->setVolumeID(3,nTile*nCy+nC ,iPhi,5);
+        auto sipmTrId64_1=segmentation->setVolumeID(3,nTile*nCy+nC ,iPhi,7);
+        auto sipmTrId64_2=segmentation->setVolumeID(3,nTile*nCy+nC ,iPhi,8);
+        int  sipmLgId32_1=segmentation->getFirst32bits(sipmLgId64_1);
+        int  sipmLgId32_2=segmentation->getFirst32bits(sipmLgId64_2);
+        int  sipmTrId32_1=segmentation->getFirst32bits(sipmTrId64_1);
+        int  sipmTrId32_2=segmentation->getFirst32bits(sipmTrId64_2);
+        dd4hep::PlacedVolume sipmLgp1=tileAssemblyVolume.placeVolume(sipmBoxLgVol,sipmLgId32_1,dispLg+dispSipmLg);
+        dd4hep::PlacedVolume sipmLgp2=tileAssemblyVolume.placeVolume(sipmBoxLgVol,sipmLgId32_2,dispLg-dispSipmLg);
+        dd4hep::PlacedVolume sipmTrp1=tileAssemblyVolume.placeVolume(sipmBoxTrVol,sipmTrId32_1,dispTr+dispSipmTr);
+        dd4hep::PlacedVolume sipmTrp2=tileAssemblyVolume.placeVolume(sipmBoxTrVol,sipmTrId32_2,dispTr-dispSipmTr);
+        sipmLgp1.addPhysVolID("system",3);
+        sipmLgp1.addPhysVolID("eta",nTile*nCy+nC);
+        sipmLgp1.addPhysVolID("phi",iPhi);
+        sipmLgp1.addPhysVolID("depth",4);
+        sipmLgp2.addPhysVolID("system",3);
+        sipmLgp2.addPhysVolID("eta",nTile*nCy+nC);
+        sipmLgp2.addPhysVolID("phi",iPhi);
+        sipmLgp2.addPhysVolID("depth",5);
+        sipmTrp1.addPhysVolID("system",3);
+        sipmTrp1.addPhysVolID("eta",nTile*nCy+nC);
+        sipmTrp1.addPhysVolID("phi",iPhi);
+        sipmTrp1.addPhysVolID("depth",7);
+        sipmTrp2.addPhysVolID("system",3);
+        sipmTrp2.addPhysVolID("eta",nTile*nCy+nC);
+        sipmTrp2.addPhysVolID("phi",iPhi);
+        sipmTrp2.addPhysVolID("depth",8);
+
+        numCrystalsTiming+=2;
+      }
+    }
+
+    for (int nGamma=0; nGamma<N_PHI_BARREL_CRYSTAL; nGamma++) {
+      double gamma =-D_PHI_GLOBAL/2+D_PHI_BARREL_CRYSTAL/2+D_PHI_BARREL_CRYSTAL*nGamma;
+      double x0y0le=z1slice*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+      double x0y0re=z1slice*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+      double x1y1le=z2slice*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+      double x1y1re=z2slice*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+      double verticesS[]={-y1slice,x0y0le,-y1slice,x0y0re,y1slice,x0y0re,y1slice,x0y0le,
+                         -y2slice,x1y1le,-y2slice,x1y1re,y2slice,x1y1re,y2slice,x1y1le};
+      double rSlice =(z1slice+z2slice)/2;
+      RotationZYX rotSlice(0,M_PI/2,0);RotationZ rotZSlice(phiEnvBarrel);rotSlice=rotZSlice*rotSlice;
+      Position dispSlice(rSlice*cos(phiEnvBarrel),rSlice*sin(phiEnvBarrel),0);
+
+      dd4hep::EightPointSolid barrelPhiAssemblyShape(zheight_slice,verticesS);
+      dd4hep::Volume barrelPhiAssemblyVolume("barrelPhiAssembly",barrelPhiAssemblyShape,theDetector.material("Vacuum"));
+      barrelPhiAssemblyVolume.setVisAttributes(theDetector,scepcalAssemblyXML.visStr());
+      dd4hep::PlacedVolume barrelPhiAssemblyPlacedVol=barrelAssemblyVol.placeVolume(barrelPhiAssemblyVolume,Transform3D(rotSlice,dispSlice));
+
+      for (int iTheta=0; iTheta<N_THETA_BARREL; iTheta++) {
+        double thC  =THETA_SIZE_ENDCAP+D_THETA_BARREL/2+(iTheta*D_THETA_BARREL);
+        double r0e  =Rin/sin(thC);
+        double r1e  =r0e+Fdz;
+        double r2e  =r1e+Rdz;
+        double y0e  =r0e*tan(D_THETA_BARREL/2.);
+        double y1e  =r1e*tan(D_THETA_BARREL/2.);
+        double y2e  =r2e*tan(D_THETA_BARREL/2.);
+        double x0y0 =r0e*sin(thC)-y0e*cos(thC);
+        double x1y0 =r0e*sin(thC)+y0e*cos(thC);
+        double x0y0l=x0y0*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x0y0r=x0y0*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x1y0l=x1y0*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x1y0r=x1y0*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x0y1 =r1e*sin(thC)-y1e*cos(thC);
+        double x1y1 =r1e*sin(thC)+y1e*cos(thC);
+        double x0y1l=x0y1*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x0y1r=x0y1*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x1y1l=x1y1*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x1y1r=x1y1*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x0y2 =r2e*sin(thC)-y2e*cos(thC);
+        double x1y2 =r2e*sin(thC)+y2e*cos(thC);
+        double x0y2l=x0y2*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x0y2r=x0y2*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x1y2l=x1y2*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x1y2r=x1y2*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double verticesF[]={x0y0r,y0e,x1y0r,-y0e,x1y0l,-y0e,x0y0l,y0e,
+                            x0y1r,y1e,x1y1r,-y1e,x1y1l,-y1e,x0y1l,y1e};
+        double verticesR[]={x0y1r,y1e,x1y1r,-y1e,x1y1l,-y1e,x0y1l,y1e,
+                            x0y2r,y2e,x1y2r,-y2e,x1y2l,-y2e,x0y2l,y2e};
+        double rF=r0e+Fdz/2.;
+        double rR=r1e+Rdz/2.;
+        int projective_sign=cos(thC)>0?-1:1;
+        RotationZYX rot(M_PI/2,-M_PI/2+thC,0);
+        Position dispF(-rF*cos(thC)+projective_sign*PROJECTIVE_GAP,0,-(rSlice-rF*sin(thC)));
+        Position dispR(-rR*cos(thC)+projective_sign*PROJECTIVE_GAP,0,-(rSlice-rR*sin(thC)));
+
+        dd4hep::EightPointSolid crystalFShape(Fdz/2,verticesF);
+        dd4hep::EightPointSolid crystalRShape(Rdz/2,verticesR);
+        dd4hep::Volume crystalFVol("BarrelCrystalF",crystalFShape,crystalFMat);
+        dd4hep::Volume crystalRVol("BarrelCrystalR",crystalRShape,crystalRMat);
+        crystalFVol.setVisAttributes(theDetector,crystalFXML.visStr());
+        crystalRVol.setVisAttributes(theDetector,crystalRXML.visStr());
+        crystalFVol.setSensitiveDetector(sens);
+        crystalRVol.setSensitiveDetector(sens);
+        auto crystalFId64=segmentation->setVolumeID(1,N_THETA_ENDCAP+iTheta ,iPhi*N_PHI_BARREL_CRYSTAL+nGamma,1);
+        auto crystalRId64=segmentation->setVolumeID(1,N_THETA_ENDCAP+iTheta ,iPhi*N_PHI_BARREL_CRYSTAL+nGamma,2);
+        int  crystalFId32=segmentation->getFirst32bits(crystalFId64);
+        int  crystalRId32=segmentation->getFirst32bits(crystalRId64);
+        dd4hep::PlacedVolume crystalFp=barrelPhiAssemblyVolume.placeVolume(crystalFVol,crystalFId32,Transform3D(rot,dispF));
+        dd4hep::PlacedVolume crystalRp=barrelPhiAssemblyVolume.placeVolume(crystalRVol,crystalRId32,Transform3D(rot,dispR));
+        crystalFp.addPhysVolID("system",1);
+        crystalFp.addPhysVolID("eta",N_THETA_ENDCAP+iTheta);
+        crystalFp.addPhysVolID("phi",iPhi*N_PHI_BARREL_CRYSTAL+nGamma);
+        crystalFp.addPhysVolID("depth",1);
+        crystalRp.addPhysVolID("system",1);
+        crystalRp.addPhysVolID("eta",N_THETA_ENDCAP+iTheta);
+        crystalRp.addPhysVolID("phi",iPhi*N_PHI_BARREL_CRYSTAL+nGamma);
+        crystalRp.addPhysVolID("depth",2);
+
+        numCrystalsBarrel+=2;
+
+      }
+
+      for (int iTheta=0; iTheta<N_PROJECTIVE_FILL; iTheta++) {
+        double thC  =M_PI/2;
+        double r0e  =Rin/sin(thC);
+        double r1e  =r0e+Fdz;
+        double r2e  =r1e+Rdz;
+        double y0e  =nomfw/2;
+        double y1e  =nomfw/2;
+        double y2e  =nomfw/2;
+        double x0y0 =r0e*sin(thC)-y0e*cos(thC);
+        double x1y0 =r0e*sin(thC)+y0e*cos(thC);
+        double x0y0l=x0y0*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x0y0r=x0y0*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x1y0l=x1y0*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x1y0r=x1y0*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x0y1 =r1e*sin(thC)-y1e*cos(thC);
+        double x1y1 =r1e*sin(thC)+y1e*cos(thC);
+        double x0y1l=x0y1*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x0y1r=x0y1*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x1y1l=x1y1*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x1y1r=x1y1*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x0y2 =r2e*sin(thC)-y2e*cos(thC);
+        double x1y2 =r2e*sin(thC)+y2e*cos(thC);
+        double x0y2l=x0y2*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x0y2r=x0y2*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double x1y2l=x1y2*tan(gamma-D_PHI_BARREL_CRYSTAL/2);
+        double x1y2r=x1y2*tan(gamma+D_PHI_BARREL_CRYSTAL/2);
+        double verticesF[]={x0y0r,y0e,x1y0r,-y0e,x1y0l,-y0e,x0y0l,y0e,
+                            x0y1r,y1e,x1y1r,-y1e,x1y1l,-y1e,x0y1l,y1e};
+        double verticesR[]={x0y1r,y1e,x1y1r,-y1e,x1y1l,-y1e,x0y1l,y1e,
+                            x0y2r,y2e,x1y2r,-y2e,x1y2l,-y2e,x0y2l,y2e};
+        double rF=r0e+Fdz/2.;
+        double rR=r1e+Rdz/2.;
+        RotationZYX rot(M_PI/2,-M_PI/2+thC,0);
+        Position dispF(-rF*cos(thC)-nomfw*(N_PROJECTIVE_FILL-1)/2+iTheta*nomfw,0,-(rSlice-rF*sin(thC)));
+        Position dispR(-rR*cos(thC)-nomfw*(N_PROJECTIVE_FILL-1)/2+iTheta*nomfw,0,-(rSlice-rR*sin(thC)));
+
+        dd4hep::EightPointSolid crystalFShape(Fdz/2,verticesF);
+        dd4hep::EightPointSolid crystalRShape(Rdz/2,verticesR);
+        dd4hep::Volume crystalFVol("BarrelCrystalF",crystalFShape,crystalFMat);
+        dd4hep::Volume crystalRVol("BarrelCrystalR",crystalRShape,crystalRMat);
+        crystalFVol.setVisAttributes(theDetector,projFXML.visStr());
+        crystalRVol.setVisAttributes(theDetector,projRXML.visStr());
+        crystalFVol.setSensitiveDetector(sens);
+        crystalRVol.setSensitiveDetector(sens);
+        auto crystalFId64=segmentation->setVolumeID(4,iTheta,iPhi*N_PHI_BARREL_CRYSTAL+nGamma,1);
+        auto crystalRId64=segmentation->setVolumeID(4,iTheta,iPhi*N_PHI_BARREL_CRYSTAL+nGamma,2);
+        int  crystalFId32=segmentation->getFirst32bits(crystalFId64);
+        int  crystalRId32=segmentation->getFirst32bits(crystalRId64);
+        dd4hep::PlacedVolume crystalFp=barrelPhiAssemblyVolume.placeVolume(crystalFVol,crystalFId32,Transform3D(rot,dispF));
+        dd4hep::PlacedVolume crystalRp=barrelPhiAssemblyVolume.placeVolume(crystalRVol,crystalRId32,Transform3D(rot,dispR));
+        crystalFp.addPhysVolID("system",4);
+        crystalFp.addPhysVolID("eta",iTheta);
+        crystalFp.addPhysVolID("phi",iPhi*N_PHI_BARREL_CRYSTAL+nGamma);
+        crystalFp.addPhysVolID("depth",1);
+        crystalRp.addPhysVolID("system",4);
+        crystalRp.addPhysVolID("eta",iTheta);
+        crystalRp.addPhysVolID("phi",iPhi*N_PHI_BARREL_CRYSTAL+nGamma);
+        crystalRp.addPhysVolID("depth",2);
+
+        numCrystalsBarrel+=2;
+      }
+    }
+  }
+
+  for (int iTheta=CONSTRUCT_ENDCAP? ENDCAP_THETA_START:N_THETA_ENDCAP;iTheta<N_THETA_ENDCAP;iTheta++) {
+    double thC=D_THETA_ENDCAP/2+iTheta*D_THETA_ENDCAP;
+    double RinEndcap=EBz*tan(thC);
+    int    nPhiEndcapCrystal=floor(2*M_PI*RinEndcap/(PHI_SEGMENTS*nomfw));
+    double dPhiEndcapCrystal=D_PHI_GLOBAL/nPhiEndcapCrystal;
+    double r0e=RinEndcap/sin(thC);
+    double r1e=r0e+Fdz;
+    double r2e=r1e+Rdz;
+    double y0e=r0e*tan(D_THETA_ENDCAP/2.);
+    double y1e=r1e*tan(D_THETA_ENDCAP/2.);
+    double y2e=r2e*tan(D_THETA_ENDCAP/2.);
+    double a=r0e/cos(D_THETA_ENDCAP/2);
+    double z1=a*cos(thC+D_THETA_ENDCAP/2);
+    double r1min=z1*tan(thC-D_THETA_ENDCAP/2);
+    double r1max=z1*tan(thC+D_THETA_ENDCAP/2);
+    double b=sqrt(r2e*r2e+y2e*y2e);
+    double z2=b*cos(thC-D_THETA_ENDCAP/2);
+    double r2min=z2*tan(thC-D_THETA_ENDCAP/2);
+    double r2max=z2*tan(thC+D_THETA_ENDCAP/2);
+
+    std::vector<double> zPolyhedra={z1+PROJECTIVE_GAP,z2+PROJECTIVE_GAP};
+    std::vector<double> rminPolyhedra={r1min,r2min};
+    std::vector<double> rmaxPolyhedra={r1max,r2max};
+    dd4hep::Polyhedra endcapRingAssemblyShape(PHI_SEGMENTS,D_PHI_GLOBAL/2,2*M_PI,zPolyhedra,rminPolyhedra,rmaxPolyhedra);
+    dd4hep::Volume    endcapRingAssemblyVolume("endcapRingAssembly",endcapRingAssemblyShape,theDetector.material("Vacuum"));
+    endcapRingAssemblyVolume.setVisAttributes(theDetector,scepcalAssemblyXML.visStr());
+    dd4hep::Volume    endcap1RingAssemblyVolume("endcapRingAssembly",endcapRingAssemblyShape,theDetector.material("Vacuum"));
+    endcap1RingAssemblyVolume.setVisAttributes(theDetector,scepcalAssemblyXML.visStr());
+    RotationY rotMirror(M_PI);
+    dd4hep::PlacedVolume endcapRingAssemblyPlacedVol=endcapAssemblyVol.placeVolume(endcapRingAssemblyVolume);
+    dd4hep::PlacedVolume endcap1RingAssemblyPlacedVol=endcap1AssemblyVol.placeVolume(endcap1RingAssemblyVolume,Transform3D(rotMirror));
+
+    for (int iPhi=ENDCAP_PHI_START;iPhi<ENDCAP_PHI_END;iPhi++) {
+      double phiEnvEndcap=iPhi*D_PHI_GLOBAL;
+      for (int nGamma=0;nGamma<nPhiEndcapCrystal;nGamma++) {
+        double gamma=-D_PHI_GLOBAL/2+dPhiEndcapCrystal/2+dPhiEndcapCrystal*nGamma;
+        double x0y0 =r0e*sin(thC)-y0e*cos(thC);
+        double x1y0 =r0e*sin(thC)+y0e*cos(thC);
+        double x0y0l=x0y0*tan(gamma-dPhiEndcapCrystal/2);
+        double x0y0r=x0y0*tan(gamma+dPhiEndcapCrystal/2);
+        double x1y0l=x1y0*tan(gamma-dPhiEndcapCrystal/2);
+        double x1y0r=x1y0*tan(gamma+dPhiEndcapCrystal/2);
+        double x0y1 =r1e*sin(thC)-y1e*cos(thC);
+        double x1y1 =r1e*sin(thC)+y1e*cos(thC);
+        double x0y1l=x0y1*tan(gamma-dPhiEndcapCrystal/2);
+        double x0y1r=x0y1*tan(gamma+dPhiEndcapCrystal/2);
+        double x1y1l=x1y1*tan(gamma-dPhiEndcapCrystal/2);
+        double x1y1r=x1y1*tan(gamma+dPhiEndcapCrystal/2);
+        double x0y2 =r2e*sin(thC)-y2e*cos(thC);
+        double x1y2 =r2e*sin(thC)+y2e*cos(thC);
+        double x0y2l=x0y2*tan(gamma-dPhiEndcapCrystal/2);
+        double x0y2r=x0y2*tan(gamma+dPhiEndcapCrystal/2);
+        double x1y2l=x1y2*tan(gamma-dPhiEndcapCrystal/2);
+        double x1y2r=x1y2*tan(gamma+dPhiEndcapCrystal/2);
+        double verticesF[]={x0y0r,y0e,x1y0r,-y0e,x1y0l,-y0e,x0y0l,y0e,
+                            x0y1r,y1e,x1y1r,-y1e,x1y1l,-y1e,x0y1l,y1e};
+        double verticesR[]={x0y1r,y1e,x1y1r,-y1e,x1y1l,-y1e,x0y1l,y1e,
+                            x0y2r,y2e,x1y2r,-y2e,x1y2l,-y2e,x0y2l,y2e};
+        double rF=r0e+Fdz/2.;
+        double rR=r1e+Rdz/2.;
+        RotationZYX rot(M_PI/2,thC,0);RotationZ rotZ(phiEnvEndcap);rot=rotZ*rot;
+        Position dispF(rF*sin(thC)*cos(phiEnvEndcap),rF*sin(thC)*sin(phiEnvEndcap),rF*cos(thC)+PROJECTIVE_GAP);
+        Position dispR(rR*sin(thC)*cos(phiEnvEndcap),rR*sin(thC)*sin(phiEnvEndcap),rR*cos(thC)+PROJECTIVE_GAP);
+
+        dd4hep::EightPointSolid crystalFShape(Fdz/2,verticesF);
+        dd4hep::EightPointSolid crystalRShape(Rdz/2,verticesR);
+        dd4hep::Volume crystalFVol("EndcapCrystalF",crystalFShape,crystalFMat);
+        dd4hep::Volume crystalRVol("EndcapCrystalR",crystalRShape,crystalRMat);
+        crystalFVol.setVisAttributes(theDetector,crystalFXML.visStr());
+        crystalRVol.setVisAttributes(theDetector,crystalRXML.visStr());
+        crystalFVol.setSensitiveDetector(sens);
+        crystalRVol.setSensitiveDetector(sens);
+        auto crystalFId64=segmentation->setVolumeID(2,iTheta,iPhi*nPhiEndcapCrystal+nGamma,1);
+        auto crystalRId64=segmentation->setVolumeID(2,iTheta,iPhi*nPhiEndcapCrystal+nGamma,2);
+        int  crystalFId32=segmentation->getFirst32bits(crystalFId64);
+        int  crystalRId32=segmentation->getFirst32bits(crystalRId64);
+        dd4hep::PlacedVolume crystalFp=endcapRingAssemblyVolume.placeVolume(crystalFVol,crystalFId32,Transform3D(rot,dispF));
+        dd4hep::PlacedVolume crystalRp=endcapRingAssemblyVolume.placeVolume(crystalRVol,crystalRId32,Transform3D(rot,dispR));
+        crystalFp.addPhysVolID("system",2);
+        crystalFp.addPhysVolID("eta",iTheta);
+        crystalFp.addPhysVolID("phi",iPhi*nPhiEndcapCrystal+nGamma);
+        crystalFp.addPhysVolID("depth",1);
+        crystalRp.addPhysVolID("system",2);
+        crystalRp.addPhysVolID("eta",iTheta);
+        crystalRp.addPhysVolID("phi",iPhi*nPhiEndcapCrystal+nGamma);
+        crystalRp.addPhysVolID("depth",2);
+        auto crystalFId641=segmentation->setVolumeID(2,N_THETA_ENDCAP+N_THETA_BARREL+N_THETA_ENDCAP-iTheta,iPhi*nPhiEndcapCrystal+nGamma,1);
+        auto crystalRId641=segmentation->setVolumeID(2,N_THETA_ENDCAP+N_THETA_BARREL+N_THETA_ENDCAP-iTheta,iPhi*nPhiEndcapCrystal+nGamma,2);
+        int  crystalFId321=segmentation->getFirst32bits(crystalFId641);
+        int  crystalRId321=segmentation->getFirst32bits(crystalRId641);
+        dd4hep::PlacedVolume crystalFp1=endcap1RingAssemblyVolume.placeVolume(crystalFVol,crystalFId321,Transform3D(rot,dispF));
+        dd4hep::PlacedVolume crystalRp1=endcap1RingAssemblyVolume.placeVolume(crystalRVol,crystalRId321,Transform3D(rot,dispR));
+        crystalFp1.addPhysVolID("system",2);
+        crystalFp1.addPhysVolID("eta",N_THETA_ENDCAP+N_THETA_BARREL+N_THETA_ENDCAP-iTheta);
+        crystalFp1.addPhysVolID("phi",iPhi*nPhiEndcapCrystal+nGamma);
+        crystalFp1.addPhysVolID("depth",1);
+        crystalRp1.addPhysVolID("system",2);
+        crystalRp1.addPhysVolID("eta",N_THETA_ENDCAP+N_THETA_BARREL+N_THETA_ENDCAP-iTheta);
+        crystalRp1.addPhysVolID("phi",iPhi*nPhiEndcapCrystal+nGamma);
+        crystalRp1.addPhysVolID("depth",2);
+
+        numCrystalsEndcap+=2;
+      }
+    }
+  }
+
+  std::cout                                                         << std::endl;
+  std::cout                                                         << std::endl;
+  std::cout << "NUM_CRYSTALS_BARREL:  " << numCrystalsBarrel        << std::endl;
+  std::cout << "NUM_CRYSTALS_ENDCAP:  " << numCrystalsEndcap        << std::endl;
+  std::cout << "NUM_CRYSTALS_TIMING:  " << numCrystalsTiming        << std::endl;
+  std::cout                                                         << std::endl;
+  std::cout                                                         << std::endl;
+
+  return ScepcalDetElement;
+}
+
+DECLARE_DETELEMENT(SegmentedCrystalECAL,create_detector_SCEPCal)

--- a/detectorSegmentations/include/detectorSegmentations/DRCrystalHit.h
+++ b/detectorSegmentations/include/detectorSegmentations/DRCrystalHit.h
@@ -1,0 +1,75 @@
+//===============================
+// Author: Wonyong Chung
+//         Princeton University
+//===============================
+#ifndef DRCrystalHit_h
+#define DRCrystalHit_h 1
+#include "G4VHit.hh"
+#include "G4THitsCollection.hh"
+#include "G4Allocator.hh"
+#include "G4ThreeVector.hh"
+#include "DDG4/Geant4Data.h"
+#include "G4OpticalPhoton.hh"
+#include "G4VProcess.hh"
+#include "DD4hep/Objects.h"
+#include "DD4hep/Segmentations.h"
+#include "CLHEP/Vector/ThreeVector.h"
+
+namespace SCEPCal {
+
+  typedef ROOT::Math::XYZVector Position;
+
+    const int nsipmbins=6000;
+
+    class DRCrystalHit : public dd4hep::sim::Geant4HitData {
+
+      public:
+        typedef dd4hep::sim::Geant4HitData base_t;
+
+        Position      position;
+        Contributions truth;
+        double        energyDeposit;
+
+        int eta;
+        int phi;
+        int depth;
+        int system;
+        
+        int ncerenkov;
+        int nscintillator;
+
+        int nbins=nsipmbins;
+        
+        float wavelen_min=300;
+        float wavelen_max=1000;
+
+        float time_min=0;
+        float time_max=300;
+        
+        std::array<int,nsipmbins> nwavelen_cer;
+        std::array<int,nsipmbins> nwavelen_scint;
+        
+        std::array<int,nsipmbins> ntime_cer;
+        std::array<int,nsipmbins> ntime_scint;
+        
+      public:
+        DRCrystalHit();
+        DRCrystalHit(DRCrystalHit&& c) = delete;
+        DRCrystalHit(const DRCrystalHit& c) = delete;
+        DRCrystalHit(const Position& cell_pos);
+        virtual ~DRCrystalHit();
+        DRCrystalHit& operator=(DRCrystalHit&& c) = delete;
+        DRCrystalHit& operator=(const DRCrystalHit& c) = delete;
+    };
+};
+
+#if defined(__CINT__) || defined(__MAKECINT__) || defined(__CLING__) || defined(__ROOTCLING__)
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ namespace dd4hep;
+#pragma link C++ namespace dd4hep::sim;
+#pragma link C++ namespace SCEPCal;
+#pragma link C++ class     SCEPCal::DRCrystalHit+;
+#endif
+#endif

--- a/detectorSegmentations/include/detectorSegmentations/SCEPCalSegmentation.h
+++ b/detectorSegmentations/include/detectorSegmentations/SCEPCalSegmentation.h
@@ -1,0 +1,98 @@
+//===============================
+// Author: Wonyong Chung
+//         Princeton University
+//===============================
+#ifndef SCEPCalSegmentation_h
+#define SCEPCalSegmentation_h 1
+#include "DDSegmentation/Segmentation.h"
+#include "TVector3.h"
+#include "DD4hep/DetFactoryHelper.h"
+#include <vector>
+#include <cmath>
+
+namespace dd4hep {
+namespace DDSegmentation {
+
+class SCEPCalSegmentation : public Segmentation {
+    public:
+        SCEPCalSegmentation(const std::string& aCellEncoding);
+        SCEPCalSegmentation(const BitFieldCoder* decoder);
+        virtual ~SCEPCalSegmentation() override;
+
+        virtual Vector3D position(const CellID& aCellID) const;
+
+        virtual Vector3D myPosition(const CellID& aCellID) ;
+
+        virtual CellID cellID(const Vector3D& aLocalPosition,
+                              const Vector3D& aGlobalPosition,
+                              const VolumeID& aVolumeID) const;
+
+        VolumeID setVolumeID(int System, int Eta, int Phi, int Depth) const;
+        CellID setCellID(int System, int Eta, int Phi, int Depth) const;
+
+        int System(const CellID& aCellID) const;
+        int Eta(const CellID& aCellID) const;
+        int Phi(const CellID& aCellID) const;
+        int Depth(const CellID& aCellID) const;
+
+        int getFirst32bits(const CellID& aCellID) const { return (int)aCellID; }
+        int getLast32bits(const CellID& aCellID) const;
+
+        CellID convertFirst32to64(const int aId32) const { return (CellID)aId32; }
+        CellID convertLast32to64(const int aId32) const;
+
+        int System(const int& aId32) const { return System( convertFirst32to64(aId32) ); }
+        int Eta(const int& aId32) const { return Eta( convertFirst32to64(aId32) ); }
+        int Phi(const int& aId32) const { return Phi( convertFirst32to64(aId32) ); }
+        int Depth(const int& aId32) const { return Depth( convertFirst32to64(aId32) ); }
+
+        inline void setGeomParams(double Fdz, double Rdz,
+                                  double nomfw, double nomth, 
+                                  double EBz, double Rin,
+                                  double sipmth,
+                                  int phiSegments, int NProjectiveFill) {
+            f_Fdz = Fdz;
+            f_Rdz = Rdz;
+            f_nomfw = nomfw;
+            f_nomth = nomth;
+            f_EBz = EBz;
+            f_Rin = Rin;
+            f_sipmth = sipmth;
+            f_phiSegments = phiSegments;
+            f_NProjectiveFill = NProjectiveFill;
+        }
+
+        inline double getFdz() const{ return f_Fdz; }
+        inline double getRdz() const{ return f_Rdz; }
+        inline double getnomfw() const{ return f_nomfw; }
+        inline double getnomth() const{ return f_nomth; }
+        inline double getEBz() const{ return f_EBz; }
+        inline double getRin() const{ return f_Rin; }
+        inline double getSipmth() const{ return f_sipmth; }
+        inline int    getphiSegments() const{ return f_phiSegments; }
+        inline int    getNProjectiveFill() const{ return f_NProjectiveFill; }
+
+    protected:
+        std::string fSystemId;
+        std::string fEtaId;
+        std::string fPhiId;
+        std::string fDepthId;
+
+        double f_Fdz;
+        double f_Rdz;
+        double f_nomfw;
+        double f_nomth;
+        double f_EBz;
+        double f_Rin;
+        double f_sipmth;
+        int    f_phiSegments;
+        int    f_NProjectiveFill;
+
+    private:
+        std::unordered_map<int, Vector3D> fPositionOf;
+
+};
+}
+}
+
+#endif

--- a/detectorSegmentations/include/detectorSegmentations/SCEPCalSegmentationHandle.h
+++ b/detectorSegmentations/include/detectorSegmentations/SCEPCalSegmentationHandle.h
@@ -1,0 +1,87 @@
+//===============================
+// Author: Wonyong Chung
+//         Princeton University
+//===============================
+#ifndef SCEPCalSegmentationHandle_h
+#define SCEPCalSegmentationHandle_h 1
+#include "detectorSegmentations/SCEPCalSegmentation.h"
+#include "DD4hep/Segmentations.h"
+#include "DD4hep/detail/SegmentationsInterna.h"
+
+namespace dd4hep {
+    
+class Segmentation;
+template <typename T>
+class SegmentationWrapper;
+
+typedef Handle<SegmentationWrapper<DDSegmentation::SCEPCalSegmentation>> SCEPCalSegmentationHandle;
+
+class SCEPCalSegmentation : public SCEPCalSegmentationHandle {
+public:
+    typedef SCEPCalSegmentationHandle::Object Object;
+
+public:
+    SCEPCalSegmentation() = default;
+    SCEPCalSegmentation(const SCEPCalSegmentation& e) = default;
+    SCEPCalSegmentation(const Segmentation& e) : Handle<Object>(e) {}
+    SCEPCalSegmentation(const Handle<Object>& e) : Handle<Object>(e) {}
+    template <typename Q>
+    SCEPCalSegmentation(const Handle<Q>& e) : Handle<Object>(e) {}
+    SCEPCalSegmentation& operator=(const SCEPCalSegmentation& seg) = default;
+    bool operator==(const SCEPCalSegmentation& seg) const { return m_element == seg.m_element; }
+
+    inline Position position(const CellID& id) const {
+        return Position(access()->implementation->position(id));
+    }
+
+    inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+        return access()->implementation->cellID(local, global, volID);
+    }
+
+    inline VolumeID setVolumeID(int System, int Eta, int Phi, int Depth) const {
+        return access()->implementation->setVolumeID(System, Eta,Phi,Depth);
+    }
+
+    inline CellID setCellID(int System, int Eta, int Phi, int Depth) const {
+        return access()->implementation->setCellID(System, Eta, Phi, Depth);
+    }
+
+    inline int System(const CellID& aCellID) const { return access()->implementation->System(aCellID); }
+    inline int Eta(const CellID& aCellID) const { return access()->implementation->Eta(aCellID); }
+    inline int Phi(const CellID& aCellID) const { return access()->implementation->Phi(aCellID); }
+    inline int Depth(const CellID& aCellID) const { return access()->implementation->Depth(aCellID); }
+
+    inline int getFirst32bits(const CellID& aCellID) const { return access()->implementation->getFirst32bits(aCellID); }
+    inline int getLast32bits(const CellID& aCellID) const { return access()->implementation->getLast32bits(aCellID); }
+
+    inline CellID convertFirst32to64(const int aId32) const { return access()->implementation->convertFirst32to64(aId32); }
+    inline CellID convertLast32to64(const int aId32) const { return access()->implementation->convertLast32to64(aId32); }
+
+    inline int System(const int& aId32) const { return access()->implementation->System(aId32); }
+    inline int Eta(const int& aId32) const { return access()->implementation->Eta(aId32); }
+    inline int Phi(const int& aId32) const { return access()->implementation->Phi(aId32); }
+    inline int Depth(const int& aId32) const { return access()->implementation->Depth(aId32); }
+
+    inline void setGeomParams(double Fdz, double Rdz,
+                              double nomfw, double nomth, 
+                              double EBz, double Rin,
+                              double sipmth,
+                              int phiSegments,
+                              int NProjectiveFill) const { 
+        return access()->implementation->setGeomParams(Fdz,Rdz,nomfw,nomth,EBz,Rin,sipmth,phiSegments,NProjectiveFill);
+    }
+
+    inline double getFdz() const{ return access()->implementation->getFdz(); }
+    inline double getRdz() const{ return access()->implementation->getRdz(); }
+    inline double getnomfw() const{ return access()->implementation->getnomfw(); }
+    inline double getnomth() const{ return access()->implementation->getnomth(); }
+    inline double getEBz() const{ return access()->implementation->getEBz(); }
+    inline double getRin() const{ return access()->implementation->getRin(); }
+    inline double getSipmth() const{ return access()->implementation->getSipmth(); }
+    inline int    getphiSegments() const{ return access()->implementation->getphiSegments(); }
+    inline int    getNProjectiveFill() const{ return access()->implementation->getNProjectiveFill(); }
+
+};
+
+}
+#endif

--- a/detectorSegmentations/src/DRCrystalHit.cpp
+++ b/detectorSegmentations/src/DRCrystalHit.cpp
@@ -1,0 +1,49 @@
+//===============================
+// Author: Wonyong Chung
+//         Princeton University
+//===============================
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Data.h>
+#include <DDG4/Geant4StepHandler.h>
+#include <DDG4/Geant4FastSimHandler.h>
+#include <G4Step.hh>
+#include <G4Allocator.hh>
+#include <G4OpticalPhoton.hh>
+#include "detectorSegmentations/DRCrystalHit.h"
+#include "G4Track.hh"
+
+using namespace dd4hep::sim;
+using namespace dd4hep;
+using namespace std;
+using namespace SCEPCal;
+
+DRCrystalHit::DRCrystalHit()
+: Geant4HitData(), position(), truth(), energyDeposit(0), eta(0), phi(0), depth(0), system(0), ncerenkov(0), nscintillator(0) {
+
+  InstanceCount::increment(this);
+
+  for( int i=0; i<nsipmbins; i++) {
+    nwavelen_cer[i]=0;
+    nwavelen_scint[i]=0;
+    ntime_cer[i]=0;
+    ntime_scint[i]=0;
+  }
+}
+
+DRCrystalHit::DRCrystalHit(const Position& pos)
+: Geant4HitData(), position(pos), truth(), energyDeposit(0), eta(0), phi(0), depth(0), system(0), ncerenkov(0), nscintillator(0) {
+
+  InstanceCount::increment(this);
+
+  for( int i=0; i<nsipmbins; i++) {
+    nwavelen_cer[i]=0;
+    nwavelen_scint[i]=0;
+    ntime_cer[i]=0;
+    ntime_scint[i]=0;
+  }
+}
+
+DRCrystalHit::~DRCrystalHit() {
+  InstanceCount::decrement(this);
+}

--- a/detectorSegmentations/src/SCEPCalSegmentation.cpp
+++ b/detectorSegmentations/src/SCEPCalSegmentation.cpp
@@ -1,0 +1,248 @@
+//===============================
+// Author: Wonyong Chung
+//         Princeton University
+//===============================
+#include "detectorSegmentations/SCEPCalSegmentation.h"
+#include <climits>
+#include <cmath>
+#include <stdexcept>
+
+namespace dd4hep {
+namespace DDSegmentation {
+
+SCEPCalSegmentation::SCEPCalSegmentation(const std::string& cellEncoding) : Segmentation(cellEncoding) {
+    _type = "SCEPCalSegmentation";
+    _description = "SCEPCal segmentation based on side/eta/phi/depth/S/C";
+    registerIdentifier("identifier_system", "Cell ID identifier for numSystem", fSystemId, "system");
+    registerIdentifier("identifier_eta", "Cell ID identifier for numEta", fEtaId, "eta");
+    registerIdentifier("identifier_phi", "Cell ID identifier for numPhi", fPhiId, "phi");
+    registerIdentifier("identifier_depth", "Cell ID identifier for numDepth", fDepthId, "depth");
+}
+
+SCEPCalSegmentation::SCEPCalSegmentation(const BitFieldCoder* decoder) : Segmentation(decoder) {
+    _type = "SCEPCalSegmentation";
+    _description = "SCEPCal segmentation based on side/eta/phi/depth/S/C";
+    registerIdentifier("identifier_system", "Cell ID identifier for numSystem", fSystemId, "system");
+    registerIdentifier("identifier_eta", "Cell ID identifier for Eta", fEtaId, "eta");
+    registerIdentifier("identifier_phi", "Cell ID identifier for Phi", fPhiId, "phi");
+    registerIdentifier("identifier_depth", "Cell ID identifier for Depth", fDepthId, "depth");
+}
+
+SCEPCalSegmentation::~SCEPCalSegmentation() {}
+
+Vector3D SCEPCalSegmentation::position(const CellID& cID) const {
+    return Vector3D(0,0,0);
+};
+
+Vector3D SCEPCalSegmentation::myPosition(const CellID& cID) {
+
+    int copyNum = (int)cID;
+
+    double Fdz           =getFdz();
+    double Rdz           =getRdz();
+    double nomfw         =getnomfw();
+    double nomth         =getnomth();
+    double EBz           =getEBz();
+    double Rin           =getRin();
+    double sipmth        =getSipmth();
+    int PHI_SEGMENTS     =getphiSegments();
+    int N_PROJECTIVE_FILL=getNProjectiveFill();
+    int system           =System(copyNum);
+    int nEta_in          =Eta(copyNum);
+    int nPhi_in          =Phi(copyNum);
+    int nDepth_in        =Depth(copyNum);
+
+    double  D_PHI_GLOBAL        =2*M_PI/PHI_SEGMENTS;
+    double  PROJECTIVE_GAP      =(N_PROJECTIVE_FILL*nomfw)/2;
+    double  THETA_SIZE_BARREL   =atan(EBz/Rin);
+    double  THETA_SIZE_ENDCAP   =atan(Rin/EBz);
+    int     N_THETA_BARREL      =2*floor(EBz/nomfw);
+    int     N_THETA_ENDCAP      =floor(Rin/nomfw);
+    double  D_THETA_BARREL      =(M_PI-2*THETA_SIZE_ENDCAP)/(N_THETA_BARREL);
+    double  D_THETA_ENDCAP      =THETA_SIZE_ENDCAP/N_THETA_ENDCAP;
+    int     N_PHI_BARREL_CRYSTAL=floor(2*M_PI*Rin/(PHI_SEGMENTS*nomfw));
+    double  D_PHI_BARREL_CRYSTAL=D_PHI_GLOBAL/N_PHI_BARREL_CRYSTAL;
+
+    if (system == 3) {
+        double thC_end         =THETA_SIZE_ENDCAP+D_THETA_BARREL/2;
+        double r0slice_end     =Rin/sin(thC_end);
+        double y0slice_end     =r0slice_end*tan(D_THETA_BARREL/2.);
+        double slice_front_jut =y0slice_end*sin(M_PI/2-thC_end);
+        double z1slice         =Rin -slice_front_jut;
+        double z2slice         =Rin +Fdz +Rdz +slice_front_jut;
+        double y1slice         =z1slice*tan(M_PI/2-THETA_SIZE_ENDCAP) +PROJECTIVE_GAP;
+        double phiTiming       =nPhi_in*D_PHI_GLOBAL;
+        double rT              =z1slice -2*nomth;
+        double wT              =rT *tan(D_PHI_GLOBAL/2);
+        int    nTiles          =ceil(y1slice/wT);
+        double lT              =2*y1slice/nTiles;
+        int    nCy             =floor(lT/nomth);
+        double actY            =lT/nCy;
+        double actX            =2*wT/nCy; 
+        double rTimingAssembly =rT+nomth;
+        int    nTile           =int(nEta_in/nCy);
+        ROOT::Math::XYZVector dispTimingAssembly(rTimingAssembly*cos(0),rTimingAssembly*sin(0),0);
+        ROOT::Math::XYZVector dispTileAssembly(0,0,-y1slice +nTile*lT +lT/2);
+        int nC=nEta_in-nTile*nCy;
+        int phiTimingSign=nPhi_in%2==0? 1:-1;
+        int sign         =nTile%2==0? 1:-1;
+        ROOT::Math::RotationZ rotZ(phiTiming);
+        ROOT::Math::XYZVector dispLg(sign*phiTimingSign*(nomth/2),-wT +actX/2 + nC*actX,0);
+        ROOT::Math::XYZVector dispTr(sign*phiTimingSign*(-nomth/2),0,-lT/2 +actY/2 +nC*actY);
+        ROOT::Math::XYZVector dispSipmLg(0, 0, lT/2-sipmth/2);
+        ROOT::Math::XYZVector dispSipmTr(0, wT-sipmth/2, 0);
+        if (nDepth_in==3) {return rotZ*(dispTimingAssembly +dispTileAssembly +dispLg);}
+        else if (nDepth_in==4) {return rotZ*(dispTimingAssembly +dispTileAssembly +dispLg +dispSipmLg);}
+        else if (nDepth_in==5) {return rotZ*(dispTimingAssembly +dispTileAssembly +dispLg -dispSipmLg);}
+        else if (nDepth_in==6) {return rotZ*(dispTimingAssembly +dispTileAssembly +dispTr);}
+        else if (nDepth_in==7) {return rotZ*(dispTimingAssembly +dispTileAssembly +dispTr +dispSipmTr);}
+        else if (nDepth_in==8) {return rotZ*(dispTimingAssembly +dispTileAssembly +dispTr -dispSipmTr);}
+    }
+    else if (system == 2) {
+        int nTheta;
+        if (nEta_in<N_THETA_ENDCAP) {nTheta=nEta_in;}
+        else if (nEta_in>N_THETA_ENDCAP+N_THETA_BARREL) {
+            nTheta = N_THETA_ENDCAP+N_THETA_BARREL+N_THETA_ENDCAP -nEta_in;
+        }
+        double thC               =D_THETA_ENDCAP/2+nTheta*D_THETA_ENDCAP;
+        double RinEndcap         =EBz*tan(thC);
+        int    nPhiEndcapCrystal =floor(2*M_PI*RinEndcap/(PHI_SEGMENTS*nomfw));
+        double dPhiEndcapCrystal =D_PHI_GLOBAL/nPhiEndcapCrystal;
+        double r0e               =RinEndcap/sin(thC);
+        double r1e               =r0e+Fdz;
+        int    nPhi              =int(nPhi_in/nPhiEndcapCrystal);
+        int    nGamma            =nPhi_in%nPhiEndcapCrystal;
+        double phi               =nPhi*D_PHI_GLOBAL;
+        double gamma             =-D_PHI_GLOBAL/2+dPhiEndcapCrystal/2+dPhiEndcapCrystal*nGamma;
+        int    mirror            =nEta_in<N_THETA_ENDCAP? 0:1;
+        double rSlice            =RinEndcap+(Fdz+Rdz)/2;
+        Position dispSlice(rSlice*cos(phi),rSlice*sin(phi),0);
+        ROOT::Math::RotationZ rotZ(phi);
+        ROOT::Math::RotationY rotY(M_PI*mirror);
+        if (nDepth_in==1) {
+            double rF=r0e+Fdz/2.;
+            ROOT::Math::XYZVector dispF(rF*sin(thC)-rSlice,rF*sin(thC)*tan(gamma),rF*cos(thC)+PROJECTIVE_GAP);
+            return rotY*(dispSlice+rotZ*dispF);
+        }
+        else if (nDepth_in==2) {
+            double rR=r1e+Rdz/2.;
+            ROOT::Math::XYZVector dispR(rR*sin(thC)-rSlice,rR*sin(thC)*tan(gamma),rR*cos(thC)+PROJECTIVE_GAP);
+            return rotY*(dispSlice+rotZ*dispR);
+        }
+    }
+    else if (system == 1) {
+        int    nTheta         =nEta_in-N_THETA_ENDCAP;
+        int    nPhi           =int(nPhi_in/N_PHI_BARREL_CRYSTAL);
+        int    nGamma         =nPhi_in%N_PHI_BARREL_CRYSTAL;
+        double phi            =nPhi*D_PHI_GLOBAL;
+        double gamma          =-D_PHI_GLOBAL/2+D_PHI_BARREL_CRYSTAL/2+D_PHI_BARREL_CRYSTAL*nGamma;
+        double thC            =THETA_SIZE_ENDCAP+D_THETA_BARREL/2+(nTheta*D_THETA_BARREL);
+        int    projective_sign=cos(thC)>0? -1:1;
+        double r0e            =Rin/sin(thC);
+        double r1e            =r0e+Fdz;
+        double rSlice         =Rin+(Fdz+Rdz)/2;
+        Position dispSlice(rSlice*cos(phi),rSlice*sin(phi),0);
+        ROOT::Math::RotationZ rotZ(phi);
+        if (nDepth_in==1) {
+            double rF=r0e+Fdz/2.;
+            ROOT::Math::XYZVector dispF(rF*sin(thC)-rSlice,rF*sin(thC)*tan(gamma),rF*cos(thC)-projective_sign*PROJECTIVE_GAP);
+            return (dispSlice+rotZ*dispF);
+        }
+        else if (nDepth_in==2) {
+            double rR=r1e+Rdz/2.;
+            ROOT::Math::XYZVector dispR(rR*sin(thC)-rSlice,rR*sin(thC)*tan(gamma),rR*cos(thC)-projective_sign*PROJECTIVE_GAP);
+            return (dispSlice+rotZ*dispR);
+        }
+    }
+    else if (system == 4) {
+        int nTheta   =nEta_in;
+        int nPhi     =int(nPhi_in/N_PHI_BARREL_CRYSTAL);
+        int nGamma   =nPhi_in%N_PHI_BARREL_CRYSTAL;
+        double phi   =nPhi*D_PHI_GLOBAL;
+        double gamma =-D_PHI_GLOBAL/2+D_PHI_BARREL_CRYSTAL/2+D_PHI_BARREL_CRYSTAL*nGamma;
+        double thC   =M_PI/2;
+        double r0e   =Rin/sin(thC);
+        double r1e   =r0e+Fdz;
+        double rSlice=Rin +(Fdz+Rdz)/2;
+        Position dispSlice(rSlice*cos(phi),rSlice*sin(phi),0);
+        ROOT::Math::RotationZ rotZ(phi);
+        if (nDepth_in==1) {
+            double rF=r0e+Fdz/2.;
+            ROOT::Math::XYZVector dispF(rF*sin(thC)-rSlice,rF*sin(thC)*tan(gamma),rF*cos(thC)-nomfw*(N_PROJECTIVE_FILL-1)/2+nTheta*nomfw);
+            return (dispSlice+rotZ*dispF);
+        }
+        else if (nDepth_in==2) {
+            double rR=r1e+Rdz/2.;
+            ROOT::Math::XYZVector dispR(rR*sin(thC)-rSlice,rR*sin(thC)*tan(gamma),rR*cos(thC)-nomfw*(N_PROJECTIVE_FILL-1)/2+nTheta*nomfw);
+            return (dispSlice+rotZ*dispR);
+        }
+    }
+    return Vector3D(0,0,0);
+}
+
+CellID SCEPCalSegmentation::cellID(const Vector3D& /*localPosition*/, 
+                                   const Vector3D& /*globalPosition*/, 
+                                   const VolumeID& vID) const {
+    return setCellID(System(vID), Eta(vID), Phi(vID), Depth(vID) );
+}
+
+VolumeID SCEPCalSegmentation::setVolumeID(int System, int Eta, int Phi, int Depth) const {
+    VolumeID SystemId = static_cast<VolumeID>(System);
+    VolumeID EtaId = static_cast<VolumeID>(Eta);
+    VolumeID PhiId = static_cast<VolumeID>(Phi);
+    VolumeID DepthId = static_cast<VolumeID>(Depth);
+    VolumeID vID = 0;
+    _decoder->set(vID, fSystemId, SystemId);
+    _decoder->set(vID, fEtaId, EtaId);
+    _decoder->set(vID, fPhiId, PhiId);
+    _decoder->set(vID, fDepthId, DepthId);
+    return vID;
+}
+
+CellID SCEPCalSegmentation::setCellID(int System, int Eta, int Phi, int Depth) const {
+    VolumeID SystemId = static_cast<VolumeID>(System);
+    VolumeID EtaId = static_cast<VolumeID>(Eta);
+    VolumeID PhiId = static_cast<VolumeID>(Phi);
+    VolumeID DepthId = static_cast<VolumeID>(Depth);
+    VolumeID vID = 0;
+    _decoder->set(vID, fSystemId, SystemId);
+    _decoder->set(vID, fEtaId, EtaId);
+    _decoder->set(vID, fPhiId, PhiId);
+    _decoder->set(vID, fDepthId, DepthId);
+    return vID;
+}
+
+int SCEPCalSegmentation::System(const CellID& aCellID) const {
+    VolumeID System = static_cast<VolumeID>(_decoder->get(aCellID, fSystemId));
+    return static_cast<int>(System);
+}
+
+int SCEPCalSegmentation::Eta(const CellID& aCellID) const {
+    VolumeID Eta = static_cast<VolumeID>(_decoder->get(aCellID, fEtaId));
+    return static_cast<int>(Eta);
+}
+
+int SCEPCalSegmentation::Phi(const CellID& aCellID) const {
+    VolumeID Phi = static_cast<VolumeID>(_decoder->get(aCellID, fPhiId));
+    return static_cast<int>(Phi);
+}
+
+int SCEPCalSegmentation::Depth(const CellID& aCellID) const {
+    VolumeID Depth = static_cast<VolumeID>(_decoder->get(aCellID, fDepthId));
+    return static_cast<int>(Depth);
+}
+
+int SCEPCalSegmentation::getLast32bits(const CellID& aCellID) const {
+    CellID aId64 = aCellID >> sizeof(int)*CHAR_BIT;
+    int aId32 = (int)aId64;
+    return aId32;
+}
+
+CellID SCEPCalSegmentation::convertLast32to64(const int aId32) const {
+    CellID aId64 = (CellID)aId32;
+    aId64 <<= sizeof(int)*CHAR_BIT;
+    return aId64;
+}
+
+}
+}

--- a/detectorSegmentations/src/SCEPCalSegmentationHandle.cpp
+++ b/detectorSegmentations/src/SCEPCalSegmentationHandle.cpp
@@ -1,0 +1,4 @@
+#include "detectorSegmentations/SCEPCalSegmentationHandle.h"
+#include "DD4hep/detail/Handle.inl"
+
+DD4HEP_INSTANTIATE_HANDLE_UNNAMED(dd4hep::DDSegmentation::SCEPCalSegmentation);

--- a/detectorSegmentations/src/plugins/SegmentationFactories.cpp
+++ b/detectorSegmentations/src/plugins/SegmentationFactories.cpp
@@ -34,3 +34,7 @@ DECLARE_SEGMENTATION(GridDRcalo_k4geo, create_segmentation<dd4hep::DDSegmentatio
 
 #include "detectorSegmentations/FCCSWEndcapTurbine_k4geo.h"
 DECLARE_SEGMENTATION(FCCSWEndcapTurbine_k4geo, create_segmentation<dd4hep::DDSegmentation::FCCSWEndcapTurbine_k4geo>)
+
+#include "detectorSegmentations/SCEPCalSegmentation.h"
+DECLARE_SEGMENTATION(SCEPCalSegmentation, create_segmentation<dd4hep::DDSegmentation::SCEPCalSegmentation>)
+

--- a/plugins/Geant4Output2EDM4hepDRCrystalHit.cpp
+++ b/plugins/Geant4Output2EDM4hepDRCrystalHit.cpp
@@ -1,0 +1,503 @@
+//===============================
+// Author: Wonyong Chung
+//         Princeton University
+//===============================
+#ifndef DD4HEP_DDG4_Geant4Output2EDM4hepDRCrystalHit_H
+#define DD4HEP_DDG4_Geant4Output2EDM4hepDRCrystalHit_H
+#include <DD4hep/Detector.h>
+#include <DDG4/EventParameters.h>
+#include <DDG4/Geant4OutputAction.h>
+#include <DDG4/RunParameters.h>
+#include <edm4hep/MCParticleCollection.h>
+#include <edm4hep/SimTrackerHitCollection.h>
+#include <edm4hep/CaloHitContributionCollection.h>
+#include <edm4dr/SimDRCalorimeterHitCollection.h>
+#include "detectorSegmentations/DRCrystalHit.h"
+#include <podio/Frame.h>
+#include <podio/ROOTFrameWriter.h>
+#include <podio/podioVersion.h>
+
+namespace dd4hep {
+
+  class ComponentCast;
+
+  namespace sim {
+
+    class  Geant4ParticleMap;
+
+    class Geant4Output2EDM4hepDRCrystalHit : public Geant4OutputAction  {
+    protected:
+      using writer_t = podio::ROOTFrameWriter;
+      using stringmap_t = std::map< std::string, std::string >;
+      using trackermap_t = std::map< std::string, edm4hep::SimTrackerHitCollection >;
+      using calorimeterpair_t = std::pair< edm4dr::SimDRCalorimeterHitCollection, edm4hep::CaloHitContributionCollection >;
+      using calorimetermap_t = std::map< std::string, calorimeterpair_t >;
+
+      std::unique_ptr<writer_t>     m_file  { };
+      podio::Frame                  m_frame { };
+      edm4hep::MCParticleCollection m_particles { };
+      trackermap_t                  m_trackerHits;
+      calorimetermap_t              m_calorimeterHits;
+      stringmap_t                   m_runHeader;
+      stringmap_t                   m_eventParametersInt;
+      stringmap_t                   m_eventParametersFloat;
+      stringmap_t                   m_eventParametersString;
+      stringmap_t                   m_cellIDEncodingStrings{};
+      std::string                   m_section_name      { "events" };
+      int                           m_runNo             { 0 };
+      int                           m_runNumberOffset   { 0 };
+      int                           m_eventNo           { 0 };
+      int                           m_eventNumberOffset { 0 };
+      bool                          m_filesByRun        { false };
+      
+      void saveParticles(Geant4ParticleMap* particles);
+      void saveFileMetaData();
+
+    public:
+      Geant4Output2EDM4hepDRCrystalHit(Geant4Context* ctxt, const std::string& nam);
+      virtual ~Geant4Output2EDM4hepDRCrystalHit();
+      virtual void beginRun(const G4Run* run);
+      virtual void endRun(const G4Run* run);
+      virtual void saveRun(const G4Run* run);
+      virtual void saveEvent( OutputContext<G4Event>& ctxt);
+      virtual void saveCollection( OutputContext<G4Event>& ctxt, G4VHitsCollection* collection);
+      virtual void commit( OutputContext<G4Event>& ctxt);
+      virtual void begin(const G4Event* event);
+    protected:
+      template <typename T>
+      void saveEventParameters(const std::map<std::string, std::string >& parameters)   {
+        for(const auto& p : parameters)   {
+          info("Saving event parameter: %-32s = %s", p.first.c_str(), p.second.c_str());
+          m_frame.putParameter(p.first, p.second);
+        }
+      }
+    };
+    
+    template <> void EventParameters::extractParameters(podio::Frame& frame)   {
+      for(auto const& p: this->intParameters()) {
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
+        frame.putParameter(p.first, p.second);
+      }
+      for(auto const& p: this->fltParameters()) {
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
+        frame.putParameter(p.first, p.second);
+      }
+      for(auto const& p: this->strParameters()) {
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
+        frame.putParameter(p.first, p.second);
+      }
+      #if podio_VERSION_MAJOR > 0 || podio_VERSION_MINOR > 16 || podio_VERSION_PATCH > 2
+      for (auto const& p: this->dblParameters()) {
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
+        frame.putParameter(p.first, p.second);
+      }
+      #endif
+    }
+
+    template <> void RunParameters::extractParameters(podio::Frame& frame)   {
+      for(auto const& p: this->intParameters()) {
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving run parameter: %s", p.first.c_str());
+        frame.putParameter(p.first, p.second);
+      }
+      for(auto const& p: this->fltParameters()) {
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving run parameter: %s", p.first.c_str());
+        frame.putParameter(p.first, p.second);
+      }
+      for(auto const& p: this->strParameters()) {
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving run parameter: %s", p.first.c_str());
+        frame.putParameter(p.first, p.second);
+      }
+      #if podio_VERSION_MAJOR > 0 || podio_VERSION_MINOR > 16 || podio_VERSION_PATCH > 2
+      for (auto const& p: this->dblParameters()) {
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving run parameter: %s", p.first.c_str());
+        frame.putParameter(p.first, p.second);
+      }
+      #endif
+    }
+
+  }   
+}     
+#endif
+
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/VolumeManager.h>
+
+#include <DDG4/Geant4HitCollection.h>
+#include <DDG4/Geant4DataConversion.h>
+#include <DDG4/Geant4SensDetAction.h>
+#include <DDG4/Geant4Context.h>
+#include <DDG4/Geant4Particle.h>
+#include <DDG4/Geant4Data.h>
+
+#include <G4Threading.hh>
+#include <G4AutoLock.hh>
+#include <G4Version.hh>
+#include <G4ParticleDefinition.hh>
+#include <G4VProcess.hh>
+#include <G4Event.hh>
+#include <G4Run.hh>
+#include <CLHEP/Units/SystemOfUnits.h>
+#include <edm4hep/EventHeaderCollection.h>
+
+using namespace dd4hep::sim;
+using namespace dd4hep;
+using namespace SCEPCal;
+
+namespace {
+  G4Mutex action_mutex = G4MUTEX_INITIALIZER;
+}
+
+#include <DDG4/Factories.h>
+DECLARE_GEANT4ACTION(Geant4Output2EDM4hepDRCrystalHit)
+
+Geant4Output2EDM4hepDRCrystalHit::Geant4Output2EDM4hepDRCrystalHit(Geant4Context* ctxt, const std::string& nam)
+: Geant4OutputAction(ctxt,nam), m_runNo(0), m_runNumberOffset(0), m_eventNumberOffset(0)
+{
+  declareProperty("RunHeader",             m_runHeader);
+  declareProperty("EventParametersInt",    m_eventParametersInt);
+  declareProperty("EventParametersFloat",  m_eventParametersFloat);
+  declareProperty("EventParametersString", m_eventParametersString);
+  declareProperty("RunNumberOffset",       m_runNumberOffset);
+  declareProperty("EventNumberOffset",     m_eventNumberOffset);
+  declareProperty("SectionName",           m_section_name);
+  declareProperty("FilesByRun",            m_filesByRun);
+  info("Writer is now instantiated ..." );
+  InstanceCount::increment(this);
+}
+
+Geant4Output2EDM4hepDRCrystalHit::~Geant4Output2EDM4hepDRCrystalHit()  {
+  G4AutoLock protection_lock(&action_mutex);
+  m_file.reset();
+  InstanceCount::decrement(this);
+}
+
+void Geant4Output2EDM4hepDRCrystalHit::beginRun(const G4Run* run)  {
+  G4AutoLock protection_lock(&action_mutex);
+  std::string fname = m_output;
+  m_runNo = run->GetRunID();
+  if ( m_filesByRun )    {
+    std::size_t idx = m_output.rfind(".");
+    if ( idx != std::string::npos )   {
+      fname = m_output.substr(0, idx) + _toString(m_runNo, ".run%08d") + m_output.substr(idx);
+    }
+  }
+  if ( !fname.empty() )   {
+    m_file = std::make_unique<podio::ROOTFrameWriter>(fname);
+    if ( !m_file )   {
+      fatal("+++ Failed to open output file: %s", fname.c_str());
+    }
+    printout( INFO, "Geant4Output2EDM4hepDRCrystalHit" ,"Opened %s for output", fname.c_str() ) ;
+  }
+}
+
+void Geant4Output2EDM4hepDRCrystalHit::endRun(const G4Run* run)  {
+  saveRun(run);
+  saveFileMetaData();
+  if ( m_file )   {
+    m_file->finish();
+    m_file.reset();
+  }
+}
+
+void Geant4Output2EDM4hepDRCrystalHit::saveFileMetaData() {
+  podio::Frame metaFrame{};
+  for (const auto& [name, encodingStr] : m_cellIDEncodingStrings) {
+    metaFrame.putParameter(name + "__CellIDEncoding", encodingStr);
+  }
+
+  m_file->writeFrame(metaFrame, "metadata");
+}
+
+void Geant4Output2EDM4hepDRCrystalHit::commit( OutputContext<G4Event>& /* ctxt */)   {
+  if ( m_file )   {
+    G4AutoLock protection_lock(&action_mutex);
+    m_frame.put( std::move(m_particles), "MCParticles");
+    for (auto it = m_trackerHits.begin(); it != m_trackerHits.end(); ++it)   {
+      m_frame.put( std::move(it->second), it->first);
+    }
+    for (auto& [colName, calorimeterHits] : m_calorimeterHits) {
+      m_frame.put( std::move(calorimeterHits.first), colName);
+      m_frame.put( std::move(calorimeterHits.second), colName + "Contributions");
+    }
+    m_file->writeFrame(m_frame, m_section_name);
+    m_particles.clear();
+    m_trackerHits.clear();
+    m_calorimeterHits.clear();
+    m_frame = {};
+    return;
+  }
+  except("+++ Failed to write output file. [Stream is not open]");
+}
+
+void Geant4Output2EDM4hepDRCrystalHit::saveRun(const G4Run* run)   {
+  G4AutoLock protection_lock(&action_mutex);
+  podio::Frame runHeader  {};
+  for (const auto& [key, value] : m_runHeader)
+    runHeader.putParameter(key, value);
+
+  m_runNo = m_runNumberOffset > 0 ? m_runNumberOffset + run->GetRunID() : run->GetRunID();
+  runHeader.putParameter("runNumber", m_runNo);
+  runHeader.putParameter("GEANT4Version", G4Version);
+  runHeader.putParameter("DD4hepVersion", versionString());
+  runHeader.putParameter("detectorName", context()->detectorDescription().header().name());
+
+  RunParameters* parameters = context()->run().extension<RunParameters>(false);
+  if ( parameters ) {
+    parameters->extractParameters(runHeader);
+  }
+
+  m_file->writeFrame(runHeader, "runs");
+}
+
+void Geant4Output2EDM4hepDRCrystalHit::begin(const G4Event* event)  {
+  m_eventNo = event->GetEventID();
+  m_frame = {};
+  m_particles = {};
+  m_trackerHits.clear();
+  m_calorimeterHits.clear();
+}
+
+void Geant4Output2EDM4hepDRCrystalHit::saveParticles(Geant4ParticleMap* particles)    {
+  typedef detail::ReferenceBitMask<const int> PropertyMask;
+  typedef Geant4ParticleMap::ParticleMap ParticleMap;
+  const ParticleMap& pm = particles->particleMap;
+
+  m_particles.clear();
+  if ( pm.size() > 0 )  {
+    size_t cnt = 0;
+    std::map<int,int> p_ids;
+    std::vector<const Geant4Particle*> p_part;
+    p_part.reserve(pm.size());
+    for (const auto& iParticle : pm) {
+      int id = iParticle.first;
+      const Geant4ParticleHandle p = iParticle.second;
+      PropertyMask mask(p->status);
+      const G4ParticleDefinition* def = p.definition();
+      auto mcp = m_particles.create();
+      mcp.setPDG(p->pdgID);
+
+      float ps_fa[3] = {float(p->psx/CLHEP::GeV),float(p->psy/CLHEP::GeV),float(p->psz/CLHEP::GeV)};
+      mcp.setMomentum( ps_fa );
+
+      float pe_fa[3] = {float(p->pex/CLHEP::GeV),float(p->pey/CLHEP::GeV),float(p->pez/CLHEP::GeV)};
+      mcp.setMomentumAtEndpoint( pe_fa );
+
+      double vs_fa[3] = { p->vsx/CLHEP::mm, p->vsy/CLHEP::mm, p->vsz/CLHEP::mm } ;
+      mcp.setVertex( vs_fa );
+
+      double ve_fa[3] = { p->vex/CLHEP::mm, p->vey/CLHEP::mm, p->vez/CLHEP::mm } ;
+      mcp.setEndpoint( ve_fa );
+
+      mcp.setTime(p->time/CLHEP::ns);
+      mcp.setMass(p->mass/CLHEP::GeV);
+      mcp.setCharge(def ? def->GetPDGCharge() : 0); 
+
+      mcp.setGeneratorStatus(0);
+      if( p->genStatus ) {
+        mcp.setGeneratorStatus( p->genStatus ) ;
+      } else {
+        if ( mask.isSet(G4PARTICLE_GEN_STABLE) )             mcp.setGeneratorStatus(1);
+        else if ( mask.isSet(G4PARTICLE_GEN_DECAYED) )       mcp.setGeneratorStatus(2);
+        else if ( mask.isSet(G4PARTICLE_GEN_DOCUMENTATION) ) mcp.setGeneratorStatus(3);
+        else if ( mask.isSet(G4PARTICLE_GEN_BEAM) )          mcp.setGeneratorStatus(4);
+        else if ( mask.isSet(G4PARTICLE_GEN_OTHER) )         mcp.setGeneratorStatus(9);
+      }
+
+      mcp.setCreatedInSimulation(         mask.isSet(G4PARTICLE_SIM_CREATED) );
+      mcp.setBackscatter(                 mask.isSet(G4PARTICLE_SIM_BACKSCATTER) );
+      mcp.setVertexIsNotEndpointOfParent( mask.isSet(G4PARTICLE_SIM_PARENT_RADIATED) );
+      mcp.setDecayedInTracker(            mask.isSet(G4PARTICLE_SIM_DECAY_TRACKER) );
+      mcp.setDecayedInCalorimeter(        mask.isSet(G4PARTICLE_SIM_DECAY_CALO) );
+      mcp.setHasLeftDetector(             mask.isSet(G4PARTICLE_SIM_LEFT_DETECTOR) );
+      mcp.setStopped(                     mask.isSet(G4PARTICLE_SIM_STOPPED) );
+      mcp.setOverlay(                     false );
+
+      if( mcp.isCreatedInSimulation() )
+        mcp.setGeneratorStatus( 0 )  ;
+
+      mcp.setSpin(p->spin);
+      mcp.setColorFlow(p->colorFlow);
+
+      p_ids[id] = cnt++;
+      p_part.push_back(p);
+    }
+
+    for(size_t i=0; i < p_ids.size(); ++i)   {
+      const Geant4Particle* p = p_part[i];
+      auto q = m_particles[i];
+
+      for (const auto& idau : p->daughters) {
+        const auto k = p_ids.find(idau);
+        if (k == p_ids.end()) {
+          fatal("+++ Particle %d: FAILED to find daughter with ID:%d",p->id,idau);
+          continue;
+        }
+        int iqdau = (*k).second;
+        auto qdau = m_particles[iqdau];
+        q.addToDaughters(qdau);
+      }
+
+      for (const auto& ipar : p->parents) {
+        if (ipar >= 0) { 
+          const auto k = p_ids.find(ipar);
+          if (k == p_ids.end()) {
+            fatal("+++ Particle %d: FAILED to find parent with ID:%d",p->id,ipar);
+            continue;
+          }
+          int iqpar = (*k).second;
+          auto qpar = m_particles[iqpar];
+          q.addToParents(qpar);
+        }
+      }
+    }
+  }
+}
+
+void Geant4Output2EDM4hepDRCrystalHit::saveEvent(OutputContext<G4Event>& ctxt)  {
+  EventParameters* parameters = context()->event().extension<EventParameters>(false);
+  int runNumber(0), eventNumber(0);
+  const int eventNumberOffset(m_eventNumberOffset > 0 ? m_eventNumberOffset : 0);
+  const int runNumberOffset(m_runNumberOffset > 0 ? m_runNumberOffset : 0);
+  std::optional<double> eventWeight{0};
+  if ( parameters ) {
+    runNumber = parameters->runNumber() + runNumberOffset;
+    eventNumber = parameters->eventNumber() + eventNumberOffset;
+    parameters->extractParameters(m_frame);
+    #if podio_VERSION_MAJOR > 0 || podio_VERSION_MINOR > 16 || podio_VERSION_PATCH > 2
+    eventWeight = m_frame.getParameter<double>("EventWeights");
+    #endif
+  } else {
+    runNumber = m_runNo + runNumberOffset;
+    eventNumber = ctxt.context->GetEventID() + eventNumberOffset;
+  }
+  printout(INFO,"Geant4Output2EDM4hepDRCrystalHit","+++ Saving EDM4hep event %d run %d.", eventNumber, runNumber);
+
+  edm4hep::EventHeaderCollection header_collection;
+  auto header = header_collection.create();
+  header.setRunNumber(runNumber);
+  header.setEventNumber(eventNumber);
+  header.setWeight(eventWeight.value());
+  header.setTimeStamp( std::time(nullptr) ) ;
+  m_frame.put( std::move(header_collection), "EventHeader");
+
+  saveEventParameters<int>(m_eventParametersInt);
+  saveEventParameters<float>(m_eventParametersFloat);
+  saveEventParameters<std::string>(m_eventParametersString);
+
+  Geant4ParticleMap* part_map = context()->event().extension<Geant4ParticleMap>(false);
+  if ( part_map )   {
+    print("+++ Saving %d EDM4hep particles....",int(part_map->particleMap.size()));
+    if ( part_map->particleMap.size() > 0 )  {
+      saveParticles(part_map);
+    }
+  }
+}
+
+struct LazyEncodingExtraction {
+  LazyEncodingExtraction(Geant4HitCollection* coll) : m_coll(coll) {}
+  operator std::string() const {
+    const auto* sd = m_coll->sensitive();
+    return dd4hep::sim::Geant4ConversionHelper::encoding(sd->sensitiveDetector());
+  }
+private:
+  Geant4HitCollection* m_coll{nullptr};
+};
+
+void Geant4Output2EDM4hepDRCrystalHit::saveCollection(OutputContext<G4Event>& /*ctxt*/, G4VHitsCollection* collection)  {
+  
+  Geant4HitCollection* coll = dynamic_cast<Geant4HitCollection*>(collection);
+
+  std::string colName = collection->GetName();
+  if( coll == nullptr ){
+    error(" no Geant4HitCollection:  %s ", colName.c_str());
+    return ;
+  }
+
+  size_t nhits = collection->GetSize();
+
+  Geant4ParticleMap* pm = context()->event().extension<Geant4ParticleMap>(false);
+  debug("+++ Saving EDM4hep collection %s with %d entries.", colName.c_str(), int(nhits));
+
+  m_cellIDEncodingStrings.try_emplace(colName, LazyEncodingExtraction{coll});
+
+  if( typeid( Geant4Tracker::Hit ) == coll->type().type()  ){
+    auto& hits = m_trackerHits[colName];
+    for(unsigned i=0 ; i < nhits ; ++i){
+      auto sth = hits->create();
+      const Geant4Tracker::Hit* hit = coll->hit(i);
+      const Geant4Tracker::Hit::Contribution& t = hit->truth;
+      int   trackID   = pm->particleID(t.trackID);
+      auto  mcp       = m_particles.at(trackID);
+      const auto& mom = hit->momentum;
+      const auto& pos = hit->position;
+      edm4hep::Vector3f();
+      sth.setCellID( hit->cellID ) ;
+      sth.setEDep(hit->energyDeposit/CLHEP::GeV);
+      sth.setPathLength(hit->length/CLHEP::mm);
+      sth.setTime(hit->truth.time/CLHEP::ns);
+      sth.setMCParticle(mcp);
+      sth.setPosition( {pos.x()/CLHEP::mm, pos.y()/CLHEP::mm, pos.z()/CLHEP::mm} );
+      sth.setMomentum( {float(mom.x()/CLHEP::GeV),float(mom.y()/CLHEP::GeV),float(mom.z()/CLHEP::GeV)} );
+      auto particleIt = pm->particles().find(trackID);
+      if( ( particleIt != pm->particles().end()) ){
+        sth.setProducedBySecondary( (particleIt->second->originalG4ID != t.trackID) );
+      }
+    }
+  }
+  else if( typeid( DRCrystalHit ) == coll->type().type() ){
+    
+    Geant4Sensitive* sd = coll->sensitive();
+    int hit_creation_mode = sd->hitCreationMode();
+
+    auto& hits = m_calorimeterHits[colName];
+    
+    for(unsigned i=0 ; i < nhits ; ++i){
+    
+      auto sch = hits.first->create();
+      const DRCrystalHit* hit = coll->hit(i);
+
+      const auto& pos = hit->position;
+      edm4hep::Vector3f hitpos( float(pos.x()/CLHEP::mm), float(pos.y()/CLHEP::mm), float(pos.z()/CLHEP::mm) );
+
+      sch.setCellID( hit->cellID );
+      sch.setPosition( hitpos );
+      sch.setEta( hit->eta );
+      sch.setPhi( hit->phi );
+      sch.setDepth( hit->depth );
+      sch.setSystem( hit->system );
+      sch.setEnergy( hit->energyDeposit/CLHEP::GeV );
+
+      sch.setNcerenkov( hit->ncerenkov );
+      sch.setNscintillator( hit->nscintillator );
+
+      sch.setNwavelen_cer( hit->nwavelen_cer );
+      sch.setNwavelen_scint( hit->nwavelen_scint );
+      
+      sch.setNtime_cer( hit->ntime_cer );
+      sch.setNtime_scint( hit->ntime_scint );
+
+      for(auto ci=hit->truth.begin(); ci != hit->truth.end(); ++ci){
+
+        auto sCaloHitCont = hits.second->create();
+        sch.addToContributions( sCaloHitCont );
+
+        const Geant4HitData::MonteCarloContrib& c = *ci;
+    
+        int trackID = pm->particleID(c.trackID);
+        auto mcp = m_particles.at(trackID);
+    
+        sCaloHitCont.setEnergy( c.deposit/CLHEP::GeV );
+        sCaloHitCont.setTime( c.time/CLHEP::ns );
+        sCaloHitCont.setParticle( mcp );
+        
+        edm4hep::Vector3f p(c.x/CLHEP::mm, c.y/CLHEP::mm, c.z/CLHEP::mm);
+    
+        sCaloHitCont.setPDG( c.pdgID );
+        sCaloHitCont.setStepPosition( p );
+      }
+    }
+  } 
+  else {
+    error("+++ unknown type in Geant4HitCollection %s ", coll->type().type().name());
+  }
+}

--- a/plugins/Geant4Output2EDM4hepDRCrystalHit.cpp
+++ b/plugins/Geant4Output2EDM4hepDRCrystalHit.cpp
@@ -11,7 +11,7 @@
 #include <edm4hep/MCParticleCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/CaloHitContributionCollection.h>
-#include <edm4dr/SimDRCalorimeterHitCollection.h>
+#include <edm4hep/SimDRCalorimeterHitCollection.h>
 #include "detectorSegmentations/DRCrystalHit.h"
 #include <podio/Frame.h>
 #include <podio/ROOTFrameWriter.h>
@@ -30,7 +30,7 @@ namespace dd4hep {
       using writer_t = podio::ROOTFrameWriter;
       using stringmap_t = std::map< std::string, std::string >;
       using trackermap_t = std::map< std::string, edm4hep::SimTrackerHitCollection >;
-      using calorimeterpair_t = std::pair< edm4dr::SimDRCalorimeterHitCollection, edm4hep::CaloHitContributionCollection >;
+      using calorimeterpair_t = std::pair< edm4hep::SimDRCalorimeterHitCollection, edm4hep::CaloHitContributionCollection >;
       using calorimetermap_t = std::map< std::string, calorimeterpair_t >;
 
       std::unique_ptr<writer_t>     m_file  { };

--- a/plugins/SCEPCalSDActionDRCrystalHit.cpp
+++ b/plugins/SCEPCalSDActionDRCrystalHit.cpp
@@ -1,0 +1,127 @@
+//===============================
+// Author: Wonyong Chung
+//         Princeton University
+//===============================
+#include "detectorSegmentations/DRCrystalHit.h"
+#include "detectorSegmentations/SCEPCalSegmentation.h"
+#include "DDG4/Geant4SensDetAction.inl"
+#include "DDG4/Factories.h"
+
+namespace SCEPCal {
+  G4double convertEvtoNm(G4double energy)
+  {
+    return 1239.84187/energy*1000.;
+  }
+  class SegmentedCrystalCalorimeterSD_DRHit {
+    public:
+      typedef DRCrystalHit Hit;
+  };
+}
+
+namespace dd4hep {
+  namespace sim {
+    using namespace SCEPCal;
+    
+    template <> void Geant4SensitiveAction<SegmentedCrystalCalorimeterSD_DRHit>::defineCollections()    {
+      m_collectionID = declareReadoutFilteredCollection<SegmentedCrystalCalorimeterSD_DRHit::Hit>();
+    }
+    template <> bool 
+    Geant4SensitiveAction<SegmentedCrystalCalorimeterSD_DRHit>::process(const G4Step* step,G4TouchableHistory* /*hist*/ ) {
+      G4double edep = step->GetTotalEnergyDeposit();
+      G4StepPoint *thePrePoint = step->GetPreStepPoint();
+      G4StepPoint *thePostPoint = step->GetPostStepPoint();
+      G4TouchableHandle  thePreStepTouchable = thePrePoint->GetTouchableHandle();
+      G4VPhysicalVolume *thePrePV = thePrePoint->GetPhysicalVolume();
+      G4double pretime = thePrePoint->GetGlobalTime();
+      G4VPhysicalVolume *thePostPV = thePostPoint->GetPhysicalVolume();
+      G4double posttime = thePostPoint->GetGlobalTime();
+      G4String thePrePVName = "";
+      if (thePrePV) thePrePVName = thePrePV->GetName();
+      G4String thePostPVName = "";
+      if (thePostPV) thePostPVName = thePostPV->GetName();
+
+      Geant4StepHandler    h(step);
+      Geant4HitData::MonteCarloContrib contrib = Geant4HitData::extractContribution(step);
+      Geant4HitCollection* coll    = collection(m_collectionID);
+
+      dd4hep::Segmentation* _geoSeg = &m_segmentation;
+      auto segmentation=dynamic_cast<dd4hep::DDSegmentation::SCEPCalSegmentation *>(_geoSeg->segmentation());
+      auto copyNum64 = segmentation->convertFirst32to64(thePreStepTouchable->GetCopyNumber(0));
+      int cellID = (int)copyNum64;
+
+      SegmentedCrystalCalorimeterSD_DRHit::Hit* hit = coll->findByKey<SegmentedCrystalCalorimeterSD_DRHit::Hit>(cellID);
+      if(!hit) {    
+        DDSegmentation::Vector3D pos = segmentation->myPosition(copyNum64);    
+        Position global(pos.x(),pos.y(),pos.z());
+        hit = new SegmentedCrystalCalorimeterSD_DRHit::Hit(global);
+        hit->cellID = cellID;
+        hit->system = segmentation->System(copyNum64);
+        hit->eta = segmentation->Eta(copyNum64);
+        hit->phi = segmentation->Phi(copyNum64);
+        hit->depth = segmentation->Depth(copyNum64);
+        coll->add(cellID, hit);
+      }
+      G4Track * track =  step->GetTrack();
+      if(track->GetDefinition()==G4OpticalPhoton::OpticalPhotonDefinition()) {
+        float wavelength=convertEvtoNm(track->GetTotalEnergy()/eV);
+        int ibin=-1;
+        float binsize=(hit->wavelen_max-hit->wavelen_min)/hit->nbins;
+        ibin = (wavelength-hit->wavelen_min)/binsize;
+        float avgarrival=(pretime+posttime)/2.;
+        int jbin=-1;
+        float tbinsize=(hit->time_max-hit->time_min)/hit->nbins;
+        jbin = (avgarrival-hit->time_min)/tbinsize;
+
+        int phstep = track->GetCurrentStepNumber();
+
+        if (track->GetCreatorProcess()->G4VProcess::GetProcessName()=="CerenkovPhys") {
+          std::string amedia = ((track->GetMaterial())->GetName());
+          if(amedia.find("Silicon")!=std::string::npos)
+          {
+            if(phstep>1) {
+              hit->ncerenkov+=1;
+              if(ibin>-1 && ibin<hit->nbins) ((hit->nwavelen_cer).at(ibin)) +=1;
+              if(jbin>-1 && jbin<hit->nbins) ((hit->ntime_cer).at(jbin)) +=1;
+            }
+            track->SetTrackStatus(fStopAndKill);
+          }
+          else {
+            if(phstep==1) {
+              hit->ncerenkov+=1;
+              if(ibin>-1 && ibin<hit->nbins) ((hit->nwavelen_cer).at(ibin)) +=1;
+              if(jbin>-1 && jbin<hit->nbins) ((hit->ntime_cer).at(jbin)) +=1;
+            }
+          }
+        } 
+        else if (track->GetCreatorProcess()->G4VProcess::GetProcessName()=="ScintillationPhys") {
+          std::string amedia = ((track->GetMaterial())->GetName());
+          if(amedia.find("Silicon")!=std::string::npos)
+          {
+            if(phstep>1) {
+              hit->nscintillator+=1;
+              if((ibin>-1)&&(ibin<hit->nbins)) ((hit->nwavelen_scint).at(ibin))+=1;
+              if(jbin>-1&&jbin<hit->nbins) ((hit->ntime_scint).at(jbin))+=1;
+            }
+            track->SetTrackStatus(fStopAndKill);
+          }
+          else {
+            if((track->GetCurrentStepNumber()==1)) {
+              hit->nscintillator+=1; 
+              if((ibin>-1)&&(ibin<hit->nbins)) ((hit->nwavelen_scint).at(ibin))+=1;
+              if(jbin>-1&&jbin<hit->nbins) ((hit->ntime_scint).at(jbin))+=1;
+            }
+          }
+        }
+      }
+      hit->truth.emplace_back(contrib);
+      hit->energyDeposit+=edep;
+      mark(h.track);
+      return true;
+    }
+  }
+}
+
+namespace dd4hep { namespace sim {
+    typedef Geant4SensitiveAction<SegmentedCrystalCalorimeterSD_DRHit> SCEPCalSDAction_DRHit;
+  }}
+DECLARE_GEANT4SENSITIVE(SCEPCalSDAction_DRHit)


### PR DESCRIPTION

BEGINRELEASENOTES
- Added geometry, segmentation, sensitive action, and hit classes for the Segmented Crystal ECAL (SCEPCal).

ENDRELEASENOTES

Hi, I have been developing a full simulation for a segmented crystal ECAL (CalVision/MAXICC collaborations) and am now submitting PRs to get the simulation into key4hep.
I should note that I needed to make a new datatype to store the scintllation/cerenkov hit information for dual-readout. So far I have simply extended the edm4hep schema with a custom 'edm4dr' schema in the simulation repo, but to merge into k4geo, it seems like it would be a better option (or the only one) to have this new schema merged into the main edm4hep. I've opened a PR to do that here: https://github.com/key4hep/EDM4hep/pull/380
Please let me know if I should take a different approach or if you have suggestions or changes I should make.
Thanks,
Wonyong