### PR TITLE
revert HCal barrel readout [URGENT]

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/HCalBarrel_TileCal_v03.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/HCalBarrel_TileCal_v03.xml
@@ -109,7 +109,7 @@
   </readouts>
 
   <detectors>
-    <detector id="BarHCal_id" name="HCalBarrel" type="HCalTileBarrel_o1_v02" readout="HCalBarrelReadoutPhiRow">
+    <detector id="BarHCal_id" name="HCalBarrel" type="HCalTileBarrel_o1_v02" readout="HCalBarrelReadout">
       <type_flags type="DetType_CALORIMETER + DetType_HADRONIC + DetType_BARREL"/>
       <dimensions rmin="BarHCal_rmin" rmax="BarHCal_rmax" dz="BarHCal_dz" vis="hcal_envelope" />
       <sensitive type="BirksLawCalorimeterSD"/>


### PR DESCRIPTION
BEGINRELEASENOTES
- Reverts change of HCal barrel readout introduced by mistake in https://github.com/key4hep/k4geo/pull/437

ENDRELEASENOTES
Fixes tests error seen for instance in https://github.com/HEP-FCC/k4RecCalorimeter/actions/runs/13477493878/job/37695815007?pr=137