### PR TITLE
add Default Material to ILD as well

### DIFF
--- a/FCCee/ILD_FCCee/compact/ILD_FCCee_v02/ILD_FCCee_v02.xml
+++ b/FCCee/ILD_FCCee/compact/ILD_FCCee_v02/ILD_FCCee_v02.xml
@@ -67,7 +67,7 @@
   <include ref="../../../MDI/compact/MDI_o1_v00/Beampipe_o4_v05.xml"/>
   <include ref="../../../MDI/compact/MDI_o1_v00/HOMAbsorber.xml"/>
 
-  <!-- vertex innerTracker and lumiCal from CLD_02_v07 -->
+  <!-- vertex, innerTracker and lumiCal from CLD_02_v07 -->
   <include ref="../../../CLD/compact/CLD_o2_v07/LumiCal_o3_v02_05.xml"/>
   <include ref="../../../CLD/compact/CLD_o2_v07/Vertex_o4_v07_smallBP.xml"/>
   <include ref="../../../CLD/compact/CLD_o2_v07/InnerTracker_o2_v08.xml"/>

--- a/ILD/compact/ILD_common_v02/materials.xml
+++ b/ILD/compact/ILD_common_v02/materials.xml
@@ -635,6 +635,12 @@
       <composite n="22" ref="H" />
     </material>
 
+    <!-- Default material to use in DDCAD import of CAD models (see CheckShape.xml in DD4hep) -->
+    <material name="DefaultMaterial">
+      <D value="7.85" unit="g/cm3"/>
+      <fraction n="0.998" ref="Fe"/>
+      <fraction n=".002"  ref="C"/>
+    </material>
 
 
   </materials>


### PR DESCRIPTION
This solves #421 for the ILD.

- Up to now, the Default Material was only available for CLD (#422) and IDEA (https://github.com/key4hep/k4geo/blob/0a49f40a1252ff7c43590b59b8d20d86b5bbb210/FCCee/IDEA/compact/IDEA_o2_v01/materials_o2_v01.xml#L304). Hence, MDI_o1_v01 could not be used with the ILD
- Includes minor change to improve the readability in config of ILD_FCCee_v02.xml

BEGINRELEASENOTES
- add Default Material to ILD as well
- minor change to improve the readability in config of ILD_FCCee_v02.xml

ENDRELEASENOTES