### PR TITLE
Adding an extension data for DRC IDEA_o1 to provide the dimensions to downstream

### DIFF
--- a/detector/calorimeter/README.md
+++ b/detector/calorimeter/README.md
@@ -55,11 +55,13 @@ Changes wrt o1_v01: Added extension (LayeredCalorimeterData) to store radial lay
 
 ## dual-readout
 
-### o1_v01
+### o1_v03
 This sub-detector makes full 4-pi monolithic fiber dual-readout calorimeter.
 Inside the single tower (trapezoidal copper absorber), two types of optical fibers (Cherenkov and scintillation) are implemented. The readout (SiPM) is attached at the rear side of the tower. The tower is repeated in both eta and phi direction to cover both barrel and endcap region.
 
+Added an extension to (`LayeredCalorimeterData`) to store the barrel and endcap rmin, rmax, zmin, zmax.
+
 ## dual-readout-tubes
 
-### o1_v01
+### o2_v01
 This folder containes the subdetectors (endcap + barrel) to make a full 4-pi fiber dual-readout calorimeter exploiting the INFN capillary-tubes technology. Each trapezoidal tower is constructed with brass capillary-tubes housing optical fibers (Cherenkov and scintillating). Endcap and barrel calorimeters are implemented ad separate subdetectors.


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [ ] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [ ] the PR does not contain any additions or modifications that do not belong to it
- [ ] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Added DDRec extension (`dd4hep::rec::LayeredCalorimeterData`) for DRC IDEA_o1 to provide necessary detector dimensions to the downstream

ENDRELEASENOTES

A patch to provide necessary detector dimensions that are required in the downstream algorithms (e.g. extrapolating tracks to the calo surface). Ideally, it is better to separate the barrel and endcap, but the code would require a decent amount of refactorization in that case. This PR is meant to be a quick patch to allow other interested people can retrieve dimensions promptly for their physics study.
