### PR TITLE
Do not set the color flow from MCParticles

### DIFF
--- a/plugins/Geant4Output2EDM4hep_DRC.cpp
+++ b/plugins/Geant4Output2EDM4hep_DRC.cpp
@@ -401,7 +401,6 @@ void Geant4Output2EDM4hep_DRC::saveParticles(Geant4ParticleMap* particles)    {
         mcp.setGeneratorStatus( 0 )  ;
 
       mcp.setSpin(p->spin);
-      mcp.setColorFlow(p->colorFlow);
 
       p_ids[id] = cnt++;
       p_part.push_back(p);


### PR DESCRIPTION
needed after https://github.com/key4hep/EDM4hep/pull/389

BEGINRELEASENOTES
- Do not set the color flow from MCParticles, needed after https://github.com/key4hep/EDM4hep/pull/389

ENDRELEASENOTES