### PR TITLE
add detector type and calodata extension to ECalEndcap_Turbine_o1_v03_geo

### DIFF
--- a/detector/calorimeter/ECalEndcap_Turbine_o1_v03_geo.cpp
+++ b/detector/calorimeter/ECalEndcap_Turbine_o1_v03_geo.cpp
@@ -1,6 +1,8 @@
 #include "DD4hep/DetFactoryHelper.h"
 #include "DD4hep/Printout.h"
 #include "TMatrixT.h"
+#include "XML/Utilities.h"
+#include <DDRec/DetectorData.h>
 
 // todo: remove gaudi logging and properly capture output
 #define endmsg std::endl
@@ -776,6 +778,22 @@ namespace det {
       dd4hep::PlacedVolume envelopePhysVol = motherVol.placeVolume(endcapsAssembly);
       caloDetElem.setPlacement(envelopePhysVol);
       envelopePhysVol.addPhysVolID("system", idDet);
+
+      // Create dummy caloData object for PandoraPFA
+      // FIXME: fill calo and layer data information
+      auto caloData = new dd4hep::rec::LayeredCalorimeterData;
+      caloData->layoutType = dd4hep::rec::LayeredCalorimeterData::EndcapLayout;
+      caloDetElem.addExtension<dd4hep::rec::LayeredCalorimeterData>(caloData);
+
+      // save extent information
+      caloData->extent[0] = dim.rmin1();
+      caloData->extent[1] = dim.rmax1();
+      caloData->extent[2] = dim.z_offset()-dim.dz()/2.;
+      caloData->extent[3] = dim.z_offset()+dim.dz()/2.;
+
+      // Set type flags
+      dd4hep::xml::setDetectorTypeFlag(xmlDetElem, caloDetElem);
+
       return caloDetElem;
     }
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Adds to ECalEndcap_Turbine_o1_v03_geo the code that fills the dd4rec calorimeter data (type and envelope) 

ENDRELEASENOTES

Fixes a problem in reconstruction of ALLEGRO v03 introduced by the recent merging of https://github.com/key4hep/k4geo/pull/426
(the code will fail because in the nightly we now switched from ECalEndcap_Turbine_o1_v02_geo to ECalEndcap_Turbine_o1_v03_geo and the calodata information used by the digitiser is missing)

Tagging @atolosadelgado and @BrieucF 