### PR TITLE
Avoid potential use of dangling temporary objects.

### DIFF
--- a/detectorCommon/src/DetUtils_k4geo.cpp
+++ b/detectorCommon/src/DetUtils_k4geo.cpp
@@ -452,7 +452,7 @@ std::array<double, 2> tubeEtaExtremes(uint64_t aVolumeId) {
   // check if it is a cylinder centred at z=0
   dd4hep::VolumeManager volMgr = dd4hep::Detector::getInstance().volumeManager();
   auto detelement = volMgr.lookupDetElement(aVolumeId);
-  const auto& transformMatrix = detelement.nominal().worldTransformation();
+  const auto transformMatrix = detelement.nominal().worldTransformation();
   double outGlobal[3];
   double inLocal[] = {0, 0, 0};  // to get middle of the volume
   transformMatrix.LocalToMaster(inLocal, outGlobal);
@@ -477,7 +477,7 @@ std::array<double, 2> tubeEtaExtremes(uint64_t aVolumeId) {
 std::array<double, 2> envelopeEtaExtremes (uint64_t aVolumeId) {
   dd4hep::VolumeManager volMgr = dd4hep::Detector::getInstance().volumeManager();
   auto detelement = volMgr.lookupDetElement(aVolumeId);
-  const auto& transformMatrix = detelement.nominal().worldTransformation();
+  const auto transformMatrix = detelement.nominal().worldTransformation();
   // calculate values of eta in all possible corners of the envelope
   auto dim = envelopeDimensions(aVolumeId);
   double minEta = 0;


### PR DESCRIPTION
In something like

```
  const auto& transformMatrix = detelement.nominal().worldTransformation();
```
nominal() returns a temporary Alignment object by value, and worldTransformation() returns a reference within that Alignment object. So we should make a copy.
(The C++ rules for extending the lifetime of a temporary bound to a reference don't help here because the object bound to a reference is different from the object whose lifetime needs to be extended.)



BEGINRELEASENOTES
- Fix potential uses of dangling temporaries.
ENDRELEASENOTES