### PR TITLE
Pandora plugin to calculate material properties of calorimeters dynamically

### DIFF
--- a/FCCee/CLD/compact/CLD_o4_v05/CLD_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/CLD_o4_v05.xml
@@ -367,7 +367,7 @@
       </plugin>
 
       <plugin name="Pandora_LayeredCalorimeterPlugin">
-        <argument value="/ECalBarrel"/>
+        <argument value="ECalBarrel"/>
         <argument value="ECalBarrel_inner_radius"/> <!-- Rmin -->
         <argument value="ECalBarrel_outer_radius"/> <!-- Rmax -->
         <argument value="ECalBarrel_half_length"/>  <!-- half_length -->

--- a/FCCee/CLD/compact/CLD_o4_v05/CLD_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/CLD_o4_v05.xml
@@ -61,15 +61,15 @@
         <constant name="BPWCool"       value="1.0*mm" />
         <constant name="BeamPipeWidth" value="2.0*BPWWall + BPWCool"/>
 
-	    <constant name="BeamPipeWidthFirstCone" value="2.0*mm" />
+	<constant name="BeamPipeWidthFirstCone" value="2.0*mm" />
         <!-- this is the inner length of the longer elipse axis -->
-	    <constant name="ConeBeamPipe_Rmax" value="28.9*mm" />
+	<constant name="ConeBeamPipe_Rmax" value="28.9*mm" />
         <constant name="CentralBeamPipe_zmax" value="90*mm"/>
-	    <constant name="SeparatedBeamPipe_z" value="1190.0*mm"/>
+	<constant name="SeparatedBeamPipe_z" value="1190.0*mm"/>
         <constant name="CentralBeamPipe_rmax" value="10.0*mm"/>
-	    <constant name="BeamPipeGoldWidth" value="0.005*mm" />
-	    <constant name="BeamPipeGoldTolerance" value="0.001*mm" />  <!-- dummy tolerance, some small non zero value -->
-	    <constant name="BeamPipeConeHalfAngle" value="(ConeBeamPipe_Rmax + BeamPipeWidthFirstCone - CentralBeamPipe_rmax ) / (SeparatedBeamPipe_z - CentralBeamPipe_zmax)" />
+	<constant name="BeamPipeGoldWidth" value="0.005*mm" />
+	<constant name="BeamPipeGoldTolerance" value="0.001*mm" />  <!-- dummy tolerance, some small non zero value -->
+	<constant name="BeamPipeConeHalfAngle" value="(ConeBeamPipe_Rmax + BeamPipeWidthFirstCone - CentralBeamPipe_rmax ) / (SeparatedBeamPipe_z - CentralBeamPipe_zmax)" />
 
         <constant name="InnerTracker_half_length" value="2300*mm" />
 
@@ -200,16 +200,16 @@
 
         <constant name="LumiCal_dz" value="(LumiCal_max_z-LumiCal_min_z)/2.0"/>
 
-	    <constant name="LumiCal_inner_radius" value="55.0*mm"/>
-	    <constant name="LumiCal_outer_radius" value="112.0*mm- env_safety"/>
+	<constant name="LumiCal_inner_radius" value="55.0*mm"/>
+	<constant name="LumiCal_outer_radius" value="112.0*mm- env_safety"/>
 
-	    <constant name="LumiCal_Instr_thickness" value="20*mm"/>
-	    <constant name="LumiCal_Instr_inner_radius" value="LumiCal_outer_radius"/>
-	    <constant name="LumiCal_Instr_outer_radius" value="LumiCal_outer_radius+LumiCal_Instr_thickness - env_safety"/>
+	<constant name="LumiCal_Instr_thickness" value="20*mm"/>
+	<constant name="LumiCal_Instr_inner_radius" value="LumiCal_outer_radius"/>
+	<constant name="LumiCal_Instr_outer_radius" value="LumiCal_outer_radius+LumiCal_Instr_thickness - env_safety"/>
 
-	    <constant name="LumiCal_Cool_thickness" value="9.75*mm"/>
-	    <constant name="LumiCal_Cool_inner_radius" value="LumiCal_Instr_outer_radius"/>
-	    <constant name="LumiCal_Cool_outer_radius" value="LumiCal_Instr_outer_radius+LumiCal_Cool_thickness"/>
+	<constant name="LumiCal_Cool_thickness" value="9.75*mm"/>
+	<constant name="LumiCal_Cool_inner_radius" value="LumiCal_Instr_outer_radius"/>
+	<constant name="LumiCal_Cool_outer_radius" value="LumiCal_Instr_outer_radius+LumiCal_Cool_thickness"/>
 
         <constant name="Lcal_services_rmax" value="LumiCal_outer_radius+30*mm"/>
         <constant name="Lcal_offset_phi" value=" 0."/>
@@ -241,7 +241,7 @@
 
         <constant name="QD0_min_z" value="2000*mm"/>
         <constant name="QD0_max_z" value="5400*mm"/>
-	    <constant name="QD0Coil_outer_radius" value="30*mm"/>
+	<constant name="QD0Coil_outer_radius" value="30*mm"/>
         <constant name="CollimatorInFrontOfQD0_dz" value="20*cm"/>
         <constant name="CollimatorInFrontOfQD0_radius" value="10*mm"/>
         <constant name="CollimatorInFrontOfQD0_dr" value="16*mm"/>

--- a/FCCee/CLD/compact/CLD_o4_v05/CLD_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/CLD_o4_v05.xml
@@ -368,6 +368,7 @@
 
       <plugin name="Pandora_LayeredCalorimeterPlugin">
         <argument value="ECalBarrel"/>
