### PR TITLE
update tracker region extent in ALLEGRO xml

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
@@ -226,9 +226,16 @@
     <constant name="QC1L1_start" value="2200*mm"/>
     <constant name="screenstart" value="-10*mm"/>
     <!-- end MDI -->
-    
-    <constant name="tracker_region_zmax" value="DCH_half_length_total"/>
-    <constant name="tracker_region_rmax" value="DCH_outer_cyl_R_total"/>
+
+    <!-- these constants are used to define the full tracking volume in reconstruction (e.g. pandora) -->
+    <!-- modified to include also the wrapper region -->
+    <!-- constant name="tracker_region_zmax" value="DCH_half_length_total"/-->
+    <!-- constant name="tracker_region_rmax" value="DCH_outer_cyl_R_total"/-->
+    <!-- the two alternatives below should be equivalent, the latter being safer -->
+    <!-- constant name="tracker_region_zmax" value="SiWrD_zmax"/ -->
+    <!-- constant name="tracker_region_rmax" value="SiWrB_outer_radius"/ -->
+    <constant name="tracker_region_zmax" value="ECalEndcap_min_z"/>
+    <constant name="tracker_region_rmax" value="BarECal_rmin"/>
 
   </define>
   


### PR DESCRIPTION
The constants tracker_region_zmax and tracker_region_rmax are used in reconstruction to define the tracking volume.
Currently these are set equal to the DCH outer R and Z
Since there is also the wrapper in the tracking volume, these constants are redefined to include also the wrapper
- [X] the code is sufficiently well documented (e.g. inline comments)
- [X] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [X] the PR does not contain any additions or modifications that do not belong to it
- [X] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Update ALLEGRO tracker_region zmaz, rmax constants to also include the wrapper

ENDRELEASENOTES

