### PR TITLE
fix envelope data for ecal endcap turbine

### DIFF
--- a/detector/calorimeter/ECalEndcap_Turbine_o1_v01_geo.cpp
+++ b/detector/calorimeter/ECalEndcap_Turbine_o1_v01_geo.cpp
@@ -18,7 +18,7 @@ namespace det {
   unsigned ECalEndCapElementCounter = 0;
 
   unsigned ECalEndcapNumCalibLayers;
-  
+
   double tForArcLength(double s, double bladeangle, double delZ, double r) {
 
     // some intermediate constants
@@ -28,17 +28,17 @@ namespace det {
     double c = (TMath::Tan(s/r) +b)/(1.-b*TMath::Tan(s/r));
     double d = c*c*r*r/(1+c*c);
     return (TMath::Sqrt(d)-zp)*TMath::Sin(bladeangle);
-    
+
   }
 
-  // return position of the inner edge of a blade 
+  // return position of the inner edge of a blade
   double getZmin(double r, double bladeangle, double delZ) {
     // r: distance from the beamline
     // bladeangle: angle of turbine blades wrt xy plane, in radians
     // delZ: z extent of the blades
     return TMath::Sqrt(r*r - ((delZ/2)/TMath::Tan(bladeangle))*((delZ/2)/TMath::Tan(bladeangle)));
   }
-  
+
   dd4hep::Solid buildOneBlade(double thickness_inner,
                               double thickness_outer,
                               double width,
@@ -52,10 +52,10 @@ namespace det {
     // set max and min extent of the blade (along the z axis in the body frame)
     double zmax = ro;
     double zmin = getZmin(ri, bladeangle, delZ);
-    
+
      dd4hep::Trd2 tmp1(thickness_inner/2., thickness_outer/2., width/2., width/2., (zmax-zmin)/2. );
       shapeBeforeSubtraction = tmp1;
- 
+
     dd4hep::Tube allowedTube(ri, ro, delZ);
 
     return dd4hep::IntersectionSolid (shapeBeforeSubtraction, allowedTube, dd4hep::Transform3D(dd4hep::RotationZYX( 0,  TMath::Pi()/2.-bladeangle, TMath::Pi()/2.),dd4hep::Position(0,0, -(zmin+zmax)/2.)));
@@ -92,7 +92,7 @@ namespace det {
       float tubeFracCovered = delZ/(2*grmin*TMath::Tan(BladeAngle));
       BladeAngle = TMath::ATan(delZ/(2*ri*tubeFracCovered));
     }
-    
+
     if (TMath::Abs(TMath::Tan(BladeAngle)) < delZ/(2.*ri)) {
       dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v01",  "The requested blade angle is too small for the given delZ and ri values.  Please adjust to at least %f degrees!",  TMath::ATan(delZ/(2.*ri))*180./TMath::Pi() );
 
@@ -102,7 +102,7 @@ namespace det {
     Float_t xRange = delZ/(TMath::Sin(BladeAngle));
 
     double delrPhiNoGap;
-    
+
     float GlueThick = glueElem.attr<float>(_Unicode(thickness));
     float CladdingThick = claddingElem.attr<float>(_Unicode(thickness));
     float AbsThickMin = absBladeElem.attr<float>(_Unicode(thickness))-(GlueThick+CladdingThick);
@@ -111,7 +111,7 @@ namespace det {
     }
     float ElectrodeThick = electrodeBladeElem.attr<float>(_Unicode(thickness));
     float LArgapi = nobleLiquidElem.attr<float>(_Unicode(gap));
-    
+
     bool sameNUnitCells = genericBladeElem.attr<bool>(_Unicode(sameNUnitCells));
     auto nUnitCellsStrArr = genericBladeElem.attr<std::string>(_Unicode(nUnitCells));
     char* nUnitCellsCStr = strtok(const_cast<char*>(nUnitCellsStrArr.c_str()), " ");
@@ -137,7 +137,7 @@ namespace det {
       AbsThicko = AbsThicki + bladeThicknessScaleFactor*((ro/ri)-1.)*AbsThicki;
     } else {
       AbsThicko = AbsThicki;
-    } 
+    }
 
     // Calculate gap thickness at inner layer
     double circ = 2*TMath::Pi()*ri;
@@ -161,7 +161,7 @@ namespace det {
     leftoverS = (circ - nUnitCells*delrPhiNoGap);
     delrPhiGapOnly = leftoverS/(2*nUnitCells);
     float LArgapo = delrPhiGapOnly*TMath::Sin(BladeAngle);
-     
+
     float riLayer = ri;
 
     std::vector<dd4hep::Volume> claddingLayerVols;
@@ -170,13 +170,13 @@ namespace det {
     std::vector<dd4hep::Volume> LArTotalLayerVols;
     std::vector<dd4hep::Volume> electrodeBladeLayerVols;
 
-   
+
     dd4hep::Solid passiveShape = buildOneBlade(AbsThicki+GlueThick+CladdingThick, AbsThicko+GlueThick+CladdingThick, xRange, ro, ri, BladeAngle, delZ );
     dd4hep::Volume passiveVol("passive", passiveShape, aLcdd.material("Air"));
 
     dd4hep::Solid activeShape = buildOneBlade(ElectrodeThick+LArgapi*2, ElectrodeThick+LArgapo*2, xRange, ro, ri, BladeAngle, delZ);
     dd4hep::Volume activeVol("active", activeShape, aLcdd.material("Air"));
-    
+
     unsigned numNonActiveLayers = 1;
     // check that either all non-active volumes are set to sensitive (for
     // sampling fraction calculations) or none are (for normal running)
@@ -198,11 +198,11 @@ namespace det {
 
     float delrNonActive = (ro-ri)/numNonActiveLayers;
     float delrActive = (ro-ri)/ECalEndcapNumCalibLayers;
-    
+
     for (unsigned iLayer = 0; iLayer < numNonActiveLayers; iLayer++) {
       float roLayer = riLayer + delrNonActive;
       dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v01", "Making layer with inner, outer radii %f, %f", riLayer, roLayer);
- 
+
       if (scaleBladeThickness) {
         AbsThicko = AbsThicki + bladeThicknessScaleFactor*((roLayer/riLayer)-1.)*AbsThicki;
       } else {
@@ -211,11 +211,11 @@ namespace det {
       dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v01",  "Inner and outer absorber thicknesses %f, %f ", AbsThicki,  AbsThicko);
 
       dd4hep::Solid claddingLayer = buildOneBlade(AbsThicki+GlueThick+CladdingThick, AbsThicko+GlueThick+CladdingThick, xRange, roLayer, riLayer, BladeAngle, delZ );
-      
+
       dd4hep::Solid glueLayer = buildOneBlade(AbsThicki+GlueThick, AbsThicko+GlueThick, xRange, roLayer, riLayer, BladeAngle, delZ );
 
       dd4hep::Solid  absBladeLayer = buildOneBlade(AbsThicki, AbsThicko, xRange, roLayer, riLayer, BladeAngle, delZ );
-     
+
       dd4hep::Volume claddingLayerVol("claddingLayer", claddingLayer, aLcdd.material(claddingElem.materialStr()));
       if (claddingElem.isSensitive()) {
         claddingLayerVol.setSensitiveDetector(aSensDet);
@@ -241,11 +241,11 @@ namespace det {
     riLayer = ri;
 
     AbsThicki = AbsThickMin;
-    
+
     for (unsigned iLayer = 0; iLayer < ECalEndcapNumCalibLayers; iLayer++) {
 
       float roLayer = riLayer + delrActive;
-      
+
       if (scaleBladeThickness) {
         AbsThicko = AbsThicki + bladeThicknessScaleFactor*((roLayer/riLayer)-1.)*AbsThicki;
       } else {
@@ -275,7 +275,7 @@ namespace det {
         electrodeBladeLayerVol.setSensitiveDetector(aSensDet);
       }
       electrodeBladeLayerVols.push_back(electrodeBladeLayerVol);
-      
+
       dd4hep::Volume LArTotalLayerVol("LArTotalLayerVol", electrodeBladeAndGapLayer,  aLcdd.material(nobleLiquidElem.materialStr()));
 
       if ( nobleLiquidElem.isSensitive() ) {
@@ -290,7 +290,7 @@ namespace det {
     dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v01",  "ECal endcap materials:  nobleLiquid: %s absorber %s electrode %s",  nobleLiquidElem.materialStr().c_str(), absBladeElem.materialStr().c_str(), electrodeBladeElem.materialStr().c_str() );
 
     int    nUnitCellsToDraw = nUnitCells;
-   
+
     dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v01",  "Number of unit cells %d",  nUnitCells);
 
     // place all components of the absorber blade inside passive volume
@@ -305,7 +305,7 @@ namespace det {
 
        dd4hep::Position posLayer(0,0,(riLayer-ri+roLayer-ro)/2.);
        dd4hep::PlacedVolume absBladeVol_pv = glueLayerVols[iLayer].placeVolume(absBladeLayerVol, posLayer);
-      
+
        absBladeVol_pv.addPhysVolID("subtype", 0); // 0 = absorber, 1 = glue, 2 = cladding
        dd4hep::printout( dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v01_geo",  "Blade layer, rho is %d, %f, %f", iLayer, absBladeVol_pv.position().Rho(), roLayer/2.);
        absBladeVol_pv.addPhysVolID("layer", iWheel*numNonActiveLayers+iLayer);
@@ -316,15 +316,15 @@ namespace det {
 
     riLayer = ri;
     iLayer =0;
-    
+
     for (auto glueLayerVol: glueLayerVols) {
 
       float roLayer = riLayer+delrNonActive;
-       
+
       dd4hep::Position posLayer(0,0,(riLayer-ri+roLayer-ro)/2.);
       dd4hep::PlacedVolume glueVol_pv = claddingLayerVols[iLayer].placeVolume(glueLayerVol, posLayer);
 
-      
+
       glueVol_pv.addPhysVolID("subtype", 1); // 0 = absorber, 1 = glue, 2 = cladding
       glueVol_pv.addPhysVolID("layer", iWheel*numNonActiveLayers+iLayer);
 
@@ -336,34 +336,34 @@ namespace det {
     iLayer =0;
 
     double zminri = getZmin(ri, BladeAngle, delZ);
-    
+
     for (auto claddingLayerVol: claddingLayerVols) {
 
       float roLayer = riLayer+delrNonActive;
-          
+
       double zminLayer = getZmin(riLayer, BladeAngle, delZ);
 
       dd4hep::Position posLayer(0,0,(zminLayer-zminri+roLayer-ro)/2.);
       dd4hep::PlacedVolume claddingVol_pv = passiveVol.placeVolume(claddingLayerVol, posLayer);
-            
+
       claddingVol_pv.addPhysVolID("subtype", 2); // 0 = absorber, 1 = glue, 2 = cladding
       claddingVol_pv.addPhysVolID("layer", iWheel*numNonActiveLayers+iLayer);
 
       riLayer = roLayer;
       iLayer++;
     }
-    
-    
+
+
     riLayer = ri;
     iLayer = 0;
-    
+
    for (auto electrodeBladeLayerVol: electrodeBladeLayerVols) {
-      
+
       float roLayer = riLayer+delrActive;
-      
+
       dd4hep::PlacedVolume electrodeBladeVol_pv = LArTotalLayerVols[iLayer].placeVolume(electrodeBladeLayerVol);
       electrodeBladeVol_pv.addPhysVolID("layer", iWheel*numNonActiveLayers+iLayer);
-      
+
       riLayer = roLayer;
       iLayer++;
     }
@@ -372,28 +372,28 @@ namespace det {
    iLayer = 0;
 
    for (auto LArTotalLayerVol: LArTotalLayerVols) {
-     
+
      float roLayer = riLayer+delrActive;
 
      double zminLayer = getZmin(riLayer, BladeAngle, delZ);
-          
+
      dd4hep::Position posLayer(0,0,(zminLayer-zminri+roLayer-ro)/2.);
-     
+
      dd4hep::PlacedVolume LArVol_pv(activeVol.placeVolume(LArTotalLayerVol, posLayer));
      dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v01",  "LAr layer: %d", iLayer );
      LArVol_pv.addPhysVolID("layer", iWheel*ECalEndcapNumCalibLayers+iLayer);
-     
+
      riLayer = roLayer;
      iLayer++;
    }
-   
+
     for (int iUnitCell = 0; iUnitCell < nUnitCellsToDraw; iUnitCell++) {
 
       int modIndex = iUnitCell-nUnitCellsToDraw/2;
       if (modIndex < 0) modIndex += nUnitCells;
       float phi = (iUnitCell-nUnitCellsToDraw/2)*2*TMath::Pi()/nUnitCells;
       float delPhi = 2*TMath::Pi()/nUnitCells;
-      
+
       dd4hep::printout( dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v01",  "Placing blade, ro, ri = %f %f", ro, ri);
       TGeoRotation tgr;
       tgr.RotateZ(BladeAngle*180/TMath::Pi());
@@ -413,7 +413,7 @@ namespace det {
       tgr.RotateZ(BladeAngle*180/TMath::Pi());
       tgr.RotateX(-(phi+delPhi/2.)*180/TMath::Pi());
       tgr.RotateY(90);
-      
+
       rotMatPtr = tgr.GetRotationMatrix();
       TMatrixT<Double_t> rotMat2(3,3, rotMatPtr);
       dd4hep::Rotation3D r3d2;
@@ -424,11 +424,11 @@ namespace det {
       riLayer = ri;
 
       float xCell = ((ro+zminri)/2.)*TMath::Cos(phi);
-      float yCell = ((ro+zminri)/2.)*TMath::Sin(phi); 
+      float yCell = ((ro+zminri)/2.)*TMath::Sin(phi);
       float zCell =  0.;
 
       dd4hep::Transform3D comCell(r3d, dd4hep::Translation3D(xCell,yCell,zCell));
-      
+
       // place passive volume in LAr bath
       dd4hep::PlacedVolume passivePhysVol = aEnvelope.placeVolume(passiveVol, comCell);
       passivePhysVol.addPhysVolID("module", modIndex*nUnitCellsLeastCommonMultiple/nUnitCells);
@@ -439,7 +439,7 @@ namespace det {
 
       // place active volume in LAr bath
       xCell = ((ro+zminri)/2.)*TMath::Cos(phi+delPhi/2.);
-      yCell = ((ro+zminri)/2.)*TMath::Sin(phi+delPhi/2.); 
+      yCell = ((ro+zminri)/2.)*TMath::Sin(phi+delPhi/2.);
       zCell =  0.;
       dd4hep::Transform3D comCell2(r3d2, dd4hep::Translation3D(xCell,yCell,zCell));
       dd4hep::PlacedVolume activePhysVol = aEnvelope.placeVolume(activeVol, comCell2);
@@ -453,7 +453,7 @@ namespace det {
       riLayer = ri;
       iLayer =0;
 
-  
+
 
       dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v01",  "LArTotalLayerVols.size = %d", LArTotalLayerVols.size());
 
@@ -470,7 +470,7 @@ namespace det {
     dd4hep::xml::DetElement calo = aXmlElement.child(_Unicode(calorimeter));
     dd4hep::xml::Dimension caloDim(calo.dimensions());
 
-    
+
     dd4hep::xml::DetElement blade = calo.child(_Unicode(turbineBlade));
     dd4hep::xml::DetElement nobleLiquid = blade.child(_Unicode(nobleLiquidGap));
 
@@ -512,7 +512,7 @@ namespace det {
     dd4hep::printout( dd4hep::INFO, "ECalEndcap_Turbine_o1_v01", "ECAL endcap cryostat: back: rmin (cm) =  %f rmax (cm) = %f dz (cm) = %f", cryoDim.rmax1(), cryoDim.rmax2(), cryoDim.dz());
     dd4hep::printout( dd4hep::INFO, "ECalEndcap_Turbine_o1_v01", "ECAL endcap cryostat: side: rmin (cm) =  %f rmax (cm) = %f dz (cm) = %f", cryoDim.rmin2(), cryoDim.rmax1(), cryoDim.dz() - caloDim.dz());
     dd4hep::printout( dd4hep::INFO, "ECalEndcap_Turbine_o1_v01", "Cryostat is made out of %s", cryostat.materialStr().c_str() );
-   
+
     dd4hep::Volume cryoFrontVol(cryostat.nameStr()+"_front", cryoFrontShape, aLcdd.material(cryostat.materialStr()));
     dd4hep::Volume cryoBackVol(cryostat.nameStr()+"_back", cryoBackShape, aLcdd.material(cryostat.materialStr()));
     dd4hep::Volume cryoSideVol(cryostat.nameStr()+"_side", cryoSideShape, aLcdd.material(cryostat.materialStr()));
@@ -556,7 +556,7 @@ namespace det {
   // 3. Create detector structure
   double length = dim.dz() * 2.;
   double zOffsetEnvelope = -length / 2.;
- 
+
   dd4hep::xml::DetElement supportTubeElem = calo.child(_Unicode(supportTube));
   unsigned nWheels = supportTubeElem.attr<unsigned>(_Unicode(nWheels));
   dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v01",  "Will build %d wheels",  nWheels);
@@ -570,9 +570,9 @@ namespace det {
   float supportTubeThickness=supportTubeElem.thickness();
 
   for (unsigned iWheel = 0; iWheel < nWheels; iWheel++) {
-   
+
     dd4hep::Tube supportTube(ro, ro+supportTubeThickness, bathDelZ );
-  
+
     dd4hep::Volume supportTubeVol("supportTube", supportTube, aLcdd.material(supportTubeElem.materialStr()));
     if (supportTubeElem.isSensitive()) {
       supportTubeVol.setSensitiveDetector(aSensDet);
@@ -583,7 +583,7 @@ namespace det {
     dd4hep::DetElement supportTubeDetElem(bathDetElem, "supportTube_"+std::to_string(iWheel), 0);
     supportTubeDetElem.setPlacement(supportTube_pv);
 
-   
+
     buildWheel(aLcdd, aSensDet, bathVol, aXmlElement, bathDetElem, ri+supportTubeThickness, ro, bathDelZ*2, iWheel);
     ri = ro;
     ro *= radiusRatio;
@@ -598,7 +598,7 @@ namespace det {
 
   return;
 }
-  
+
 
 
   static dd4hep::Ref_t
@@ -611,15 +611,15 @@ createECalEndcapTurbine(dd4hep::Detector& aLcdd, dd4hep::xml::Handle_t aXmlEleme
   dd4hep::DetElement caloDetElem(nameDet, idDet);
   dd4hep::xml::Dimension sdType = xmlDetElem.child(_U(sensitive));
   aSensDet.setType(sdType.typeStr());
- 
+
   ECalEndcapNumCalibLayers = aLcdd.constant<int>("ECalEndcapNumCalibLayers");
- 
+
 
   // Create air envelope for one endcap (will be copied to make both endcaps)
   dd4hep::Tube endcapShape( dim.rmin1(), dim.rmax1(), dim.dz());
 
   dd4hep::Volume envelopeVol(nameDet + "_vol", endcapShape, aLcdd.material("Air"));
-  
+
 
   dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v01",  "Placing detector on the positive side: (cm) %f  with min, max radii %f %f",dim.z_offset(), dim.rmin1(), dim.rmax1() );
 
@@ -627,7 +627,7 @@ createECalEndcapTurbine(dd4hep::Detector& aLcdd, dd4hep::xml::Handle_t aXmlEleme
   buildOneSide_Turbine(aLcdd, aSensDet, envelopeVol,  aXmlElement, iModule);
 
   dd4hep::Assembly endcapsAssembly("ECalEndcaps_turbine");
-  
+
   // Place the positive endcap
   dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v01",  "Placing detector on the positive side: (cm) %f  with min, max radii %f %f",dim.z_offset(), dim.rmin1(), dim.rmax1() );
   dd4hep::Transform3D envelopePositiveVolume_tr(dd4hep::RotationZYX( 0 ,0,0), dd4hep::Translation3D(0, 0, dim.z_offset()));
@@ -643,7 +643,7 @@ createECalEndcapTurbine(dd4hep::Detector& aLcdd, dd4hep::xml::Handle_t aXmlEleme
   envelopeNegativePhysVol.addPhysVolID("side", -1);
   dd4hep::DetElement caloNegativeDetElem(caloDetElem, "negative", 0);
   caloNegativeDetElem.setPlacement(envelopeNegativePhysVol);
-  
+
   dd4hep::Volume motherVol = aLcdd.pickMotherVolume(caloDetElem);
   dd4hep::PlacedVolume envelopePhysVol = motherVol.placeVolume(endcapsAssembly);
   caloDetElem.setPlacement(envelopePhysVol);
@@ -659,8 +659,8 @@ createECalEndcapTurbine(dd4hep::Detector& aLcdd, dd4hep::xml::Handle_t aXmlEleme
   // GM: this is the envelope - maybe save the bath dimensions instead?
   caloData->extent[0] = dim.rmin1();
   caloData->extent[1] = dim.rmax1();
-  caloData->extent[2] = dim.z_offset()-dim.dz()/2.;
-  caloData->extent[3] = dim.z_offset()+dim.dz()/2.;
+  caloData->extent[2] = dim.z_offset()-dim.dz();
+  caloData->extent[3] = dim.z_offset()+dim.dz();
 
   // Set type flags
   dd4hep::xml::setDetectorTypeFlag(xmlDetElem, caloDetElem);

--- a/detector/calorimeter/ECalEndcap_Turbine_o1_v03_geo.cpp
+++ b/detector/calorimeter/ECalEndcap_Turbine_o1_v03_geo.cpp
@@ -20,8 +20,8 @@ namespace det {
     const unsigned nWheels = 3;
 
     unsigned ECalEndcapNumCalibRhoLayersArr[nWheels], ECalEndcapNumCalibZLayersArr[nWheels];
-    
-  
+
+
     double tForArcLength(double s, double bladeangle, double delZ, double r) {
 
       // some intermediate constants
@@ -31,25 +31,25 @@ namespace det {
       double c = (TMath::Tan(s/r) +b)/(1.-b*TMath::Tan(s/r));
       double d = c*c*r*r/(1+c*c);
       return (TMath::Sqrt(d)-zp)*TMath::Sin(bladeangle);
-    
+
 
     }
 
-    // return position of the inner edge of a blade 
+    // return position of the inner edge of a blade
     double getZmin(double r, double bladeangle, double delZ) {
       // r: distance from the beamline
       // bladeangle: angle of turbine blades wrt xy plane, in radians
       // delZ: z extent of the blades
       return TMath::Sqrt(r*r - ((delZ/2)/TMath::Tan(bladeangle))*((delZ/2)/TMath::Tan(bladeangle)));
     }
-  
+
     dd4hep::Solid buildOneBlade(double thickness_inner,
 				double thickness_outer,
 				double width,
 				double ro, double ri,
 				double bladeangle,
 				double delZ,
-				double zStart) 
+				double zStart)
     {
 
       dd4hep::Solid shapeBeforeSubtraction;
@@ -57,16 +57,16 @@ namespace det {
       // set max and min extent of the blade (along the z axis in the body frame)
       double zmax = ro;
       double zmin = getZmin(ri, bladeangle, delZ);
-    
+
       dd4hep::Trd2 tmp1(thickness_inner/2., thickness_outer/2., width/2., width/2., (zmax-zmin)/2. );
       shapeBeforeSubtraction = tmp1;
- 
+
       dd4hep::Tube allowedTube(ri, ro, delZ);
 
       return dd4hep::IntersectionSolid (shapeBeforeSubtraction, allowedTube, dd4hep::Transform3D(dd4hep::RotationZYX( 0,  TMath::Pi()/2.-bladeangle, TMath::Pi()/2.),dd4hep::Position(0,-zStart, -(zmin+zmax)/2.)));
 
     }
-			      
+
     void buildWheel(dd4hep::Detector& aLcdd,
 		    dd4hep::SensitiveDetector& aSensDet,
 		    dd4hep::Volume& aEnvelope,
@@ -90,12 +90,12 @@ namespace det {
       unsigned ECalEndcapNumCalibRhoLayers = ECalEndcapNumCalibRhoLayersArr[iWheel], ECalEndcapNumCalibZLayers=ECalEndcapNumCalibZLayersArr[iWheel];
 
       unsigned LayerIndexBaseline = 0;
-      
+
       if (iWheel == 0) {
 	BladeAngle = genericBladeElem.attr<float>(_Unicode(angle1));
 	AbsThickMin = absBladeElem.attr<float>(_Unicode(thickness1));
 	BladeThicknessScaleFactor = absBladeElem.attr<float>(_Unicode(thicknessScaleFactor1));
-	
+
 	nUnitCells = genericBladeElem.attr<int>(_Unicode(nUnitCells1));
       }
       if (iWheel == 1) {
@@ -112,12 +112,12 @@ namespace det {
 	nUnitCells = genericBladeElem.attr<int>(_Unicode(nUnitCells3));
 	LayerIndexBaseline = ECalEndcapNumCalibRhoLayersArr[0]*ECalEndcapNumCalibZLayersArr[0] + ECalEndcapNumCalibRhoLayersArr[1]*ECalEndcapNumCalibZLayersArr[1];
       }
-    
+
       dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03", "Making wheel with inner, outer radii %f, %f", ri, ro);
       dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03", "Blade angle is %f ", BladeAngle);
       dd4hep::xml::Dimension dim(aXmlElement.child(_Unicode(dimensions)));
       dd4hep::printout( dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03", "delZ is %f", delZ);
-    
+
       if (TMath::Abs(TMath::Tan(BladeAngle)) < delZ/(2.*ri)) {
 	dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v03",  "The requested blade angle is too small for the given delZ and ri values.  Please adjust to at least %f degrees!",  TMath::ATan(delZ/(2.*ri))*180./TMath::Pi() );
 	return;
@@ -126,9 +126,9 @@ namespace det {
       Float_t xRange = delZ/(TMath::Sin(BladeAngle));
 
       double delrPhiNoGap;
-    
+
       float GlueThick = glueElem.attr<float>(_Unicode(thickness));
-      
+
       float CladdingThick = claddingElem.attr<float>(_Unicode(thickness));
 
       AbsThickMin = AbsThickMin-(GlueThick+CladdingThick);
@@ -137,7 +137,7 @@ namespace det {
       }
       float ElectrodeThick = electrodeBladeElem.attr<float>(_Unicode(thickness));
       float LArgapi = nobleLiquidElem.attr<float>(_Unicode(gap));
-    
+
 
       dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03",  "nUnitCells: %d", nUnitCells);
 
@@ -151,25 +151,25 @@ namespace det {
       double x2 =(AbsThickMin+(GlueThick+CladdingThick)+ElectrodeThick)/TMath::Sin(BladeAngle);
       double y2 = TMath::Sqrt(ri*ri-x2*x2);
       double rPhi1 = ri*TMath::Pi()/2.;
-      double rPhi2 = ri*TMath::ATan(y2/x2);    
+      double rPhi2 = ri*TMath::ATan(y2/x2);
       delrPhiNoGap = TMath::Abs(rPhi1-rPhi2);
       double leftoverS = (circ - nUnitCells*delrPhiNoGap);
       double delrPhiGapOnly = leftoverS/(2*nUnitCells);
       LArgapi = delrPhiGapOnly*TMath::Sin(BladeAngle);
       dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03", "LArGap at inner radius is %f", LArgapi);
-    
+
       // now find gap at outer radius
       circ = 2*TMath::Pi()*ro;
       x2 = (AbsThicko+GlueThick+CladdingThick+ElectrodeThick)/TMath::Sin(BladeAngle);
       y2 = TMath::Sqrt(ro*ro-x2*x2);
       rPhi1 = ro*TMath::Pi()/2.;
-      rPhi2 = ro*TMath::ATan(y2/x2);    
+      rPhi2 = ro*TMath::ATan(y2/x2);
       delrPhiNoGap = TMath::Abs(rPhi1-rPhi2);
       leftoverS = (circ - nUnitCells*delrPhiNoGap);
-      delrPhiGapOnly = leftoverS/(2*nUnitCells);   
+      delrPhiGapOnly = leftoverS/(2*nUnitCells);
       float LArgapo = delrPhiGapOnly*TMath::Sin(BladeAngle);
       //    LArgapo *= 2.;
-    
+
       dd4hep::Solid absBlade;
       float riLayer = ri;
 
@@ -179,16 +179,16 @@ namespace det {
       std::vector<dd4hep::Volume> LArTotalLayerVols;
       std::vector<dd4hep::Volume> electrodeBladeLayerVols;
 
-   
+
       dd4hep::Solid passiveShape = buildOneBlade(AbsThicki+GlueThick+CladdingThick, AbsThicko+GlueThick+CladdingThick, xRange, ro, ri, BladeAngle, delZ, 0 );
       dd4hep::Volume passiveVol("passive", passiveShape, aLcdd.material("Air"));
 
       dd4hep::Solid activeShape = buildOneBlade(ElectrodeThick+LArgapi*2, ElectrodeThick+LArgapo*2, xRange, ro, ri, BladeAngle, delZ, 0);
       dd4hep::Volume activeVol("active", activeShape, aLcdd.material("Air"));
-    
+
       unsigned numNonActiveRhoLayers = 1;
       unsigned numNonActiveZLayers = 1;
-      
+
       // check that either all non-active volumes are set to sensitive (for
       // sampling fraction calculations) or none are (for normal running)
       bool allNonActiveSensitive = ( claddingElem.isSensitive() &&
@@ -206,40 +206,40 @@ namespace det {
       else if (!allNonActiveNotSensitive) {
 	dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v03",  "Some non-active layers are sensitive and others are not -- this is likely a misconfiguration");
       }
-    
+
       float delrNonActive = (ro-ri)/numNonActiveRhoLayers;
       float delrActive = (ro-ri)/ECalEndcapNumCalibRhoLayers;
 
       for (unsigned iRhoLayer = 0; iRhoLayer < numNonActiveRhoLayers; iRhoLayer++) {
 	float roLayer = riLayer + delrNonActive;
 	dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v03", "Making layer with inner, outer radii %f, %f", riLayer, roLayer);
- 
+
 	AbsThicko = AbsThicki + BladeThicknessScaleFactor*((roLayer/riLayer)-1.)*AbsThicki;
 
 	dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03",  "Inner and outer absorber thicknesses %f, %f ", AbsThicki,  AbsThicko);
 
 	float zStart = -xRange/2. + xRange/(2.*numNonActiveZLayers);
-	
+
 	for (unsigned iZLayer = 0; iZLayer < numNonActiveZLayers; iZLayer++) {
-	
+
 	  dd4hep::Solid claddingLayer = buildOneBlade(AbsThicki+GlueThick+CladdingThick, AbsThicko+GlueThick+CladdingThick, xRange/numNonActiveZLayers, roLayer, riLayer, BladeAngle, delZ, zStart );
-      
+
 	  dd4hep::Solid glueLayer = buildOneBlade(AbsThicki+GlueThick, AbsThicko+GlueThick, xRange/numNonActiveZLayers, roLayer, riLayer, BladeAngle, delZ, zStart );
 
 	  dd4hep::Solid  absBladeLayer = buildOneBlade(AbsThicki, AbsThicko, xRange/numNonActiveZLayers, roLayer, riLayer, BladeAngle, delZ, zStart );
-     
+
 	  dd4hep::Volume claddingLayerVol("claddingLayer", claddingLayer, aLcdd.material(claddingElem.materialStr()));
 	  if (claddingElem.isSensitive()) {
 	    claddingLayerVol.setSensitiveDetector(aSensDet);
 	  }
 	  claddingLayerVols.push_back(claddingLayerVol);
-	  
+
 	  dd4hep::Volume glueLayerVol("glueLayer", glueLayer, aLcdd.material(glueElem.materialStr()));
 	  if (glueElem.isSensitive()) {
 	    glueLayerVol.setSensitiveDetector(aSensDet);
 	  }
 	  glueLayerVols.push_back(glueLayerVol);
-	  
+
 	  dd4hep::Volume absBladeLayerVol("absBladeLayer", absBladeLayer, aLcdd.material(absBladeElem.materialStr()));
 	  if (absBladeElem.isSensitive()) {
 	    absBladeLayerVol.setSensitiveDetector(aSensDet);
@@ -252,17 +252,17 @@ namespace det {
 	AbsThicki = AbsThicko;
 
       }
-    
+
 
       riLayer = ri;
 
       AbsThicki = AbsThickMin;
 
-      
+
       for (unsigned iRhoLayer = 0; iRhoLayer < ECalEndcapNumCalibRhoLayers; iRhoLayer++) {
 
 	float roLayer = riLayer + delrActive;
-	
+
 	AbsThicko = AbsThicki + BladeThicknessScaleFactor*((roLayer/riLayer)-1.)*AbsThicki;
 
 	// now find gap at outer layer
@@ -270,43 +270,43 @@ namespace det {
 	x2 = (AbsThicko+GlueThick+CladdingThick+ElectrodeThick)/TMath::Sin(BladeAngle);
 	y2 = TMath::Sqrt(roLayer*roLayer-x2*x2);
 	rPhi1 = roLayer*TMath::Pi()/2.;
-	rPhi2 = roLayer*TMath::ATan(y2/x2);    
+	rPhi2 = roLayer*TMath::ATan(y2/x2);
 	delrPhiNoGap = TMath::Abs(rPhi1-rPhi2);
 	leftoverS = (circ - nUnitCells*delrPhiNoGap);
-	delrPhiGapOnly = leftoverS/(2*nUnitCells);   
+	delrPhiGapOnly = leftoverS/(2*nUnitCells);
 	LArgapo = delrPhiGapOnly*TMath::Sin(BladeAngle);
 	dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03",  "Outer LAr gap is %f", LArgapo) ;
 	dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v03", "Inner and outer thicknesses of noble liquid volume %f, %f", ElectrodeThick+LArgapi*2,  ElectrodeThick+LArgapo*2);
 
 	float zStart = -xRange/2. + xRange/(2.*ECalEndcapNumCalibZLayers);
-	
+
 	for (unsigned iZLayer = 0; iZLayer < ECalEndcapNumCalibZLayers; iZLayer++) {
-	  
+
 	  dd4hep::Solid electrodeBladeAndGapLayer = buildOneBlade(ElectrodeThick+LArgapi*2, ElectrodeThick+LArgapo*2, xRange/ECalEndcapNumCalibZLayers, roLayer, riLayer, BladeAngle, delZ, zStart);
-	  
+
 	  dd4hep::Solid electrodeBladeLayer = buildOneBlade(ElectrodeThick, ElectrodeThick, xRange/ECalEndcapNumCalibZLayers, roLayer, riLayer, BladeAngle, delZ, zStart);
-	  
+
 	  dd4hep::Volume electrodeBladeLayerVol("electrodeBladeLayer", electrodeBladeLayer, aLcdd.material(electrodeBladeElem.materialStr()));
 	  if (electrodeBladeElem.isSensitive()) {
-	    electrodeBladeLayerVol.setSensitiveDetector(aSensDet); 
+	    electrodeBladeLayerVol.setSensitiveDetector(aSensDet);
 	  }
 	  electrodeBladeLayerVols.push_back(electrodeBladeLayerVol);
-	  
+
 	  dd4hep::Volume LArTotalLayerVol("LArTotalLayerVol", electrodeBladeAndGapLayer,  aLcdd.material(nobleLiquidElem.materialStr()));
-	  
+
 	  if ( nobleLiquidElem.isSensitive() ) {
 	    LArTotalLayerVol.setSensitiveDetector(aSensDet);
 	  }
 	  LArTotalLayerVols.push_back(LArTotalLayerVol);
 
 	  zStart += xRange/ECalEndcapNumCalibZLayers;
-	}	  
+	}
 	riLayer = roLayer;
 	LArgapi = LArgapo;
 	AbsThicki = AbsThicko;
-       
+
       }
-      dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v03",  "ECal endcap materials:  nobleLiquid: %s absorber %s electrode %s",  nobleLiquidElem.materialStr().c_str(), absBladeElem.materialStr().c_str(), electrodeBladeElem.materialStr().c_str() ); 
+      dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v03",  "ECal endcap materials:  nobleLiquid: %s absorber %s electrode %s",  nobleLiquidElem.materialStr().c_str(), absBladeElem.materialStr().c_str(), electrodeBladeElem.materialStr().c_str() );
 
       int    nUnitCellsToDraw = nUnitCells;
 
@@ -319,7 +319,7 @@ namespace det {
       riLayer = ri;
 
       double xOffset = -xRange/2 + xRange/(2*numNonActiveZLayers);
-      
+
       for (auto absBladeLayerVol: absBladeLayerVols) {
 
 	float roLayer = riLayer+delrNonActive;
@@ -327,14 +327,14 @@ namespace det {
 	dd4hep::Position posLayer(0,0,0);
 	xOffset += xRange/numNonActiveZLayers;
 	dd4hep::PlacedVolume absBladeVol_pv = glueLayerVols[iLayer].placeVolume(absBladeLayerVol, posLayer);
-      
+
 	absBladeVol_pv.addPhysVolID("subtype", 1); // 1 = absorber, 2 = glue, 3 = cladding
 	dd4hep::printout( dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03_geo",  "Blade layer, rho is %d, %f, %f", iLayer, absBladeVol_pv.position().Rho(), roLayer/2.);
 	absBladeVol_pv.addPhysVolID("layer", LayerIndexBaseline+iLayer);
 
 	dd4hep::printout( dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03_geo",  "AbsBalde volume %s", absBladeVol_pv.toString().c_str());
 
-	
+
 	iLayer++;
 	if (iLayer % numNonActiveZLayers ==0) {
 	  riLayer = roLayer;
@@ -342,20 +342,20 @@ namespace det {
 	}
       }
 
-     
+
       riLayer = ri;
       iLayer =0;
 
       xOffset = -xRange/2 + xRange/(2*numNonActiveZLayers);
-      
+
       for (auto glueLayerVol: glueLayerVols) {
 
 	float roLayer = riLayer+delrNonActive;
-       
+
 	dd4hep::Position posLayer(0,xOffset/2.,0);
 	dd4hep::PlacedVolume glueVol_pv = claddingLayerVols[iLayer].placeVolume(glueLayerVol, posLayer);
 	xOffset += xRange/numNonActiveZLayers;
-      
+
 	glueVol_pv.addPhysVolID("subtype", 2); // 1 = absorber, 2 = glue, 3 = cladding
 	glueVol_pv.addPhysVolID("layer", LayerIndexBaseline+iLayer);
 
@@ -367,25 +367,25 @@ namespace det {
 	  xOffset = -xRange/2 + xRange/(2*numNonActiveZLayers);
 	}
       }
-  
-      
+
+
       riLayer = ri;
       iLayer =0;
 
       double zminri = getZmin(ri, BladeAngle, delZ);
 
       xOffset = -xRange/2 + xRange/(2*numNonActiveZLayers);
-     
+
       for (auto claddingLayerVol: claddingLayerVols) {
 
 	float roLayer = riLayer+delrNonActive;
-          
+
 	double zminLayer = getZmin(riLayer, BladeAngle, delZ);
 
 	dd4hep::Position posLayer(0,xOffset/2.,(zminLayer-zminri+roLayer-ro)/2.);
 	xOffset +=  xRange/numNonActiveZLayers;
 	dd4hep::PlacedVolume claddingVol_pv = passiveVol.placeVolume(claddingLayerVol, posLayer);
-            
+
 	claddingVol_pv.addPhysVolID("subtype", 3); // 1 = absorber, 2 = glue, 3 = cladding
 	claddingVol_pv.addPhysVolID("layer", LayerIndexBaseline+iLayer);
 
@@ -398,18 +398,18 @@ namespace det {
 	}
 
       }
-    
-    
+
+
       riLayer = ri;
       iLayer = 0;
 
       xOffset = -xRange/2 + xRange/(2*ECalEndcapNumCalibZLayers);
-      
+
       for (auto electrodeBladeLayerVol: electrodeBladeLayerVols) {
-      
+
 	float roLayer = riLayer+delrActive;
 	dd4hep::Position posLayer(0,0,0);
-      
+
 	dd4hep::PlacedVolume electrodeBladeVol_pv = LArTotalLayerVols[iLayer].placeVolume(electrodeBladeLayerVol, posLayer);
 	xOffset += xRange/ECalEndcapNumCalibZLayers;
 	electrodeBladeVol_pv.addPhysVolID("layer", LayerIndexBaseline+iLayer);
@@ -430,18 +430,18 @@ namespace det {
       std::vector<dd4hep::PlacedVolume> LArVol_pvs;
 
       xOffset = -xRange/2 + xRange/(2*ECalEndcapNumCalibZLayers);
-      
+
       for (auto LArTotalLayerVol: LArTotalLayerVols) {
-     
-	float roLayer = riLayer+delrActive;   
+
+	float roLayer = riLayer+delrActive;
 
 	double zminLayer = getZmin(riLayer, BladeAngle, delZ);
-          
+
 	dd4hep::Position posLayer(0,xOffset,(zminLayer-zminri+roLayer-ro)/2.);
 
 	dd4hep::PlacedVolume LArVol_pv(activeVol.placeVolume(LArTotalLayerVol, posLayer));
 	xOffset += xRange/ECalEndcapNumCalibZLayers;
-	
+
 	dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03",  "LAr layer: %d layer in readout: %d", iLayer, LayerIndexBaseline+iLayer );
 	LArVol_pv.addPhysVolID("layer", LayerIndexBaseline+iLayer);
 	LArVol_pvs.push_back(LArVol_pv);
@@ -453,9 +453,9 @@ namespace det {
 	  riLayer = roLayer;
 	  xOffset = -xRange/2 + xRange/(2*ECalEndcapNumCalibZLayers);
 	}
-	
+
       }
-		
+
       for (int iUnitCell = 0; iUnitCell < nUnitCellsToDraw; iUnitCell++) {
 
 	int modIndex = iUnitCell-nUnitCellsToDraw/2;
@@ -467,7 +467,7 @@ namespace det {
 
 	TGeoRotation tgr;
 	tgr.RotateZ(BladeAngle*180/TMath::Pi());
-	tgr.RotateX(-phi*180/TMath::Pi());   
+	tgr.RotateX(-phi*180/TMath::Pi());
 	tgr.RotateY(90);
 
 	const Double_t *rotMatPtr;
@@ -481,12 +481,12 @@ namespace det {
 
 	tgr.Clear();
 	tgr.RotateZ(BladeAngle*180/TMath::Pi());
-	tgr.RotateX(-(phi+delPhi/2.)*180/TMath::Pi());   
+	tgr.RotateX(-(phi+delPhi/2.)*180/TMath::Pi());
 	tgr.RotateY(90);
-      
+
 	rotMatPtr = tgr.GetRotationMatrix();
 	TMatrixT<Double_t> rotMat2(3,3, rotMatPtr);
-	dd4hep::Rotation3D r3d2; 
+	dd4hep::Rotation3D r3d2;
 	r3d2.SetComponents(rotMat2(0,0), rotMat2(0,1), rotMat2(0,2),
 			   rotMat2(1,0), rotMat2(1,1), rotMat2(1,2),
 			   rotMat2(2,0), rotMat2(2,1), rotMat2(2,2));
@@ -497,8 +497,8 @@ namespace det {
 	float yCell = ((ro+zminri)/2.)*TMath::Sin(phi); //ri*TMath::Sin(phi)/6.;
 	float zCell =  offsetZ;
 
-	dd4hep::Transform3D comCell(r3d, dd4hep::Translation3D(xCell,yCell,zCell));	
-      
+	dd4hep::Transform3D comCell(r3d, dd4hep::Translation3D(xCell,yCell,zCell));
+
 	// place passive volume in LAr bath
 	dd4hep::PlacedVolume passivePhysVol = aEnvelope.placeVolume(passiveVol, comCell);
 	passivePhysVol.addPhysVolID("module", modIndex);
@@ -522,7 +522,7 @@ namespace det {
 	dd4hep::DetElement activeDetElem(bathDetElem, "active" + std::to_string(iUnitCell)+"_"+std::to_string(iWheel), modIndex);
 
 	dd4hep::printout( dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03_geo",  "Active volume %s", activePhysVol.toString().c_str());
-	
+
 	activeDetElem.setPlacement(activePhysVol);
 	iLayer = 0;
 	for (auto LArVol_pv: LArVol_pvs) {
@@ -530,11 +530,11 @@ namespace det {
 	  LArDetElem.setPlacement(LArVol_pv);
 	  iLayer++;
 	}
-	
+
 	riLayer = ri;
 	iLayer =0;
 
-  
+
 	dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03",  "LArTotalLayerVols.size = %d", LArTotalLayerVols.size());
 
       }
@@ -550,13 +550,13 @@ namespace det {
       dd4hep::xml::DetElement calo = aXmlElement.child(_Unicode(calorimeter));
       dd4hep::xml::Dimension caloDim(calo.dimensions());
 
-    
+
       dd4hep::xml::DetElement blade = calo.child(_Unicode(turbineBlade));
       dd4hep::xml::DetElement nobleLiquid = blade.child(_Unicode(nobleLiquidGap));
 
       dd4hep::xml::DetElement xmlDetElem = aXmlElement;
       std::string nameDet = xmlDetElem.nameStr();
-   
+
       dd4hep::xml::Dimension dim(aXmlElement.child(_Unicode(dimensions)));
 
       //build cryostat
@@ -566,8 +566,8 @@ namespace det {
       double cryoThicknessFront = aLcdd.constant<float>("CryoEMECThicknessFront");
       double cryoThicknessBack = aLcdd.constant<float>("CryoEMECThicknessBack");
       double bathThicknessFront = aLcdd.constant<float>("BathThicknessFront");
-      double bathThicknessBack = aLcdd.constant<float>("BathThicknessBack");   
-      
+      double bathThicknessBack = aLcdd.constant<float>("BathThicknessBack");
+
       dd4hep::xml::DetElement cryoFront = cryostat.child(_Unicode(front));
       dd4hep::xml::DetElement cryoBack = cryostat.child(_Unicode(back));
       dd4hep::xml::DetElement cryoInner = cryostat.child(_Unicode(inner));
@@ -577,7 +577,7 @@ namespace det {
       bool cryoBackSensitive = cryoBack.isSensitive();
       bool cryoInnerSensitive = cryoInner.isSensitive();
       bool cryoOuterSensitive = cryoOuter.isSensitive();
-      
+
       double bathRmin = cryoDim.rmin2(); // - margin for inclination
       double bathRmax = cryoDim.rmax1(); // + margin for inclination
       double bathDelZ = cryoDim.dz();
@@ -590,12 +590,12 @@ namespace det {
 	dd4hep::Tube cryoFrontShape(cryoDim.rmin1(), cryoDim.rmax2(), cryoThicknessFront/2.);
 	dd4hep::Tube cryoBackShape(cryoDim.rmin2(), cryoDim.rmax2(), cryoThicknessBack/2.);
 	dd4hep::Tube cryoInnerShape(cryoDim.rmin1(), cryoDim.rmin2(), cryoDim.dz());
-	dd4hep::Tube cryoOuterShape(cryoDim.rmax1(), cryoDim.rmax2(), cryoDim.dz());	
+	dd4hep::Tube cryoOuterShape(cryoDim.rmax1(), cryoDim.rmax2(), cryoDim.dz());
 	dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v03",  "ECAL endcap cryostat: front: rmin (cm) = %f rmax (cm) = %f dz (cm) = %f ", cryoDim.rmin1(),  cryoDim.rmin2(),  cryoDim.dz());
 	dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v03",  "ECAL encdap cryostat: back: rmin (cm) =  %f rmax (cm) = %f dz (cm) = %f", cryoDim.rmax1(), cryoDim.rmax2(), cryoDim.dz());
 	dd4hep::printout( dd4hep::INFO, "ECalEndcap_Turbine_o1_v03", "ECAL endcap cryostat: side: rmin (cm) =  %f rmax (cm) = %f dz (cm) = %f", cryoDim.rmin2(), cryoDim.rmax1(), cryoDim.dz() - caloDim.dz());
 	dd4hep::printout( dd4hep::INFO, "ECalEndcap_Turbine_o1_v03",  "Cryostat is made out of %s", cryostat.materialStr().c_str() );
-   
+
 	dd4hep::Volume cryoFrontVol(cryostat.nameStr()+"_front", cryoFrontShape, aLcdd.material(cryostat.materialStr()));
 	dd4hep::Volume cryoBackVol(cryostat.nameStr()+"_back", cryoBackShape, aLcdd.material(cryostat.materialStr()));
 	dd4hep::Volume cryoInnerVol(cryostat.nameStr()+"_inner", cryoInnerShape, aLcdd.material(cryostat.materialStr()));
@@ -603,10 +603,10 @@ namespace det {
 
 	dd4hep::Position cryoFrontPos(0,0,-cryoDim.dz());
 	dd4hep::PlacedVolume cryoFrontPhysVol = aEnvelope.placeVolume(cryoFrontVol, cryoFrontPos);
-	dd4hep::Position cryoBackPos(0,0,cryoDim.dz());	
+	dd4hep::Position cryoBackPos(0,0,cryoDim.dz());
 	dd4hep::PlacedVolume cryoBackPhysVol = aEnvelope.placeVolume(cryoBackVol, cryoBackPos);
 	dd4hep::PlacedVolume cryoInnerPhysVol = aEnvelope.placeVolume(cryoInnerVol);
-	dd4hep::PlacedVolume cryoOuterPhysVol = aEnvelope.placeVolume(cryoOuterVol);	
+	dd4hep::PlacedVolume cryoOuterPhysVol = aEnvelope.placeVolume(cryoOuterVol);
 	unsigned sidetype = 0x4;  // probably not needed anymore...
 	if (cryoFrontSensitive) {
 	  cryoFrontVol.setSensitiveDetector(aSensDet);
@@ -631,7 +631,7 @@ namespace det {
 	  cryoOuterPhysVol.addPhysVolID("cryo", 1);
 	  cryoOuterPhysVol.addPhysVolID("type", sidetype+4);
 	  dd4hep::printout( dd4hep::INFO, "ECalEndcap_Turbine_o1_v03",  "Cryostat outer volume set as sensitive" );
-	}	
+	}
 	dd4hep::DetElement cryoFrontDetElem(caloDetElem, "cryo_front", 0);
 	cryoFrontDetElem.setPlacement(cryoFrontPhysVol);
 	dd4hep::DetElement cryoBackDetElem(caloDetElem, "cryo_back", 0);
@@ -641,16 +641,16 @@ namespace det {
 	dd4hep::DetElement cryoOuterDetElem(caloDetElem, "cryo_outer", 0);
 	cryoOuterDetElem.setPlacement(cryoOuterPhysVol);
       }
-						     
+
       // 2. Create noble liquid bath
       std::string nobleLiquidMaterial = nobleLiquid.materialStr();
       dd4hep::Volume bathVol(nobleLiquidMaterial + "_bath", bathOuterShape, aLcdd.material(nobleLiquidMaterial));
       dd4hep::printout( dd4hep::INFO, "ECalEndcap_Turbine_o1_v03", "ECAL endcap bath: material = %s rmin (cm) = %f rmax (cm) = %f, dz (cm) = %f, thickness in front of ECal (cm) = %f,  thickness behind ECal (cm) = %f", nobleLiquidMaterial.c_str(),  bathRmin, bathRmax, caloDim.dz(), caloDim.rmin() - cryoDim.rmin2(), cryoDim.rmax1() - caloDim.rmax());
 
       dd4hep::Position bathPos(0,0,(cryoThicknessFront-cryoThicknessBack)/2.);
-      
+
       dd4hep::PlacedVolume bathPhysVol = aEnvelope.placeVolume(bathVol, bathPos);
- 
+
       dd4hep::DetElement bathDetElem(caloDetElem, "bath", 1);
 
       bathDetElem.setPlacement(bathPhysVol);
@@ -658,13 +658,13 @@ namespace det {
       // 3. Create detector structure
       double length = dim.dz() * 2.;
       double zOffsetEnvelope = -length / 2.;
- 
+
       dd4hep::xml::DetElement supportTubeElem = calo.child(_Unicode(supportTube));
       unsigned nWheelsXML = supportTubeElem.attr<unsigned>(_Unicode(nWheels));
       if (nWheelsXML != nWheels) {
 	dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v03",  "Number of wheels in XML (%d) does not match hard-coded number of wheels (%d) ",  nWheelsXML, nWheels);
       }
-      
+
       dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v03",  "Will build %d wheels",  nWheels);
       double rmin = bathRmin;
       double rmax = bathRmax;
@@ -675,11 +675,11 @@ namespace det {
       float supportTubeThickness=supportTubeElem.thickness();
       unsigned iSupportTube = 0;
 
-      
+
       for (unsigned iWheel = 0; iWheel < nWheels; iWheel++) {
-   
+
 	dd4hep::Tube supportTube(ro, ro+supportTubeThickness, bathDelZ );
-  
+
 	dd4hep::Volume supportTubeVol("supportTube", supportTube, aLcdd.material(supportTubeElem.materialStr()));
 	if (supportTubeElem.isSensitive()) {
 	  supportTubeVol.setSensitiveDetector(aSensDet);
@@ -690,7 +690,7 @@ namespace det {
 	dd4hep::DetElement supportTubeDetElem(bathDetElem, "supportTube_"+std::to_string(iWheel), 0);
 	supportTubeDetElem.setPlacement(supportTube_pv);
 
-   
+
 	buildWheel(aLcdd, aSensDet, bathVol, aXmlElement, bathDetElem, ri+supportTubeThickness, ro, bathDelZ*2-bathThicknessFront-bathThicknessBack, (bathThicknessFront-bathThicknessBack)/2., iWheel);
 	ri = ro;
 	ro *= radiusRatio;
@@ -704,7 +704,7 @@ namespace det {
 
       return;
     }
-  
+
 
 
     static dd4hep::Ref_t
@@ -723,38 +723,38 @@ namespace det {
       numReadoutRhoLayers = aLcdd.constant<int>("ECalEndcapNumReadoutRhoLayersWheel1");
       if ((numReadoutRhoLayers % ECalEndcapNumCalibRhoLayersArr[0]) != 0) {
 	dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v03",  "Number of readout layers must be a multiple of number of calibration layers");
-      }      
+      }
       ECalEndcapNumCalibRhoLayersArr[1] = aLcdd.constant<int>("ECalEndcapNumCalibRhoLayersWheel2");
       numReadoutRhoLayers = aLcdd.constant<int>("ECalEndcapNumReadoutRhoLayersWheel2");
       if ((numReadoutRhoLayers % ECalEndcapNumCalibRhoLayersArr[1]) != 0) {
 	dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v03",  "Number of readout layers must be a multiple of number of calibration layers");
-      }      
+      }
       ECalEndcapNumCalibRhoLayersArr[2] = aLcdd.constant<int>("ECalEndcapNumCalibRhoLayersWheel3");
       numReadoutRhoLayers = aLcdd.constant<int>("ECalEndcapNumReadoutRhoLayersWheel3");
       if ((numReadoutRhoLayers % ECalEndcapNumCalibRhoLayersArr[2]) != 0) {
 	dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v03",  "Number of readout layers must be a multiple of number of calibration layers");
-      }      
+      }
       ECalEndcapNumCalibZLayersArr[0] = aLcdd.constant<int>("ECalEndcapNumCalibZLayersWheel1");
       numReadoutZLayers = aLcdd.constant<int>("ECalEndcapNumReadoutZLayersWheel1");
       if ((numReadoutZLayers % ECalEndcapNumCalibZLayersArr[0]) != 0) {
 	dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v03",  "Number of readout layers must be a multiple of number of calibration layers");
-      }      
+      }
       ECalEndcapNumCalibZLayersArr[1] = aLcdd.constant<int>("ECalEndcapNumCalibZLayersWheel2");
       numReadoutZLayers = aLcdd.constant<int>("ECalEndcapNumReadoutZLayersWheel2");
       if ((numReadoutZLayers % ECalEndcapNumCalibZLayersArr[1]) != 0) {
 	dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v03",  "Number of readout layers must be a multiple of number of calibration layers");
-      }  
+      }
       ECalEndcapNumCalibZLayersArr[2] = aLcdd.constant<int>("ECalEndcapNumCalibZLayersWheel3");
       numReadoutZLayers = aLcdd.constant<int>("ECalEndcapNumReadoutZLayersWheel3");
       if ((numReadoutZLayers % ECalEndcapNumCalibZLayersArr[2]) != 0) {
 	dd4hep::printout(dd4hep::ERROR, "ECalEndcap_Turbine_o1_v03",  "Number of readout layers must be a multiple of number of calibration layers");
-      }  
-      
+      }
+
       // Create air envelope for one endcap (will be copied to make both endcaps)
       dd4hep::Tube endcapShape( dim.rmin1(), dim.rmax1(), dim.dz());
 
       dd4hep::Volume envelopeVol(nameDet + "_vol", endcapShape, aLcdd.material("Air"));
-  
+
 
       dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03",  "Placing detector on the positive side: (cm) %f  with min, max radii %f %f",dim.z_offset(), dim.rmin1(), dim.rmax1() );
 
@@ -762,7 +762,7 @@ namespace det {
       buildOneSide_Turbine(aLcdd, caloDetElem, aSensDet, envelopeVol,  aXmlElement, iModule);
 
       dd4hep::Assembly endcapsAssembly("ECalEndcaps_turbine");
-  
+
       // Place the envelope
       dd4hep::Transform3D envelopePositiveVolume_tr(dd4hep::RotationZYX( 0 ,0,0), dd4hep::Translation3D(0, 0, dim.z_offset()));
       dd4hep::PlacedVolume envelopePositivePhysVol = endcapsAssembly.placeVolume(envelopeVol, envelopePositiveVolume_tr);
@@ -773,7 +773,7 @@ namespace det {
       dd4hep::PlacedVolume envelopeNegativePhysVol =
 	endcapsAssembly.placeVolume(envelopeVol, envelopeNegativeVolume_tr);
       envelopeNegativePhysVol.addPhysVolID("side", -1);
-  
+
       dd4hep::Volume motherVol = aLcdd.pickMotherVolume(caloDetElem);
       dd4hep::PlacedVolume envelopePhysVol = motherVol.placeVolume(endcapsAssembly);
       caloDetElem.setPlacement(envelopePhysVol);
@@ -788,8 +788,8 @@ namespace det {
       // save extent information
       caloData->extent[0] = dim.rmin1();
       caloData->extent[1] = dim.rmax1();
-      caloData->extent[2] = dim.z_offset()-dim.dz()/2.;
-      caloData->extent[3] = dim.z_offset()+dim.dz()/2.;
+      caloData->extent[2] = dim.z_offset()-dim.dz();
+      caloData->extent[3] = dim.z_offset()+dim.dz();
 
       // Set type flags
       dd4hep::xml::setDetectorTypeFlag(xmlDetElem, caloDetElem);


### PR DESCRIPTION
two-line bugfix in the envelope data (for reconstruction) being saved for the endcap turbine, dz is already the half length of the detector, and was further divided by 2 by mistake
- [X] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [X] the PR does not contain any additions or modifications that do not belong to it
- [X] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Fix envelope of endcap turbine saved in detector data extension for reconstruction

ENDRELEASENOTES