+        <argument value="DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL" />
         <argument value="ECalBarrel_inner_radius"/> <!-- Rmin -->
         <argument value="ECalBarrel_outer_radius"/> <!-- Rmax -->
         <argument value="ECalBarrel_half_length"/>  <!-- half_length -->

--- a/FCCee/CLD/compact/CLD_o4_v05/LAr_ECalBarrel.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/LAr_ECalBarrel.xml
@@ -82,15 +82,15 @@
     <!-- readout for the simulation -->
     <!-- offset in eta is eta max value including cryostat -->
     <readout name="ECalBarrelEta">
-        <!-- segmentation type="GridTheta_k4geo" grid_size_theta="0.5625" offset_theta="-0.83"/ -->
-        <segmentation type="GridEta_k4geo" grid_size_eta="0.01" offset_eta="-1.2"/>
+      <!-- segmentation type="GridTheta_k4geo" grid_size_theta="0.5625" offset_theta="-0.83"/ -->
+      <segmentation type="GridEta_k4geo" grid_size_eta="0.01" offset_eta="-1.2"/>
       <id>system:5,cryo:1,type:3,subtype:3,layer:8,module:11,eta:9</id>
     </readout>
     <!-- readout for the reconstruction -->
     <!-- phi position is calculated based on the centre of volume (hence it cannot be done in the simulation from energy deposits position) -->
     <readout name="ECalBarrelPhiEta">
-        <!-- segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.5625" phi_bins="768" offset_theta="-0.83" offset_phi="-pi+(pi/768.)"/ -->
-        <segmentation type="FCCSWGridPhiEta_k4geo" grid_size_eta="0.01" phi_bins="768" offset_eta="-1.2" offset_phi="-pi+(pi/768.)"/>
+      <!-- segmentation type="FCCSWGridPhiTheta" grid_size_theta="0.5625" phi_bins="768" offset_theta="-0.83" offset_phi="-pi+(pi/768.)"/ -->
+      <segmentation type="FCCSWGridPhiEta_k4geo" grid_size_eta="0.01" phi_bins="768" offset_eta="-1.2" offset_phi="-pi+(pi/768.)"/>
       <id>system:5,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10</id>
     </readout>
   </readouts>

--- a/FCCee/CLD/compact/CLD_o4_v05/materials.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/materials.xml
@@ -265,4 +265,11 @@
       <fraction n="0.156851578703752" ref="O"/>
     </material>
 
+    <!-- Default material to use in DDCAD import of CAD models (see CheckShape.xml in DD4hep) -->
+    <material name="DefaultMaterial">
+      <D value="7.85" unit="g/cm3"/>
+      <fraction n="0.998" ref="Fe"/>
+      <fraction n=".002"  ref="C"/>
+    </material>
+
 </materials>

--- a/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01_geo.cpp
@@ -559,6 +559,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
   dd4hep::PlacedVolume envelopePhysVol = motherVol.placeVolume(envelopeVol);
   envelopePhysVol.addPhysVolID("system", xmlDetElem.id());
   caloDetElem.setPlacement(envelopePhysVol);
+  dd4hep::xml::setDetectorTypeFlag(xmlDetElem, caloDetElem);
 
  /* // Create caloData object
   auto caloData = new dd4hep::rec::LayeredCalorimeterData;

--- a/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01_geo.cpp
@@ -559,7 +559,6 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd,
   dd4hep::PlacedVolume envelopePhysVol = motherVol.placeVolume(envelopeVol);
   envelopePhysVol.addPhysVolID("system", xmlDetElem.id());
   caloDetElem.setPlacement(envelopePhysVol);
-  dd4hep::xml::setDetectorTypeFlag(xmlDetElem, caloDetElem);
 
  /* // Create caloData object
   auto caloData = new dd4hep::rec::LayeredCalorimeterData;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,11 @@ ADD_TEST( t_test_${det_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName
 	ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../FCCee/CLD/compact/${det_name}/${det_name}.xml --runType=batch -G -N=1 --outputFile=test${det_name}.slcio )
 SET_TESTS_PROPERTIES( t_test_${det_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
+SET( det_name "CLD_o4_v05" )
+ADD_TEST( t_test_${det_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
+	ddsim --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../FCCee/CLD/compact/${det_name}/${det_name}.xml --runType=batch -G -N=1 --outputFile=test${det_name}.slcio )
+SET_TESTS_PROPERTIES( t_test_${det_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+
 SET( test_name "test_steeringFile" )
 ADD_TEST( t_${test_name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
   ddsim --steeringFile=${CMAKE_CURRENT_SOURCE_DIR}/../example/steeringFile.py --compactFile=${CMAKE_CURRENT_SOURCE_DIR}/../CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --runType=batch -G -N=1 --outputFile=testCLIC_o2_v04.slcio )


### PR DESCRIPTION

BEGINRELEASENOTES
- PandoraPFA uses ```LayeredCalorimeterData``` class from DD4hep to store layer-by-layer information e.g radiation length., essential for shower reconstruction and energy measurement. 
- In this plugin,  using another class from DD4hep, MaterialManager, LayeredCalorimeterData object is dynamically built based on the detector geometry ensuring each calorimeter layer correctly reflects its material composition. 
- This plugin can be used for any calorimeter irrespective of its geometry. It is essential to have LayeredCalorimeterData information to run Pandora.
- The changes in the geometry source file ```ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01_geo.cpp``` and xml file ```CLD_o4_v05.xml``` should also be noted to accommodate the plugin. 
ENDRELEASENOTES