### PR TITLE
DCH patch

### DIFF
--- a/detector/tracker/DriftChamber_o1_v02.cpp
+++ b/detector/tracker/DriftChamber_o1_v02.cpp
@@ -578,7 +578,7 @@ dd4hep::Solid CompositeTT(double twist_angle,  double cell_rin_z0,  double cell_
   // ROOT hyperboloid require stereoangles stin and stout
   //-- stereo for rmin
   double stin  = DCH_i.stereoangle_z0(cell_rin_z0);
-  //-- stereo for rour
+  //-- stereo for rout
   double stout = DCH_i.stereoangle_z0(cell_rout_z0);
 
   // make hyperboloid longer, later intersection with gtrap will lead to proper length

--- a/detector/tracker/DriftChamber_o1_v02.cpp
+++ b/detector/tracker/DriftChamber_o1_v02.cpp
@@ -25,6 +25,8 @@ using DCH_length_t = dd4hep::rec::DCH_info_struct::DCH_length_t;
 using DCH_angle_t  = dd4hep::rec::DCH_info_struct::DCH_angle_t;
 using DCH_layer    = dd4hep::rec::DCH_info_struct::DCH_layer;
 
+dd4hep::Solid CompositeTT(double twist_angle,  double cell_rin_z0,  double cell_rout_z0, double dz, double dphi, const dd4hep::rec::DCH_info & DCH_i);
+
 /// Function to build DCH
 static dd4hep::Ref_t create_DCH_o1_v02(dd4hep::Detector &desc, dd4hep::xml::Handle_t handle, dd4hep::SensitiveDetector sens)
 {
@@ -75,6 +77,7 @@ static dd4hep::Ref_t create_DCH_o1_v02(dd4hep::Detector &desc, dd4hep::xml::Hand
     }
 
     bool debugGeometry = detElem.hasChild(_Unicode(debugGeometry));
+    bool useG4TT = detElem.hasChild(_Unicode(useG4TT));
     auto gasElem    = detElem.child("gas");
     auto gasvolMat  = desc.material(gasElem.attr<std::string>(_Unicode(material)));
     auto gasvolVis  = desc.visAttributes(gasElem.attr<std::string>(_Unicode(vis)));
@@ -285,7 +288,9 @@ static dd4hep::Ref_t create_DCH_o1_v02(dd4hep::Detector &desc, dd4hep::xml::Hand
         DCH_length_t cell_rout_zLhalf  = DCH_i->Radius_zLhalf(cell_rout_z0);
         DCH_length_t cell_dz           = DCH_i->Lhalf;
         DCH_angle_t cell_phi_width     = phi_step - safety_phi_interspace;
-        dd4hep::TwistedTube cell_s( cell_twistangle, cell_rin_zLhalf, cell_rout_zLhalf, cell_dz, 1, cell_phi_width);
+        dd4hep::Solid cell_s;
+        if( useG4TT ) cell_s = dd4hep::TwistedTube ( cell_twistangle, cell_rin_zLhalf, cell_rout_zLhalf, cell_dz, 1, cell_phi_width);
+        else          cell_s = CompositeTT(cell_twistangle, cell_rin_z0, cell_rout_z0, cell_dz, cell_phi_width, *DCH_i);
 
         // initialize cell volume
         std::string cell_name = detName+"_layer"+std::to_string(ilayer)+"_cell";
@@ -508,6 +513,81 @@ static dd4hep::Ref_t create_DCH_o1_v02(dd4hep::Detector &desc, dd4hep::xml::Hand
 
     return det;
 
+}
+
+inline double Circumradius(double Apothem, double dphi){return Apothem/cos(0.5*dphi/dd4hep::rad);}
+
+dd4hep::Solid CompositeTT(double twist_angle,  double cell_rin_z0,  double cell_rout_z0, double dz, double dphi, const dd4hep::rec::DCH_info & DCH_i)
+{
+
+  //----------------- G. trapezoid -------------
+  // make generic trapezoid bigger, later intersected with hyperboloid of proper radii
+  double rmin_zLhalf = DCH_i.Radius_zLhalf(cell_rin_z0 );
+  double rout_zLhalf = DCH_i.Radius_zLhalf(cell_rout_z0);
+  double trap_rin    = 0.9*rmin_zLhalf;
+  double trap_rout   = Circumradius(1.1*rout_zLhalf, dphi);
+
+  double poly_angle = dphi/2;
+  double twist_angle_half = twist_angle/2.;
+  // change sign, so the final shape has the same orientation as G4 twisted tube
+  twist_angle_half*= -1;
+
+  // define points of 8 genenric trapezoid
+  struct point2d
+  {
+    double x = {0.0};
+    double y = {0.0};
+  };
+
+  struct face
+  {
+    point2d A;
+    point2d B;
+    point2d C;
+    point2d D;
+  };
+
+  face fZneg;
+  face fZpos;
+
+  fZpos.A = { trap_rin*cos(  poly_angle + twist_angle_half ), trap_rin*sin(  poly_angle + twist_angle_half ) };
+  fZpos.B = { trap_rin*cos( -poly_angle + twist_angle_half ), trap_rin*sin( -poly_angle + twist_angle_half ) };
+
+  fZneg.A = { trap_rin*cos(  poly_angle - twist_angle_half ), trap_rin*sin(  poly_angle - twist_angle_half ) };
+  fZneg.B = { trap_rin*cos( -poly_angle - twist_angle_half ), trap_rin*sin( -poly_angle - twist_angle_half ) };
+
+  fZpos.C = { trap_rout*cos(  poly_angle + twist_angle_half ), trap_rout*sin(  poly_angle + twist_angle_half ) };
+  fZpos.D = { trap_rout*cos( -poly_angle + twist_angle_half ), trap_rout*sin( -poly_angle + twist_angle_half ) };
+
+  fZneg.C = { trap_rout*cos(  poly_angle - twist_angle_half ), trap_rout*sin(  poly_angle - twist_angle_half ) };
+  fZneg.D = { trap_rout*cos( -poly_angle - twist_angle_half ), trap_rout*sin( -poly_angle - twist_angle_half ) };
+
+  std::vector<double> vertices_array = {  fZpos.B.x, fZpos.B.y,
+                                          fZpos.A.x, fZpos.A.y,
+                                          fZpos.C.x, fZpos.C.y,
+                                          fZpos.D.x, fZpos.D.y,
+                                          fZneg.B.x, fZneg.B.y,
+                                          fZneg.A.x, fZneg.A.y,
+                                          fZneg.C.x, fZneg.C.y,
+                                          fZneg.D.x, fZneg.D.y
+                                        };
+
+  dd4hep::EightPointSolid gtrap_shape(dz, vertices_array.data() );
+
+  //----------------- Hyperboloid -------------
+  // ROOT hyperboloid require stereoangles stin and stout
+  //-- stereo for rmin
+  double stin  = DCH_i.stereoangle_z0(cell_rin_z0);
+  //-- stereo for rour
+  double stout = DCH_i.stereoangle_z0(cell_rout_z0);
+
+  // make hyperboloid longer, later intersection with gtrap will lead to proper length
+  double dz_safe = 1.1*dz;
+  dd4hep::Hyperboloid layer_s(cell_rin_z0, stin, cell_rout_z0, stout, dz_safe);
+
+  // create a twisted tube as intersection of the generic trapezoid and the hyperboloid
+  dd4hep::Solid mytt = dd4hep::IntersectionSolid(gtrap_shape,layer_s);
+  return mytt;
 }
 
 }; // end DCH_v2 namespace

--- a/detector/tracker/DriftChamber_o1_v02.cpp
+++ b/detector/tracker/DriftChamber_o1_v02.cpp
@@ -519,6 +519,7 @@ inline double Circumradius(double Apothem, double dphi){return Apothem/cos(0.5*d
 
 /// Solid equivalent to a twisted tube, resulting from the intersection of an hyperboloid and a generic trapezoid
 /// the hyperboloid provides the hyperboloidal surfaces, the trapezoid provides the other two types of surfaces
+/// the generic trapezoid is built in such a manner that circumscribe the twisted tube
 dd4hep::Solid CompositeTT(double twist_angle,  double cell_rin_z0,  double cell_rout_z0, double dz, double dphi, const dd4hep::rec::DCH_info & DCH_i)
 {
 
@@ -551,6 +552,9 @@ dd4hep::Solid CompositeTT(double twist_angle,  double cell_rin_z0,  double cell_
 
   face fZneg;
   face fZpos;
+
+  // The generic trapezoid is built in such a manner as to circumscribe the twisted tube
+  // The following points correspond to the corners of the twisted tube
 
   fZpos.A = { trap_rin*cos(  poly_angle + twist_angle_half ), trap_rin*sin(  poly_angle + twist_angle_half ) };
   fZpos.B = { trap_rin*cos( -poly_angle + twist_angle_half ), trap_rin*sin( -poly_angle + twist_angle_half ) };

--- a/detector/tracker/DriftChamber_o1_v02.cpp
+++ b/detector/tracker/DriftChamber_o1_v02.cpp
@@ -517,6 +517,8 @@ static dd4hep::Ref_t create_DCH_o1_v02(dd4hep::Detector &desc, dd4hep::xml::Hand
 
 inline double Circumradius(double Apothem, double dphi){return Apothem/cos(0.5*dphi/dd4hep::rad);}
 
+/// Solid equivalent to a twisted tube, resulting from the intersection of an hyperboloid and a generic trapezoid
+/// the hyperboloid provides the hyperboloidal surfaces, the trapezoid provides the other two types of surfaces
 dd4hep::Solid CompositeTT(double twist_angle,  double cell_rin_z0,  double cell_rout_z0, double dz, double dphi, const dd4hep::rec::DCH_info & DCH_i)
 {
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -111,7 +111,7 @@ if(DCH_INFO_H_EXIST)
 SET( test_name "test_IDEA_with_DRC_o1_v03" )
 ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
 	ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/compact/IDEA_withDRC_o1_v03.xml --steeringFile=${CMAKE_CURRENT_SOURCE_DIR}/../example/SteeringFile_IDEA_o1_v03.py -G --gun.distribution uniform --random.seed 1988301045 )
-    SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  " Exception; EXCEPTION;ERROR;Error" TIMEOUT 600)
+    SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  " Exception; EXCEPTION;ERROR;Error" TIMEOUT 900)
 endif()
 
 #--------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,7 +102,7 @@ if(DCH_INFO_H_EXIST)
 SET( test_name "test_IDEA_o1_v03" )
 ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
     ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml -N 1 -G --gun.distribution uniform --random.seed 1988301045 )
-    SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  " Exception; EXCEPTION;ERROR;Error" TIMEOUT 100)
+    SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  " Exception; EXCEPTION;ERROR;Error" TIMEOUT 300)
 endif()
 
 #--------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -169,7 +169,7 @@ SET( test_name "test_DCH_o1_v02_overlap" )
 ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
 	ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/compact/DCH_standalone_o1_v02.xml --runType run --part.userParticleHandler= --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/../utils/overlap.mac  )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
-set_tests_properties( t_${test_name} PROPERTIES TIMEOUT 60)
+set_tests_properties( t_${test_name} PROPERTIES TIMEOUT 400)
 endif()
 
 #--------------------------------------------------


### PR DESCRIPTION
BEGINRELEASENOTES
- The drift chamber cell shape has been updated to a composite design, improving navigation speed in simulations by factor 10. To revert to the original twisted tube shape, add the optional `useG4TT` tag in the detector section.

ENDRELEASENOTES

Hi,

After the patch I did for Geant4 twisted tube, it seems there is still an error when shooting exactly at theta 90 degrees. While this bug is being fixed, I implemented an alternative shape. Original twisted tube shape can be used if optional tag is added within the detector section.

The change is transparent to the user, so I did not increase the version number of the detector, what do you think?