### PR TITLE
add detector type flags to DCH

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o1_v03/DriftChamber_o1_v02.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/DriftChamber_o1_v02.xml
@@ -116,6 +116,10 @@
         FCentralWire_material ="DCH_FCentralWireMat"
       >
     </wires>
+    <!-- /detectors/detector/type_flags -->
+    <!-- for reconstrution -->
+    <type_flags type="DetType_TRACKER +  DetType_BARREL + DetType_GASEOUS "/>
+
     </detector>
   </detectors>
 

--- a/detector/tracker/DriftChamber_o1_v02.cpp
+++ b/detector/tracker/DriftChamber_o1_v02.cpp
@@ -16,6 +16,7 @@
 #include "DD4hep/DetFactoryHelper.h"
 #include "DD4hep/Shapes.h"
 #include "DD4hep/Detector.h"
+#include "XML/Utilities.h"
 
 #include "DDRec/DCH_info.h"
 
@@ -34,6 +35,7 @@ static dd4hep::Ref_t create_DCH_o1_v02(dd4hep::Detector &desc, dd4hep::xml::Hand
     std::string detName = detElem.nameStr();
     int detID = detElem.id();
     dd4hep::DetElement det(detName, detID);
+    dd4hep::xml::setDetectorTypeFlag(detElem, det);
     sens.setType("tracker");
 
     // initialize empty DCH_info object


### PR DESCRIPTION
Trivial change to add detector type to the drift chamber, so that in reconstruction one can retrieve DCH info with:
```
        const std::vector< dd4hep::DetElement>& dchDets= dd4hep::DetectorSelector(mainDetector).detectors(  ( dd4hep::DetType::TRACKER |  dd4hep::DetType::BARREL  | dd4hep::DetType::GASEOUS ), dd4hep::DetType::VERTEX) ;
        auto dchExtension = dchDets[0].extension<dd4hep::rec::DCH_info>();
        m_dchInnerR = dchExtension->rin/dd4hep::mm ;
..
```

- [X] the code is sufficiently well documented (e.g. inline comments)
- [X] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [X] the PR does not contain any additions or modifications that do not belong to it
- [X] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Set detector type flag for the IDEA_o1_v03 drift chamber (this propagates to other detectors using the drift chamber) 
ENDRELEASENOTES

