### PR TITLE
Switch monolithic DRC's calo hit type to edm4hep::SimCalorimeterHit to store positions

### DIFF
--- a/plugins/FiberDRCaloSDAction.cpp
+++ b/plugins/FiberDRCaloSDAction.cpp
@@ -99,6 +99,8 @@ namespace sim {
 
     m_userData.fastfiber.fSafety = 1;
     m_userData.fastfiber.fVerbose = 0;
+
+    m_hitCreationMode = HitCreationFlags::DETAILED_MODE; // always store step position
   }
 
   /// Define collections created by this sensitive action object

--- a/plugins/FiberDRCaloSDAction.cpp
+++ b/plugins/FiberDRCaloSDAction.cpp
@@ -230,6 +230,7 @@ namespace sim {
         if (!drHit) {
           drHit = new Geant4DRCalorimeter::Hit(m_userData.fWavlenStep, m_userData.fTimeStep);
           drHit->cellID = cID;
+          drHit->position = m_segmentation->position(cID)*CLHEP::mm/dd4hep::mm; // segmentation gives dd4hep unit
           drHit->SetSiPMnum(cID);
           drHit->SetTimeStart(m_userData.fTimeStart);
           drHit->SetTimeEnd(m_userData.fTimeEnd);
@@ -247,8 +248,6 @@ namespace sim {
         drHit->CountWavlenSpectrum(wavBin);
         int timeBin = m_userData.findTimeBin(hitTime);
         drHit->CountTimeStruct(timeBin);
-
-        drHit->position = glob;
 
         // finally kill optical photon
         step->GetTrack()->SetTrackStatus(fStopAndKill);
@@ -274,6 +273,7 @@ namespace sim {
         if (!caloHit) {
           caloHit = new Geant4Calorimeter::Hit(glob);
           caloHit->cellID = cID;
+          caloHit->position = m_segmentation->position(cID)*CLHEP::mm/dd4hep::mm; // segmentation gives dd4hep unit
           coll_scint->add(cID, caloHit);
         }
 
@@ -317,6 +317,7 @@ namespace sim {
       if (!hit) {
         hit = new Geant4DRCalorimeter::Hit(m_userData.fWavlenStep, m_userData.fTimeStep);
         hit->cellID = cID;
+        hit->position = m_segmentation->position(cID)*CLHEP::mm/dd4hep::mm; // segmentation gives dd4hep unit
         hit->SetSiPMnum(cID);
         hit->SetTimeStart(m_userData.fTimeStart);
         hit->SetTimeEnd(m_userData.fTimeEnd);
@@ -330,8 +331,6 @@ namespace sim {
       hit->CountWavlenSpectrum(wavBin);
       int timeBin = m_userData.findTimeBin(hitTime);
       hit->CountTimeStruct(timeBin);
-
-      hit->position = glob;
 
       return true;
     } // !skipScint

--- a/plugins/Geant4Output2EDM4hep_DRC.cpp
+++ b/plugins/Geant4Output2EDM4hep_DRC.cpp
@@ -287,7 +287,7 @@ void Geant4Output2EDM4hep_DRC::commit(OutputContext<G4Event>& /* ctxt */) {
       m_frame.put(std::move(calorimeterHits.second), colName + "Contributions");
     }
     for (auto& [colName, calorimeterHits] : m_drcaloHits) {
-      m_frame.put(std::move(calorimeterHits.first), colName + "RawHit");
+      m_frame.put(std::move(calorimeterHits.first), colName + "SimHit");
       m_frame.put(std::move(calorimeterHits.second), colName + "TimeStruct");
     }
     for (auto it = m_drcaloWaves.begin(); it != m_drcaloWaves.end(); ++it) {
@@ -605,7 +605,7 @@ void Geant4Output2EDM4hep_DRC::saveCollection(OutputContext<G4Event>& /*ctxt*/, 
     for (unsigned i = 0; i < nhits; ++i) {
       const Geant4DRCalorimeter::Hit* hit = coll->hit(i);
 
-      // For DRC raw calo hit & raw time series
+      // For DRC calo hit & time series
       auto simCaloHits = DRhits.first->create();
       auto rawTimeStruct = DRhits.second->create();
       auto rawWaveStruct = DRwaves->create();

--- a/plugins/Geant4Output2EDM4hep_DRC.cpp
+++ b/plugins/Geant4Output2EDM4hep_DRC.cpp
@@ -11,7 +11,6 @@
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <edm4hep/RawCalorimeterHitCollection.h>
 #include <edm4hep/RawTimeSeriesCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/SimTrackerHitCollection.h>
@@ -53,7 +52,7 @@ namespace sim {
     using trackermap_t = std::map<std::string, edm4hep::SimTrackerHitCollection>;
     using calorimeterpair_t = std::pair<edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionCollection>;
     using calorimetermap_t = std::map<std::string, calorimeterpair_t>;
-    using drcalopair_t = std::pair<edm4hep::RawCalorimeterHitCollection,
+    using drcalopair_t = std::pair<edm4hep::SimCalorimeterHitCollection,
                                    edm4hep::RawTimeSeriesCollection>; // Required info for IDEA DRC sim hit
     using drcalomap_t = std::map<std::string, drcalopair_t>;          // Required info for IDEA DRC sim hit
     using drcaloWavmap_t = std::map<std::string, edm4hep::RawTimeSeriesCollection>;
@@ -607,7 +606,7 @@ void Geant4Output2EDM4hep_DRC::saveCollection(OutputContext<G4Event>& /*ctxt*/, 
       const Geant4DRCalorimeter::Hit* hit = coll->hit(i);
 
       // For DRC raw calo hit & raw time series
-      auto rawCaloHits = DRhits.first->create();
+      auto simCaloHits = DRhits.first->create();
       auto rawTimeStruct = DRhits.second->create();
       auto rawWaveStruct = DRwaves->create();
 
@@ -662,9 +661,13 @@ void Geant4Output2EDM4hep_DRC::saveCollection(OutputContext<G4Event>& /*ctxt*/, 
         rawWaveStruct.addToAdcCounts(count);
       }
 
-      rawCaloHits.setCellID(hit->cellID);
-      rawCaloHits.setAmplitude(hit->GetPhotonCount());
-      rawCaloHits.setTimeStamp(peakTime - 1 + static_cast<int>(timeStart / samplingT));
+      const auto& pos = hit->position;
+      simCaloHits.setCellID(hit->cellID);
+      // store the number of photon in place of energy
+      // will become energy after the conversion to ADC counts
+      // no hit contribution is stored
+      simCaloHits.setEnergy(static_cast<float>(hit->GetPhotonCount()));
+      simCaloHits.setPosition({float(pos.x() / CLHEP::mm), float(pos.y() / CLHEP::mm), float(pos.z() / CLHEP::mm)});
     }
     //-------------------------------------------------------------------
   } else {

--- a/plugins/Geant4Output2EDM4hep_DRC.cpp
+++ b/plugins/Geant4Output2EDM4hep_DRC.cpp
@@ -632,8 +632,6 @@ void Geant4Output2EDM4hep_DRC::saveCollection(OutputContext<G4Event>& /*ctxt*/, 
 
       unsigned nbinTime = static_cast<unsigned>((timeEnd - timeStart) / samplingT);
       unsigned nbinWav = static_cast<unsigned>((wavMax - wavMin) / samplingW);
-      int peakTime = 0.;
-      int peakVal = 0;
 
       // same as the ROOT TH1 binning scheme (0: underflow, nbin+1:overflow)
       for (unsigned itime = 1; itime < nbinTime + 1; itime++) {
@@ -641,13 +639,6 @@ void Geant4Output2EDM4hep_DRC::saveCollection(OutputContext<G4Event>& /*ctxt*/, 
 
         if (timemap.find(itime) != timemap.end())
           count = timemap.at(itime);
-
-        int candidate = std::max(peakVal, count);
-
-        if (peakVal < candidate) {
-          peakVal = candidate;
-          peakTime = itime;
-        }
 
         rawTimeStruct.addToAdcCounts(count);
       }


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [x] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Switch monolithic DRC's calo hit type to edm4hep::SimCalorimeterHit to store positions

ENDRELEASENOTES


Switching the type of calo hits for the (fiber) DRC from `edm4hep::RawCalorimeterHit` to `edm4hep::SimCalorimeterHit` to store the 3D position of each hit. Since we plan to share the SiPM digitizer & clustering algorithms downstream with capillary tube DRC, it'd be better to call `DD4hep::Segmentation` in upstream and avoid calling it later as much as possible.  

