### PR TITLE
Make ALLEGRO HCal endcap symmetric between positive and negative halves.

### DIFF
--- a/detector/calorimeter/HCalThreePartsEndcap_o1_v02_geo.cpp
+++ b/detector/calorimeter/HCalThreePartsEndcap_o1_v02_geo.cpp
@@ -151,7 +151,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
   // Calculate correction along z based on the module size (can only have natural number of modules)
   double dzDetector1 = (numSequencesZ1 * dzSequence) / 2 + 2 * dZEndPlate + space;
   double dzDetector2 = (numSequencesZ2 * dzSequence) / 2;
-  double dzDetector3 = (numSequencesZ3 * dzSequence) / 2 + 2 * dZEndPlate + space;
+  double dzDetector3 = (numSequencesZ3 * dzSequence) / 2;
 
   dd4hep::printout(dd4hep::DEBUG, "HCalThreePartsEndcap_o1_v02",
                    "correction of dz (negative = size reduced) first part EC: %.2f",
@@ -215,7 +215,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
 
     // Endplates placed for the extended Barrels in front and in the back to the central Barrel
     DetElement endPlatePos(caloDetElem, "endPlate_" + std::to_string(1 * sign), 0);
-    dd4hep::Position posOffset(0, 0, sign * (extBarrelOffset3 + dzDetector3 - dZEndPlate));
+    dd4hep::Position posOffset(0, 0, sign * (extBarrelOffset3 + dzDetector3 + dZEndPlate + space));
     PlacedVolume placedEndPlatePos = envelopeVolume.placeVolume(endPlateVol3, posOffset);
     endPlatePos.setPlacement(placedEndPlatePos);
 
@@ -280,7 +280,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
         Volume tileVol("HCalECTileVol_" + xComp.materialStr(), tileShape, lcdd.material(xComp.materialStr()));
         tileVol.setVisAttributes(lcdd, xComp.visStr());
 
-        dd4hep::Position tileOffset(0, 0, tileZOffset + 0.5 * xComp.thickness());
+        dd4hep::Position tileOffset(0, 0, sign * (tileZOffset + 0.5 * xComp.thickness()) );
         dd4hep::PlacedVolume placedTileVol = tileSequenceVolume.placeVolume(tileVol, tileOffset);
 
         if (xComp.isSensitive()) {
@@ -292,7 +292,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
 
       // second z loop (place sequences in layer)
       std::vector<dd4hep::PlacedVolume> seqs;
-      double zOffset = -dzDetector1 + 0.5 * dzSequence; // 2*dZEndPlate + space + 0.5 * dzSequence;
+      double zOffset = -dzDetector1 + 0.5 * dzSequence + 2*dZEndPlate + space;
 
       for (uint numSeq = 0; numSeq < numSequencesZ1; numSeq++) {
         dd4hep::Position tileSequencePosition(0, 0, zOffset);
@@ -342,7 +342,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
         Volume tileVol("HCalECTileVol_", tileShape, lcdd.material(xComp.materialStr()));
         tileVol.setVisAttributes(lcdd, xComp.visStr());
 
-        dd4hep::Position tileOffset(0, 0, tileZOffset + 0.5 * xComp.thickness());
+        dd4hep::Position tileOffset(0, 0, sign * (tileZOffset + 0.5 * xComp.thickness()) );
         dd4hep::PlacedVolume placedTileVol = tileSequenceVolume.placeVolume(tileVol, tileOffset);
 
         if (xComp.isSensitive()) {
@@ -414,7 +414,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
         Volume tileVol("HCalECTileVol_", tileShape, lcdd.material(xComp.materialStr()));
         tileVol.setVisAttributes(lcdd, xComp.visStr());
 
-        dd4hep::Position tileOffset(0, 0, tileZOffset + 0.5 * xComp.thickness());
+        dd4hep::Position tileOffset(0, 0, sign * (tileZOffset + 0.5 * xComp.thickness()) );
         dd4hep::PlacedVolume placedTileVol = tileSequenceVolume.placeVolume(tileVol, tileOffset);
 
         if (xComp.isSensitive()) {


### PR DESCRIPTION
The cell layout of the endcaps was not symmetric between the positive and negative halves.  Fixed so that is actually symmetric. See issue #455 (https://github.com/key4hep/k4geo/issues/455) for details.

To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [ x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [ x] the PR does not contain any additions or modifications that do not belong to it
- [ x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Adjust ALLEGRO HCal endcap (HCalThreePartsEndcap) cell positions so that they are symmetric under z-inversion.
ENDRELEASENOTES

