### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/detector/calorimeter/ECalEndcap_Turbine_o1_v01_geo.cpp
+++ b/detector/calorimeter/ECalEndcap_Turbine_o1_v01_geo.cpp
@@ -4,15 +4,6 @@
 #include "XML/Utilities.h"
 #include <DDRec/DetectorData.h>
 
-// todo: remove gaudi logging and properly capture output
-#define endmsg std::endl
-#define lLog std::cout
-namespace MSG {
-const std::string ERROR = " Error: ";
-const std::string DEBUG = " Debug: ";
-const std::string INFO = " Info: ";
-} // namespace MSG
-
 namespace det {
 
 unsigned ECalEndCapElementCounter = 0;

--- a/detector/calorimeter/ECalEndcap_Turbine_o1_v02_geo.cpp
+++ b/detector/calorimeter/ECalEndcap_Turbine_o1_v02_geo.cpp
@@ -5,17 +5,6 @@
 #include "XML/Utilities.h"
 #include <DDRec/DetectorData.h>
 
-// todo: remove gaudi logging and properly capture output
-#define endmsg std::endl
-#define lLog std::cout
-namespace MSG {
-
-const std::string ERROR = " Error: ";
-const std::string DEBUG = " Debug: ";
-const std::string INFO = " Info: ";
-
-} // namespace MSG
-
 namespace det {
 
 namespace ECalEndcap_Turbine_o1_v02 {
@@ -174,7 +163,6 @@ namespace ECalEndcap_Turbine_o1_v02 {
     delrPhiGapOnly = leftoverS / (2 * nUnitCells);
     float LArgapo = delrPhiGapOnly * TMath::Sin(BladeAngle);
 
-    dd4hep::Solid absBlade;
     float riLayer = ri;
 
     std::vector<dd4hep::Volume> claddingLayerVols;
@@ -648,7 +636,6 @@ namespace ECalEndcap_Turbine_o1_v02 {
     double ri = rmin;
 
     float supportTubeThickness = supportTubeElem.thickness();
-    unsigned iSupportTube = 0;
 
     for (unsigned iWheel = 0; iWheel < nWheels; iWheel++) {
 
@@ -671,7 +658,6 @@ namespace ECalEndcap_Turbine_o1_v02 {
       ro *= radiusRatio;
       if (ro > rmax)
         ro = rmax;
-      iSupportTube++;
     }
 
     dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v02", "Total number of modules:  %d", iModule);

--- a/detector/calorimeter/ECalEndcap_Turbine_o1_v03_geo.cpp
+++ b/detector/calorimeter/ECalEndcap_Turbine_o1_v03_geo.cpp
@@ -4,15 +4,6 @@
 #include "XML/Utilities.h"
 #include <DDRec/DetectorData.h>
 
-// todo: remove gaudi logging and properly capture output
-#define endmsg std::endl
-#define lLog std::cout
-namespace MSG {
-const std::string ERROR = " Error: ";
-const std::string DEBUG = " Debug: ";
-const std::string INFO = " Info: ";
-} // namespace MSG
-
 namespace det {
 
 namespace ECalEndcap_Turbine_o1_v03 {
@@ -164,7 +155,6 @@ namespace ECalEndcap_Turbine_o1_v03 {
     float LArgapo = delrPhiGapOnly * TMath::Sin(BladeAngle);
     //    LArgapo *= 2.;
 
-    dd4hep::Solid absBlade;
     float riLayer = ri;
 
     std::vector<dd4hep::Volume> claddingLayerVols;
@@ -698,7 +688,6 @@ namespace ECalEndcap_Turbine_o1_v03 {
     double ri = rmin;
 
     float supportTubeThickness = supportTubeElem.thickness();
-    unsigned iSupportTube = 0;
 
     for (unsigned iWheel = 0; iWheel < nWheels; iWheel++) {
 
@@ -722,7 +711,6 @@ namespace ECalEndcap_Turbine_o1_v03 {
       ro *= radiusRatio;
       if (ro > rmax)
         ro = rmax;
-      iSupportTube++;
     }
 
     dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03", "Total number of modules:  %d", iModule);

--- a/detector/calorimeter/dual-readout-tubes/include/DRTubesconstructor.h
+++ b/detector/calorimeter/dual-readout-tubes/include/DRTubesconstructor.h
@@ -9,14 +9,12 @@
 
 #include "DRutils.h"
 
-using namespace dd4hep;
-
 namespace DRBarrelTubes {
 
 class DRTubesconstructor {
 public:
   // Constructor
-  DRTubesconstructor(Detector* description, xml_h& entities, SensitiveDetector* sens);
+  DRTubesconstructor(dd4hep::Detector* description, xml_h& entities, dd4hep::SensitiveDetector* sens);
 
   // Destructor
   ~DRTubesconstructor() {}
@@ -42,29 +40,29 @@ public:
   double calculate_tower_width(int given_row, bool backface = true);
 
   // Function to calculate the tube lengths and place them to create the actual tower (not the air)
-  void assemble_tower(Volume& tower_air_volume);
+  void assemble_tower(dd4hep::Volume& tower_air_volume);
 
   // Mostly just a wrapper function
-  void construct_tower_trapezoid(Volume& trap_volume);
+  void construct_tower_trapezoid(dd4hep::Volume& trap_volume);
 
   // Function to calculate the position of the tower inside the stave
   void calculate_tower_position();
 
   // Function to construct the trapezoidal support structure for the tower in which fibres are placed
-  void construct_tower(Volume& trap_volume);
+  void construct_tower(dd4hep::Volume& trap_volume);
 
   void increase_covered_theta(const double& delta_theta) { m_covered_theta += delta_theta; }
 
   // Function to place the tower in the stave volume
-  void place_tower(Volume& stave_volume, Volume& tower_volume, unsigned int layer);
+  void place_tower(dd4hep::Volume& stave_volume, dd4hep::Volume& tower_volume, unsigned int layer);
 
   // Overarching function to construct the calorimeter
-  void construct_calorimeter(Volume& calorimeter_volume);
+  void construct_calorimeter(dd4hep::Volume& calorimeter_volume);
 
 private:
-  Detector* m_description;
+  dd4hep::Detector* m_description;
   xml_h m_entities;
-  SensitiveDetector* m_sens;
+  dd4hep::SensitiveDetector* m_sens;
 
   // Calorimeter parameters
   double m_calo_inner_r;
@@ -79,11 +77,11 @@ private:
   double m_scin_core_outer_r;
   double m_cher_clad_outer_r;
   double m_cher_core_outer_r;
-  Material m_capillary_material;
-  Material m_scin_clad_material;
-  Material m_scin_core_material;
-  Material m_cher_clad_material;
-  Material m_cher_core_material;
+  dd4hep::Material m_capillary_material;
+  dd4hep::Material m_scin_clad_material;
+  dd4hep::Material m_scin_core_material;
+  dd4hep::Material m_cher_clad_material;
+  dd4hep::Material m_cher_core_material;
   std::string m_capillary_visString;
   std::string m_scin_clad_visString;
   std::string m_scin_core_visString;
@@ -97,8 +95,8 @@ private:
 
   // Maps to store the tube volumes, so that one volume can be used multiple times
   // The key to the map is an indicator of the tube length (multiple of the tolerance)
-  std::unordered_map<int, Volume> m_scin_tube_volume_map;
-  std::unordered_map<int, Volume> m_cher_tube_volume_map;
+  std::unordered_map<int, dd4hep::Volume> m_scin_tube_volume_map;
+  std::unordered_map<int, dd4hep::Volume> m_cher_tube_volume_map;
 
   // Tolerance for which new tube volumes are created
   // e.g 1mm, then all tube lengths are rounded (down) to the nearest mm
@@ -147,15 +145,15 @@ private:
   double m_trap_azimuthal_angle; // azimuthal angle for the trapezoid
   double m_trap_polar_angle;     // polar angle for the trapezoid
   double m_trap_half_length;     // half length for the trapezoid
-  Material m_trap_material;
+  dd4hep::Material m_trap_material;
   std::string m_trap_visString;
 
   // Construction parameters (which change for each tower)
   double m_covered_theta;
   double m_back_shift;
-  Position m_tower_position;
+  dd4hep::Position m_tower_position;
 
-  Material m_air;
+  dd4hep::Material m_air;
   std::string m_air_visString;
 };
 

--- a/detector/calorimeter/dual-readout-tubes/include/DRutils.h
+++ b/detector/calorimeter/dual-readout-tubes/include/DRutils.h
@@ -6,8 +6,6 @@
 #include "DD4hep/DD4hepUnits.h"
 #include "DD4hep/Objects.h"
 
-using namespace dd4hep;
-
 // Utility functions for the construction of the barrel dual-readout calorimeter (based on tubes)
 namespace DRBarrelTubes {
 // Quick rounding functions
@@ -17,11 +15,12 @@ int fast_ceil(double x);
 bool check_for_integer(double x);
 
 // Functions which are used to calculate the tube lengths using the crossing point of a line and a plane
-std::vector<double> get_plane_equation(const Position& point1, const Position& point2, const Position& point3);
-Position get_intersection(const std::vector<double>& plane_coefficients, const Position& line_point,
-                          const Direction& line_direction);
-Position get_intersection(const Direction& plane_normal, const Position& plane_point, const Position& line_point,
-                          const Direction& line_direction);
+std::vector<double> get_plane_equation(const dd4hep::Position& point1, const dd4hep::Position& point2,
+                                       const dd4hep::Position& point3);
+dd4hep::Position get_intersection(const std::vector<double>& plane_coefficients, const dd4hep::Position& line_point,
+                                  const dd4hep::Direction& line_direction);
+dd4hep::Position get_intersection(const dd4hep::Direction& plane_normal, const dd4hep::Position& plane_point,
+                                  const dd4hep::Position& line_point, const dd4hep::Direction& line_direction);
 } // namespace DRBarrelTubes
 
 #endif // DRutils_h

--- a/detector/muonSystem/muonSystemMuRWELL_o1_v01.cpp
+++ b/detector/muonSystem/muonSystemMuRWELL_o1_v01.cpp
@@ -481,7 +481,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd, dd4h
                   sensDet.setType(sdType.typeStr());
                   sliceVolume.setSensitiveDetector(sensDet);
                   slicePlacedVolume.addPhysVolID("slice", sensitiveSliceIndex);
-                  dd4hep::DetElement sliceDE(rectangleRemainderEnvDE, "slice_" + sensitiveSliceIndex,
+                  dd4hep::DetElement sliceDE(rectangleRemainderEnvDE, "slice_" + std::to_string(sensitiveSliceIndex),
                                              sensitiveSliceIndex);
                   sliceDE.setPlacement(slicePlacedVolume);
                   //  dd4hep::printout(dd4hep::INFO,"Sensitive Slice has been created at", name, BarrelChamberName);
@@ -523,7 +523,8 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd, dd4h
                   sensDet.setType(sdType.typeStr());
                   sliceVolume.setSensitiveDetector(sensDet);
                   slicePlacedVolume.addPhysVolID("slice", sensitiveSliceIndex);
-                  dd4hep::DetElement sliceDE(envDE, "slice_" + sensitiveSliceIndex, sensitiveSliceIndex);
+                  dd4hep::DetElement sliceDE(envDE, "slice_" + std::to_string(sensitiveSliceIndex),
+                                             sensitiveSliceIndex);
                   sliceDE.setPlacement(slicePlacedVolume);
                   // dd4hep::printout(dd4hep::INFO,"Sensitive slice has been created at", name, BarrelChamberName);
                   sensitiveSliceIndex++;
@@ -655,7 +656,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd, dd4h
                   sensDet.setType(sdType.typeStr());
                   sliceVolume.setSensitiveDetector(sensDet);
                   slicePlacedVolume.addPhysVolID("slice", sensitiveSliceIndex);
-                  dd4hep::DetElement sliceDE(rectangleRemainderEnvDE, "slice_" + sensitiveSliceIndex,
+                  dd4hep::DetElement sliceDE(rectangleRemainderEnvDE, "slice_" + std::to_string(sensitiveSliceIndex),
                                              sensitiveSliceIndex);
                   sliceDE.setPlacement(slicePlacedVolume);
                   // dd4hep::printout(dd4hep::INFO,"Sensitive slice has been created at", name, BarrelChamberName);
@@ -697,7 +698,8 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd, dd4h
                   sensDet.setType(sdType.typeStr());
                   sliceVolume.setSensitiveDetector(sensDet);
                   slicePlacedVolume.addPhysVolID("slice", sensitiveSliceIndex);
-                  dd4hep::DetElement sliceDE(envDE, "slice_" + sensitiveSliceIndex, sensitiveSliceIndex);
+                  dd4hep::DetElement sliceDE(envDE, "slice_" + std::to_string(sensitiveSliceIndex),
+                                             sensitiveSliceIndex);
                   sliceDE.setPlacement(slicePlacedVolume);
                   // dd4hep::printout(dd4hep::INFO,"Sensitive slice has been created at", name, BarrelChamberName);
                   sensitiveSliceIndex++;
@@ -1117,7 +1119,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd, dd4h
                   sensDet.setType(sdType.typeStr());
                   sliceVolume.setSensitiveDetector(sensDet);
                   slicePlacedVolume.addPhysVolID("slice", sensitiveSliceIndex);
-                  dd4hep::DetElement sliceDE(rectangleRemainderEnvDE, "slice_" + sensitiveSliceIndex,
+                  dd4hep::DetElement sliceDE(rectangleRemainderEnvDE, "slice_" + std::to_string(sensitiveSliceIndex),
                                              sensitiveSliceIndex);
                   sliceDE.setPlacement(slicePlacedVolume);
                   //  dd4hep::printout(dd4hep::INFO,"Sensitive slice has been created at", name,EndcapChamberName);
@@ -1164,7 +1166,8 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd, dd4h
                   sensDet.setType(sdType.typeStr());
                   sliceVolume.setSensitiveDetector(sensDet);
                   slicePlacedVolume.addPhysVolID("slice", sensitiveSliceIndex);
-                  dd4hep::DetElement sliceDE(envDE, "slice_" + sensitiveSliceIndex, sensitiveSliceIndex);
+                  dd4hep::DetElement sliceDE(envDE, "slice_" + std::to_string(sensitiveSliceIndex),
+                                             sensitiveSliceIndex);
                   sliceDE.setPlacement(slicePlacedVolume);
                   // dd4hep::printout(dd4hep::INFO,"Sensitive slice has been created at", name, EndcapChamberName);
                   sensitiveSliceIndex++;

--- a/detector/tracker/VertexEndcap_detailed_o1_v02_geo.cpp
+++ b/detector/tracker/VertexEndcap_detailed_o1_v02_geo.cpp
@@ -22,6 +22,8 @@
 #include "DD4hep/Printout.h"
 #include "XML/Utilities.h"
 
+#include <list>
+
 using namespace std;
 
 using dd4hep::_toString;

--- a/plugins/DRCaloFastSimModel.h
+++ b/plugins/DRCaloFastSimModel.h
@@ -29,7 +29,6 @@ public:
     mOpWLSNumIntLenLeft = DBL_MAX;
     mStepLengthInterval = 0.;
   }
-  ~FastFiberData() = default;
 
   void reset() {
     this->mOpBoundaryStatus = G4OpBoundaryProcessStatus::Undefined;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix compiler warnings caught with clang 19
- Add a missing `#include <list>` that will be needed with https://github.com/AIDASoft/DD4hep/pull/1432

ENDRELEASENOTES

The changes in the muon system have appeared before, @mahmoudali2, in
https://github.com/key4hep/k4geo/pull/353.

Not all the warnings are fixed here since others may require some validation:

@varnes, this could be wrong since whatever the pointer points to may or may not be that string:
```
/k4geo/detector/calorimeter/ECalEndcap_Turbine_o1_v02_geo.cpp:125:37: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
  125 |     char* nUnitCellsStrArr = (char*)genericBladeElem.attr<std::string>(_Unicode(nUnitCells)).c_str();
```

@Archil-AD, it complains about hiding the original `neighbours` in the base class Segmentation . If that was not intended I would simply suggest to change the name to something else like `getNeighbours`. In general it's good practice to call different things witht different names.

```
/k4geo/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h:54:27: warning: 'dd4hep::DDSegmentation::FCCSWHCalPhiRow_k4geo::neighbours' hides overloaded virtual function [-Woverloaded-virtual]
   54 |     std::vector<uint64_t> neighbours(const CellID& cID) const;
      |                           ^
/DD4hep/install/include/DDSegmentation/Segmentation.h:89:20: note: hidden overloaded virtual function 'dd4hep::DDSegmentation::Segmentation::neighbours' declared here: different number of parameters (2 vs 1)
   89 |       virtual void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const;
```