### PR TITLE
Collect files of different MDI versions in a config file for each version

### DIFF
--- a/FCCee/ILD_FCCee/compact/ILD_FCCee_v01/ILD_FCCee_v01.xml
+++ b/FCCee/ILD_FCCee/compact/ILD_FCCee_v01/ILD_FCCee_v01.xml
@@ -61,10 +61,9 @@
 
   <include ref="../ILD_common_v02/display.xml"/>
 
-  <!-- MDI from common directory -->
-  <include ref="../../../MDI/compact/MDI_o1_v00/BeamInstrumentation_o1_v01.xml"/>
-  <include ref="../../../MDI/compact/MDI_o1_v00/Beampipe_o4_v05.xml"/>
-  <include ref="../../../MDI/compact/MDI_o1_v00/HOMAbsorber.xml"/>
+
+  <!-- Include the MDI Collection for Option 1 Version 00 (MDI_o1_v00) -->
+  <include ref="../../../MDI/compact/MDI_o1_v00/MDI_o1_v00_collection.xml"/>
 
   <!-- vertex and lumiCal from CLD_02_v07 -->
   <include ref="../../../CLD/compact/CLD_o2_v07/LumiCal_o3_v02_05.xml"/>

--- a/FCCee/ILD_FCCee/compact/ILD_FCCee_v02/ILD_FCCee_v02.xml
+++ b/FCCee/ILD_FCCee/compact/ILD_FCCee_v02/ILD_FCCee_v02.xml
@@ -62,10 +62,9 @@
 
   <include ref="../ILD_common_v02/display.xml"/>
 
-  <!-- MDI from common directory -->
-  <include ref="../../../MDI/compact/MDI_o1_v00/BeamInstrumentation_o1_v01.xml"/>
-  <include ref="../../../MDI/compact/MDI_o1_v00/Beampipe_o4_v05.xml"/>
-  <include ref="../../../MDI/compact/MDI_o1_v00/HOMAbsorber.xml"/>
+
+  <!-- Include the MDI Collection for Option 1 Version 00 (MDI_o1_v00) -->
+  <include ref="../../../MDI/compact/MDI_o1_v00/MDI_o1_v00_collection.xml"/>
 
   <!-- vertex, innerTracker and lumiCal from CLD_02_v07 -->
   <include ref="../../../CLD/compact/CLD_o2_v07/LumiCal_o3_v02_05.xml"/>

--- a/FCCee/MDI/compact/MDI_o1_v00/MDI_o1_v00_collection.xml
+++ b/FCCee/MDI/compact/MDI_o1_v00/MDI_o1_v00_collection.xml
@@ -1,0 +1,7 @@
+<lccdd>
+
+    <include ref="BeamInstrumentation_o1_v01.xml"/>
+    <include ref="Beampipe_o4_v05.xml"/>
+    <include ref="HOMAbsorber.xml"/>
+
+</lccdd>

--- a/FCCee/MDI/compact/MDI_o1_v01/MDI_o1_v01_collection.xml
+++ b/FCCee/MDI/compact/MDI_o1_v01/MDI_o1_v01_collection.xml
@@ -1,0 +1,6 @@
+<lccdd>
+
+    <include ref="BeamInstrumentation_o1_v01.xml"/>
+    <include ref="Beampipe_CADimport_o1_v02.xml"/>
+
+</lccdd>


### PR DESCRIPTION
- collect the files of the individual MDI versions in a “global” MDI version configuration file in the folder of this version
- avoid redundant specification of the MDI version number in each file name of each component of the MDI version (single source of truth)



BEGINRELEASENOTES
- collect the files of the individual MDI versions in a “global” MDI version configuration file in the folder of this version
- avoid redundant specification of the MDI version number in each file name of each component of the MDI version (single source of truth)

ENDRELEASENOTES