### PR TITLE
CLD_o2_v07: make tracking volume actually parallel

### DIFF
--- a/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml
@@ -262,7 +262,7 @@
        else if the volume is part of the parallelworld:  connected="false"
        The volume is always connected to the top level!
     -->
-    <parallelworld_volume name="tracking_volume" anchor="/world" material="Air" connected="true"
+    <parallelworld_volume name="tracking_volume" anchor="/world" material="Air" connected="false"
         vis="VisibleBlue">
         <shape type="Polycone" material="Air">
             <!-- small-angle approximation for tan(theta) -->


### PR DESCRIPTION
BEGINRELEASENOTES
- CLD_o2_v07: made tracking volume actually parallel

ENDRELEASENOTES

looks like I overlooked this :(
with `connected="true"` the volume is placed in the world not the parallelworld
https://github.com/AIDASoft/DD4hep/blob/f775dbf817dde0e6c1685bd8dccb87dc25136af5/DDCore/src/plugins/Compact2Objects.cpp#L1587