### PR TITLE
Enforce clang format

### DIFF
--- a/.github/scripts/clang-format-hook
+++ b/.github/scripts/clang-format-hook
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Thin wrapper around clang-format for easier to parse output from the
+# pre-commit hook.
+#
+# Needs to work with multiple input files as pre-commit passes multiple files to
+# the "executables"
+
+# Make sure that diff is actually recent enough (diffutils >= 3.4) to support
+# colored output
+COLOR_OUTPUT=$(diff --color=always <(echo) <(echo) > /dev/null 2>&1 && echo "--color=always")
+
+success=0
+for file in ${@}; do
+    if ! $(clang-format --style=file --Werror --dry-run ${file} > /dev/null 2>&1); then
+        echo "Necessary changes for: '${file}' (run 'clang-format --style=file -i ${file}' to fix it)"
+        diff ${COLOR_OUTPUT} -u ${file} <(clang-format --style=file ${file}) | tail -n +3
+        success=1
+    fi
+done
+exit ${success}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,8 @@ repos:
         entry: ruff format --force-exclude
         types: [python]
         language: system
+      - id: clang-format
+        name: clang-format
+        entry: .github/scripts/clang-format-hook
+        types: [c++]
+        language: system

--- a/detector/PID/ARC_geo_o1_v01.cpp
+++ b/detector/PID/ARC_geo_o1_v01.cpp
@@ -519,7 +519,7 @@ static Ref_t create_ARC_endcaps(Detector& desc, xml::Handle_t handle, SensitiveD
         cell_reflected_DE.setPlacement(cell_ref_PV);
       }
     } //-- end loop for sector
-  } //-- end loop for endcap
+  }   //-- end loop for endcap
 
   endcap_cells_vessel_envelope.placeVolume(endcap_cells_gas_envelope);
 

--- a/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03_geo.cpp
@@ -68,8 +68,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
     layersTotalHeight += layer.repeat() * layer.thickness();
   }
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "Total electrode length from calorimeter xml description (cm): %f ",
-                   layersTotalHeight / dd4hep::cm);
+                   "Total electrode length from calorimeter xml description (cm): %f ", layersTotalHeight / dd4hep::cm);
 
   // The following code checks if the xml geometry file contains a constant defining
   // the number of layers the barrel. In that case, it makes the program abort
@@ -88,8 +87,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
                      "Incorrect number of layers (ECalBarrelNumLayers = %d) in readout in calorimeter xml description!",
                      nLayers);
     dd4hep::printout(dd4hep::ERROR, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "Number of layers should be: %d",
-                     numLayers);
+                     "Number of layers should be: %d", numLayers);
     throw std::runtime_error("Incorrect number of layers (ECalBarrelNumLayers) in calorimeter xml description!");
   }
 
@@ -134,14 +132,14 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
     dd4hep::SubtractionSolid cryoSideShape(cryoSideOuterShape, bathAndServicesOuterShape);
 
     dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "ECAL cryostat: front: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f",
-                     cryoDim.rmin1() / dd4hep::cm, cryoDim.rmin2() / dd4hep::cm, cryoDim.dz() / dd4hep::cm);
+                     "ECAL cryostat: front: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f", cryoDim.rmin1() / dd4hep::cm,
+                     cryoDim.rmin2() / dd4hep::cm, cryoDim.dz() / dd4hep::cm);
     dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "ECAL cryostat: back: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f",
-                     cryoDim.rmax1() / dd4hep::cm, cryoDim.rmax2() / dd4hep::cm, cryoDim.dz() / dd4hep::cm);
+                     "ECAL cryostat: back: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f", cryoDim.rmax1() / dd4hep::cm,
+                     cryoDim.rmax2() / dd4hep::cm, cryoDim.dz() / dd4hep::cm);
     dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "ECAL cryostat: side: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f",
-                     cryoDim.rmin2() / dd4hep::cm, cryoDim.rmax1() / dd4hep::cm, (cryoDim.dz() - caloDim.dz()) / dd4hep::cm);
+                     "ECAL cryostat: side: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f", cryoDim.rmin2() / dd4hep::cm,
+                     cryoDim.rmax1() / dd4hep::cm, (cryoDim.dz() - caloDim.dz()) / dd4hep::cm);
 
     dd4hep::Volume cryoFrontVol(cryostat.nameStr() + "_front", cryoFrontShape, aLcdd.material(cryostat.materialStr()));
     dd4hep::Volume cryoBackVol(cryostat.nameStr() + "_back", cryoBackShape, aLcdd.material(cryostat.materialStr()));
@@ -186,11 +184,11 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
     dd4hep::Tube servicesBackShape(bathRmax, cryoDim.rmax1(), caloDim.dz());
 
     dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "ECAL services: front: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f",
-                     cryoDim.rmin2() / dd4hep::cm, bathRmin / dd4hep::cm / dd4hep::cm, caloDim.dz() / dd4hep::cm);
+                     "ECAL services: front: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f", cryoDim.rmin2() / dd4hep::cm,
+                     bathRmin / dd4hep::cm / dd4hep::cm, caloDim.dz() / dd4hep::cm);
     dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "ECAL services: back: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f",
-                     bathRmax / dd4hep::cm, cryoDim.rmax1() / dd4hep::cm, caloDim.dz() / dd4hep::cm);
+                     "ECAL services: back: rmin (cm) = %f  rmax (cm) = %f  dz (cm) = %f", bathRmax / dd4hep::cm,
+                     cryoDim.rmax1() / dd4hep::cm, caloDim.dz() / dd4hep::cm);
 
     dd4hep::Volume servicesFrontVol("services_front", servicesFrontShape, aLcdd.material(activeMaterial));
     dd4hep::Volume servicesBackVol("services_back", servicesBackShape, aLcdd.material(activeMaterial));
@@ -227,11 +225,10 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   double dR = Rmax - Rmin;
 
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "ECAL bath: material = %s  rmin (cm) = %f  rmax (cm) = %f",
-                   activeMaterial.c_str(), bathRmin / dd4hep::cm, bathRmax / dd4hep::cm);
+                   "ECAL bath: material = %s  rmin (cm) = %f  rmax (cm) = %f", activeMaterial.c_str(),
+                   bathRmin / dd4hep::cm, bathRmax / dd4hep::cm);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "ECAL calorimeter volume rmin (cm) = %f  rmax (cm) = %f",
-                   Rmin / dd4hep::cm, Rmax / dd4hep::cm);
+                   "ECAL calorimeter volume rmin (cm) = %f  rmax (cm) = %f", Rmin / dd4hep::cm, Rmax / dd4hep::cm);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "ECAL thickness of calorimeter (cm) = %f", dR / dd4hep::cm);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
@@ -259,8 +256,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   //////////////////////////////
 
   // passive volumes consist of inner part and two outer, joined by glue
-  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "Passive elements:");
+  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "Passive elements:");
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "   material in inner part of absorber (except 1st layer) = %s", passiveInnerMaterial.c_str());
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
@@ -274,19 +270,17 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "   thickness of inner part at outer radius (cm) = ", passiveInnerThicknessMax / dd4hep::cm);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   thickness of outer part (cm) = %f", passiveOuterThickness / dd4hep::cm );
+                   "   thickness of outer part (cm) = %f", passiveOuterThickness / dd4hep::cm);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   thickness of middle part (cm) = %f", passiveGlueThickness / dd4hep::cm );
+                   "   thickness of middle part (cm) = %f", passiveGlueThickness / dd4hep::cm);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "   total thickness of absorber at inner radius (cm) = %f", passiveThickness / dd4hep::cm);
-
 
   //////////////////////////////
   // ELECTRODES
   //////////////////////////////
 
-  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "Electrodes:" );
+  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "Electrodes:");
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "   rotation angle (radians) = %f , (degrees) = %f", angle, angle * 57.295780);
 
@@ -298,9 +292,9 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "   number of planes (calculated) = %d , azim. angle difference = %f", numPlanes, dPhi);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   distance at inner radius (cm) = %f", 2. * M_PI * Rmin / dd4hep::cm / numPlanes );
+                   "   distance at inner radius (cm) = %f", 2. * M_PI * Rmin / dd4hep::cm / numPlanes);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   distance at outer radius (cm) = %f", 2. * M_PI * Rmax / dd4hep::cm / numPlanes );
+                   "   distance at outer radius (cm) = %f", 2. * M_PI * Rmax / dd4hep::cm / numPlanes);
 
   // The following code checks if the xml geometry file contains a constant defining
   // the number of planes in the barrel. In that case, it makes the program abort
@@ -319,19 +313,19 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   }
   if (nModules > 0 && nModules != int(numPlanes)) {
     dd4hep::printout(dd4hep::ERROR, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "Incorrect number of planes (ECalBarrelNumPlanes) in calorimeter xml description!" );
+                     "Incorrect number of planes (ECalBarrelNumPlanes) in calorimeter xml description!");
     throw std::runtime_error("Incorrect number of planes (ECalBarrelNumPlanes) in calorimeter xml description!");
   }
 
   // Readout is in the middle between two passive planes
   double offsetPassivePhi = caloDim.offset() + dPhi / 2.;
   double offsetReadoutPhi = caloDim.offset() + 0;
+  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "   readout material = %s",
+                   readoutMaterial.c_str());
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   readout material = %s", readoutMaterial.c_str());
-  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   thickness of readout planes (cm) = %f", readoutThickness / dd4hep::cm );
-  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   number of layers = %d", numLayers);
+                   "   thickness of readout planes (cm) = %f", readoutThickness / dd4hep::cm);
+  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "   number of layers = %d",
+                   numLayers);
 
   // Electrode length, given inclination angle and min/max radius of the active calorimeter volume
   double planeLength = -Rmin * cos(angle) + sqrt(pow(Rmax, 2) - pow(Rmin * sin(angle), 2));
@@ -339,24 +333,24 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   double runningHeight = 0.;
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "   total length from Rmin, Rmax and angle (cm) = %f", planeLength / dd4hep::cm);
-  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   predicted layer radii:");
+  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "   predicted layer radii:");
   for (uint iLay = 0; iLay < numLayers; iLay++) {
     double Lmin = runningHeight;
     double Lmax = runningHeight + layerHeight[iLay];
     runningHeight += layerHeight[iLay];
     double rMin = sqrt(Rmin * Rmin + Lmin * Lmin + 2 * Rmin * Lmin * cos(angle));
     double rMax = sqrt(Rmin * Rmin + Lmax * Lmax + 2 * Rmin * Lmax * cos(angle));
-    dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "      layer %d (cm) = %f - %f", iLay, rMin / dd4hep::cm, rMax / dd4hep::cm);
+    dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "      layer %d (cm) = %f - %f",
+                     iLay, rMin / dd4hep::cm, rMax / dd4hep::cm);
   }
 
   // Check that electrode length is consistent with calorimeter radial extent
   // and inclination angle to within 0.5 mm
   if (fabs(planeLength - layersTotalHeight) > 0.05 * dd4hep::cm) {
-    dd4hep::printout(dd4hep::ERROR, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "   the sum of the electrode lengths per layer in the calorimeter xml file is not consistent with the "
-                     "length calculated from the calorimeter radial extent and the inclination angle");
+    dd4hep::printout(
+        dd4hep::ERROR, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
+        "   the sum of the electrode lengths per layer in the calorimeter xml file is not consistent with the "
+        "length calculated from the calorimeter radial extent and the inclination angle");
     throw std::runtime_error("Incorrect length of electrode layers in calorimeter xml description!");
   }
 
@@ -365,21 +359,20 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   // the code calculates the (max) passive thickness per layer i.e. at Rout of layer
   // rescaling by runningHeight / Ltot
   std::vector<double> passiveInnerThicknessLayer(numLayers + 1);
-  dd4hep::printout(dd4hep::DEBUG, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "passiveInnerThickness: ");
+  dd4hep::printout(dd4hep::DEBUG, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "passiveInnerThickness: ");
   runningHeight = 0.;
   for (uint iLay = 0; iLay < numLayers; iLay++) {
     passiveInnerThicknessLayer[iLay] =
         passiveInnerThicknessMin +
         (passiveInnerThicknessMax - passiveInnerThicknessMin) * (runningHeight) / layersTotalHeight;
-    dd4hep::printout(dd4hep::DEBUG, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "   layer %d = %f cm", iLay, passiveInnerThicknessLayer[iLay]);
+    dd4hep::printout(dd4hep::DEBUG, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "   layer %d = %f cm", iLay,
+                     passiveInnerThicknessLayer[iLay]);
   }
   passiveInnerThicknessLayer[numLayers] =
       passiveInnerThicknessMin +
       (passiveInnerThicknessMax - passiveInnerThicknessMin) * (runningHeight) / layersTotalHeight;
-  dd4hep::printout(dd4hep::DEBUG, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   layer %d = %f cm", numLayers, passiveInnerThicknessLayer[numLayers]);
+  dd4hep::printout(dd4hep::DEBUG, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "   layer %d = %f cm", numLayers,
+                   passiveInnerThicknessLayer[numLayers]);
 
   // Calculate the angle of the passive elements if trapezoidal absorbers are used (Max != Min)
   // if parallel absorbers are used then passiveAngle = 0 and cosPassiveAngle = 1
@@ -423,10 +416,9 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
       2. * activeOutThickness - readoutThickness -
       2. * activePassiveOverlap *
           (passiveThickness + passiveInnerThicknessMax - passiveInnerThicknessMin); // correct thickness for trapezoid
-  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "Active elements:" );
-  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "   material = %s", activeMaterial.c_str());
+  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "Active elements:");
+  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "   material = %s",
+                   activeMaterial.c_str());
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "   thickness at inner radius (cm) = %f", activeInThicknessAfterSubtraction / dd4hep::cm);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
@@ -434,7 +426,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "   thickness relative increase from inner to outer radius = %f %%",
                    (activeOutThicknessAfterSubtraction - activeInThicknessAfterSubtraction) * 100 /
-                   activeInThicknessAfterSubtraction);
+                       activeInThicknessAfterSubtraction);
   dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                    "   active passive initial overlap (before subtraction) (cm) = %f  (%f %%)",
                    passiveThickness / dd4hep::cm * activePassiveOverlap, activePassiveOverlap * 100);
@@ -817,7 +809,9 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   caloData->extent[3] = caloDim.dz();
 
   // Retrieve segmentation, needed to get cell size in theta and phi
-  dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged_k4geo* seg = dynamic_cast<dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged_k4geo*>(aSensDet.readout().segmentation().segmentation());
+  dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged_k4geo* seg =
+      dynamic_cast<dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged_k4geo*>(
+          aSensDet.readout().segmentation().segmentation());
   if (seg == nullptr) {
     dd4hep::printout(dd4hep::ERROR, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                      "Incorrect readout, cannot cast to FCCSWGridModuleThetaMerged");
@@ -844,12 +838,10 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   // direction cellSize0 and the depth of the layers
   dd4hep::rec::MaterialManager matMgr(envelopeVol);
   dd4hep::rec::LayeredCalorimeterData::Layer caloLayer;
-  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                   "Layer structure information:");
+  dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "Layer structure information:");
   runningHeight = 0.0;
   for (uint iLay = 0; iLay < numLayers; iLay++) {
-    dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "  Layer %d", iLay);
+    dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "  Layer %d", iLay);
     double Lmin = runningHeight;
     double Lmax = runningHeight + layerHeight[iLay];
     double Lmid = runningHeight + layerHeight[iLay] / 2.0;
@@ -867,8 +859,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
         dd4hep::rec::Vector3D(0., rad_last, 0); // defining end vector points of the given layer
 
     dd4hep::printout(dd4hep::DEBUG, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "    radius first = %f, radius last = %f, radius middle = %f",
-                     rad_first, rad_last, rad_mid);
+                     "    radius first = %f, radius last = %f, radius middle = %f", rad_first, rad_last, rad_mid);
     const dd4hep::rec::MaterialVec& materials =
         matMgr.materialsBetween(ivr1, ivr2); // calling material manager to get material info between two points
     auto mat = matMgr.createAveragedMaterial(materials); // creating average of all the material between two points to
@@ -889,13 +880,12 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
         absorberThickness += materials.at(imat).second;
       }
     }
+    dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "    sensitive thickness : %f",
+                     thickness_sen);
+    dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03", "    absorber thickness : %f",
+                     absorberThickness);
     dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "    sensitive thickness : %f", thickness_sen);
-    dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "    absorber thickness : %f", absorberThickness);
-    dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
-                     "    radiation length : %f , interaction length : %f",
-                     value_of_x0, value_of_lambda );
+                     "    radiation length : %f , interaction length : %f", value_of_x0, value_of_lambda);
 
     caloLayer.distance = rad_first;
     caloLayer.absorberThickness = absorberThickness;
@@ -917,7 +907,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
     std::vector<double> cellSizeVector = seg->cellDimensions(cID);
     double cellSizeTheta = cellSizeVector[1];
     double cellSizeModule = cellSizeVector[0];
-    double cellSizePhi = dPhi*cellSizeModule;
+    double cellSizePhi = dPhi * cellSizeModule;
     dd4hep::printout(dd4hep::INFO, "ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03",
                      "    cell sizes in theta, phi: %f , %f", cellSizeTheta, cellSizePhi);
     caloLayer.cellSize0 = cellSizeTheta;

--- a/detector/calorimeter/ECalEndcap_Turbine_o1_v03_geo.cpp
+++ b/detector/calorimeter/ECalEndcap_Turbine_o1_v03_geo.cpp
@@ -43,7 +43,7 @@ namespace ECalEndcap_Turbine_o1_v03 {
     dd4hep::Trd2 tmp1(thickness_inner / 2., thickness_outer / 2., width / 2., width / 2., (zmax - zmin) / 2.);
     shapeBeforeSubtraction = tmp1;
 
-    dd4hep::Tube allowedTube(ri, ro, delZ/2.);
+    dd4hep::Tube allowedTube(ri, ro, delZ / 2.);
 
     return dd4hep::IntersectionSolid(
         shapeBeforeSubtraction, allowedTube,
@@ -242,7 +242,7 @@ namespace ECalEndcap_Turbine_o1_v03 {
     AbsThicki = AbsThickMin;
 
     float LArgapiLayer = LArgapi;
-    
+
     for (unsigned iRhoLayer = 0; iRhoLayer < ECalEndcapNumCalibRhoLayers; iRhoLayer++) {
 
       float roLayer = riLayer + delrActive;
@@ -261,8 +261,8 @@ namespace ECalEndcap_Turbine_o1_v03 {
       delrPhiGapOnly = leftoverS / (2 * nUnitCells);
       LArgapo = delrPhiGapOnly * TMath::Sin(BladeAngle);
       */
-      float LArgapoLayer = LArgapi + (LArgapo - LArgapi)*(1.0*iRhoLayer)/ECalEndcapNumCalibRhoLayers;
-      
+      float LArgapoLayer = LArgapi + (LArgapo - LArgapi) * (1.0 * iRhoLayer) / ECalEndcapNumCalibRhoLayers;
+
       dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03", "Outer LAr gap is %f", LArgapoLayer);
       dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v03",
                        "Inner and outer thicknesses of noble liquid volume %f, %f", ElectrodeThick + LArgapiLayer * 2,
@@ -586,7 +586,7 @@ namespace ECalEndcap_Turbine_o1_v03 {
 
     dd4hep::printout(dd4hep::INFO, "ECalEndcap_Turbine_o1_v03", "Cryostat front thickness is %f", cryoDim.rmin2());
 
-    float NLcenterZ = (cryoThicknessFront - cryoThicknessBack)/2.;
+    float NLcenterZ = (cryoThicknessFront - cryoThicknessBack) / 2.;
     if (cryoThicknessFront > 0) {
       // 1. Create cryostat
       dd4hep::Tube cryoFrontShape(cryoDim.rmin1(), cryoDim.rmax2(), cryoThicknessFront / 2.);
@@ -613,11 +613,11 @@ namespace ECalEndcap_Turbine_o1_v03 {
       dd4hep::Volume cryoOuterVol(cryostat.nameStr() + "_outer", cryoOuterShape,
                                   aLcdd.material(cryostat.materialStr()));
 
-      dd4hep::Position cryoFrontPos(0, 0, NLcenterZ-cryoDim.dz()-cryoThicknessFront/2.);
+      dd4hep::Position cryoFrontPos(0, 0, NLcenterZ - cryoDim.dz() - cryoThicknessFront / 2.);
       dd4hep::PlacedVolume cryoFrontPhysVol = aEnvelope.placeVolume(cryoFrontVol, cryoFrontPos);
-      dd4hep::Position cryoBackPos(0, 0, NLcenterZ+cryoDim.dz()+cryoThicknessBack/2.);
+      dd4hep::Position cryoBackPos(0, 0, NLcenterZ + cryoDim.dz() + cryoThicknessBack / 2.);
       dd4hep::PlacedVolume cryoBackPhysVol = aEnvelope.placeVolume(cryoBackVol, cryoBackPos);
-      dd4hep::Position cryoInnerOuterPos(0,0,NLcenterZ);
+      dd4hep::Position cryoInnerOuterPos(0, 0, NLcenterZ);
       dd4hep::PlacedVolume cryoInnerPhysVol = aEnvelope.placeVolume(cryoInnerVol, cryoInnerOuterPos);
       dd4hep::PlacedVolume cryoOuterPhysVol = aEnvelope.placeVolume(cryoOuterVol, cryoInnerOuterPos);
       unsigned sidetype = 0x4; // probably not needed anymore...
@@ -665,8 +665,8 @@ namespace ECalEndcap_Turbine_o1_v03 {
                      cryoDim.rmax1() - caloDim.rmax());
 
     //    dd4hep::Position bathPos(0, 0, (cryoThicknessFront - cryoThicknessBack)/2.);
-    dd4hep::Position bathPos(0,0,NLcenterZ);
-    
+    dd4hep::Position bathPos(0, 0, NLcenterZ);
+
     dd4hep::PlacedVolume bathPhysVol = aEnvelope.placeVolume(bathVol, bathPos);
 
     dd4hep::DetElement bathDetElem(caloDetElem, "bath", 1);
@@ -778,8 +778,8 @@ namespace ECalEndcap_Turbine_o1_v03 {
     dd4hep::Volume envelopeVol(nameDet + "_vol", endcapShape, aLcdd.material("Air"));
 
     dd4hep::printout(dd4hep::DEBUG, "ECalEndcap_Turbine_o1_v03",
-                     "Placing detector on the positive side: (cm) %f  with min, max radii %f %f and depth %f", dim.z_offset(),
-                     dim.rmin1(), dim.rmax1(), dim.dz());
+                     "Placing detector on the positive side: (cm) %f  with min, max radii %f %f and depth %f",
+                     dim.z_offset(), dim.rmin1(), dim.rmax1(), dim.dz());
 
     unsigned iModule = 0;
     buildOneSide_Turbine(aLcdd, caloDetElem, aSensDet, envelopeVol, aXmlElement, iModule);

--- a/detector/calorimeter/HCalThreePartsEndcap_o1_v02_geo.cpp
+++ b/detector/calorimeter/HCalThreePartsEndcap_o1_v02_geo.cpp
@@ -280,7 +280,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
         Volume tileVol("HCalECTileVol_" + xComp.materialStr(), tileShape, lcdd.material(xComp.materialStr()));
         tileVol.setVisAttributes(lcdd, xComp.visStr());
 
-        dd4hep::Position tileOffset(0, 0, sign * (tileZOffset + 0.5 * xComp.thickness()) );
+        dd4hep::Position tileOffset(0, 0, sign * (tileZOffset + 0.5 * xComp.thickness()));
         dd4hep::PlacedVolume placedTileVol = tileSequenceVolume.placeVolume(tileVol, tileOffset);
 
         if (xComp.isSensitive()) {
@@ -292,7 +292,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
 
       // second z loop (place sequences in layer)
       std::vector<dd4hep::PlacedVolume> seqs;
-      double zOffset = -dzDetector1 + 0.5 * dzSequence + 2*dZEndPlate + space;
+      double zOffset = -dzDetector1 + 0.5 * dzSequence + 2 * dZEndPlate + space;
 
       for (uint numSeq = 0; numSeq < numSequencesZ1; numSeq++) {
         dd4hep::Position tileSequencePosition(0, 0, zOffset);
@@ -342,7 +342,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
         Volume tileVol("HCalECTileVol_", tileShape, lcdd.material(xComp.materialStr()));
         tileVol.setVisAttributes(lcdd, xComp.visStr());
 
-        dd4hep::Position tileOffset(0, 0, sign * (tileZOffset + 0.5 * xComp.thickness()) );
+        dd4hep::Position tileOffset(0, 0, sign * (tileZOffset + 0.5 * xComp.thickness()));
         dd4hep::PlacedVolume placedTileVol = tileSequenceVolume.placeVolume(tileVol, tileOffset);
 
         if (xComp.isSensitive()) {
@@ -414,7 +414,7 @@ static dd4hep::Ref_t createHCalEC(dd4hep::Detector& lcdd, xml_h xmlElement, dd4h
         Volume tileVol("HCalECTileVol_", tileShape, lcdd.material(xComp.materialStr()));
         tileVol.setVisAttributes(lcdd, xComp.visStr());
 
-        dd4hep::Position tileOffset(0, 0, sign * (tileZOffset + 0.5 * xComp.thickness()) );
+        dd4hep::Position tileOffset(0, 0, sign * (tileZOffset + 0.5 * xComp.thickness()));
         dd4hep::PlacedVolume placedTileVol = tileSequenceVolume.placeVolume(tileVol, tileOffset);
 
         if (xComp.isSensitive()) {

--- a/detector/calorimeter/HCalTileBarrel_o1_v02_geo.cpp
+++ b/detector/calorimeter/HCalTileBarrel_o1_v02_geo.cpp
@@ -238,9 +238,9 @@ static dd4hep::Ref_t createHCal(dd4hep::Detector& lcdd, xml_det_t xmlDet, dd4hep
   // try to retrieve segmentation itself
   std::string layerFieldName;
   dd4hep::DDSegmentation::FCCSWHCalPhiTheta_k4geo* seg_phitheta =
-    dynamic_cast<dd4hep::DDSegmentation::FCCSWHCalPhiTheta_k4geo*>(segHandle.segmentation());
+      dynamic_cast<dd4hep::DDSegmentation::FCCSWHCalPhiTheta_k4geo*>(segHandle.segmentation());
   dd4hep::DDSegmentation::FCCSWHCalPhiRow_k4geo* seg_phirow =
-    dynamic_cast<dd4hep::DDSegmentation::FCCSWHCalPhiRow_k4geo*>(segHandle.segmentation());
+      dynamic_cast<dd4hep::DDSegmentation::FCCSWHCalPhiRow_k4geo*>(segHandle.segmentation());
   if (seg_phitheta) {
     dd4hep::printout(dd4hep::DEBUG, "HCalTileBarrel_o1_v02", "Segmentation is of type FCCSWHCalPhiTheta_k4geo");
     layerFieldName = seg_phitheta->fieldNameLayer();
@@ -307,8 +307,10 @@ static dd4hep::Ref_t createHCal(dd4hep::Detector& lcdd, xml_det_t xmlDet, dd4hep
     }
     dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    sensitive thickness is: %lf", thickness_sen);
     dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    absorber thickness is: %lf", absorberThickness);
-    dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    number of radiation length is: %lf", nRadiationLengths);
-    dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    number of interaction length is: %lf", nInteractionLengths);
+    dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    number of radiation length is: %lf",
+                     nRadiationLengths);
+    dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    number of interaction length is: %lf",
+                     nInteractionLengths);
 
     caloLayer.distance = layerInnerRadii.at(idxLayer);   // radius of the current layer
     caloLayer.sensitive_thickness = difference_bet_r1r2; // radial dimension of the current layer
@@ -327,11 +329,11 @@ static dd4hep::Ref_t createHCal(dd4hep::Detector& lcdd, xml_det_t xmlDet, dd4hep
       std::vector<double> cellSizeVector = seg_phitheta->cellDimensions(0);
       double cellSizeTheta = cellSizeVector[1];
       double cellSizePhi = cellSizeVector[0];
-      dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    cell sizes in theta, phi: %lf , %lf", cellSizeTheta, cellSizePhi);
+      dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    cell sizes in theta, phi: %lf , %lf", cellSizeTheta,
+                       cellSizePhi);
       caloLayer.cellSize0 = cellSizeTheta;
       caloLayer.cellSize1 = cellSizePhi;
-    }
-    else if (seg_phirow) {
+    } else if (seg_phirow) {
       // the merging of the rows into cells can differ layer by layer so need to pass
       // cellID with layer field properly filled in order to get good dimension
       dd4hep::CellID cID;
@@ -339,7 +341,8 @@ static dd4hep::Ref_t createHCal(dd4hep::Detector& lcdd, xml_det_t xmlDet, dd4hep
       std::vector<double> cellSizeVector = seg_phirow->cellDimensions(cID);
       double cellSizeZ = cellSizeVector[1];
       double cellSizePhi = cellSizeVector[0];
-      dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    cell sizes in z, phi: %lf , %lf", cellSizeZ, cellSizePhi);
+      dd4hep::printout(dd4hep::INFO, "HCalTileBarrel_o1_v02", "    cell sizes in z, phi: %lf , %lf", cellSizeZ,
+                       cellSizePhi);
       caloLayer.cellSize0 = cellSizeZ;
       caloLayer.cellSize1 = cellSizePhi;
     }

--- a/detector/calorimeter/SEcal05_Helpers.cpp
+++ b/detector/calorimeter/SEcal05_Helpers.cpp
@@ -227,7 +227,7 @@ std::vector<SEcal05_Helpers::dimposXYStruct> SEcal05_Helpers::getSlabXYDimension
         layerslabdims.push_back(ss);
         totTow++;
       } // towers
-    } // modules
+    }   // modules
 
     // if slab dimensions do not change layer-by-layer, memorise for next time
     if (_module_XZtype == 0)
@@ -738,12 +738,12 @@ void SEcal05_Helpers::makeModule(dd4hep::Volume& mod_vol,                       
           ++s_num;
 
         } // end slice within one slab
-      } // slabs
+      }   // slabs
       myLayerNum = myLayerNumTemp;
       currentLayerBase_pos_Z += slab_dim_Z;
       layer_index++; // this is the structural layer counter (one per slab, not per sensitive layer)
-    } // layers in compact file
-  } // layer types in compact file
+    }                // layers in compact file
+  }                  // layer types in compact file
 
   // add material after last slab. Just CF
   updateCaloLayers(_CF_alvWall + _CF_back, _carbon_fibre_material, false, false, -1, -1, true); // the last layer

--- a/detector/calorimeter/SEcal06_Helpers.cpp
+++ b/detector/calorimeter/SEcal06_Helpers.cpp
@@ -232,7 +232,7 @@ std::vector<SEcal06_Helpers::dimposXYStruct> SEcal06_Helpers::getSlabXYDimension
         layerslabdims.push_back(ss);
         totTow++;
       } // towers
-    } // modules
+    }   // modules
 
     // if slab dimensions do not change layer-by-layer, memorise for next time
     if (_module_XZtype == 0)
@@ -850,12 +850,12 @@ void SEcal06_Helpers::makeModule(dd4hep::Volume& mod_vol,                       
                     waferSeg->setWaferOffsetX(myLayerNumTemp, wafer_num, 0.0);
                   }
                 } // isMagic
-              } // y-wafers
+              }   // y-wafers
 
               wafer_pos_X += megatile_size_x;
 
             } // x-wafers
-          } // end sensitive slice
+          }   // end sensitive slice
 
           // Increment Z position of slice.
           s_pos_Z += s_thick;
@@ -864,12 +864,12 @@ void SEcal06_Helpers::makeModule(dd4hep::Volume& mod_vol,                       
           ++s_num;
 
         } // end slice within one slab
-      } // slabs
+      }   // slabs
       myLayerNum = myLayerNumTemp;
       currentLayerBase_pos_Z += slab_dim_Z;
       layer_index++; // this is the structural layer counter (one per slab, not per sensitive layer)
-    } // layers in compact file
-  } // layer types in compact file
+    }                // layers in compact file
+  }                  // layer types in compact file
 
   // add material after last slab. Just CF
   updateCaloLayers(_CF_alvWall + _CF_back, _carbon_fibre_material, false, false, -1, -1, true); // the last layer

--- a/detector/calorimeter/Yoke06_Endcaps.cpp
+++ b/detector/calorimeter/Yoke06_Endcaps.cpp
@@ -225,10 +225,10 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
       caloLayer.cellSize1 = cell_sizeY;
 
       //	PolyhedraRegular ChamberSolid( symmetry, M_PI/symmetry, rInnerEndcap + tolerance, rOuterEndcap -
-      //tolerance,  l_thickness);
+      // tolerance,  l_thickness);
 
       //	SubtractionSolid YokeEndcapSolid( PolyhedraRegular( symmetry, M_PI/symmetry, rInnerEndcap, rOuterEndcap,
-      //Yoke_Endcap_module_dim_z), innerBox, Position(0, 0, 0) );
+      // Yoke_Endcap_module_dim_z), innerBox, Position(0, 0, 0) );
 
       SubtractionSolid ChamberSolid(
           PolyhedraRegular(symmetry, M_PI / symmetry, rInnerEndcap + tolerance, rOuterEndcap - tolerance, l_thickness),

--- a/detector/calorimeter/dual-readout-tubes/include/DREndcapTubes.hh
+++ b/detector/calorimeter/dual-readout-tubes/include/DREndcapTubes.hh
@@ -7,15 +7,14 @@
 //**************************************************************************
 
 #ifndef DREndcapTube_H
-#  define DREndcapTube_H
+#define DREndcapTube_H
 
 // This struct represents a plane corresponding to a tower's face.
 // I construct it with the 4 edges (points) of the tower's face,
 // however only 3 points will be used to define the plane.
-struct Plane
-{
-    Vector3D P1, P2, P3, P4;
-    Plane(Vector3D p1, Vector3D p2, Vector3D p3, Vector3D p4) : P1(p1), P2(p2), P3(p3), P4(p4) {};
+struct Plane {
+  Vector3D P1, P2, P3, P4;
+  Plane(Vector3D p1, Vector3D p2, Vector3D p3, Vector3D p4) : P1(p1), P2(p2), P3(p3), P4(p4){};
 };
 
 // This struct represents a line towards negatize Z
@@ -23,92 +22,86 @@ struct Plane
 // The starting points will be distributed over the back face
 // of the a tower. The corresponding lines will be used to find
 // the intersection with the tower's faces.
-struct ZLine
-{
-    Vector3D origin;
-    Vector3D fuZ = Vector3D(0, 0, -1);
-    ZLine(Vector3D P) : origin(P) {};
+struct ZLine {
+  Vector3D origin;
+  Vector3D fuZ = Vector3D(0, 0, -1);
+  ZLine(Vector3D P) : origin(P){};
 };
 
 // Custom exception class for intersecting ZLines with Planes
-class IntersectException : public std::exception
-{
-  public:
-    const char* what() const noexcept override
-    {
-      return "IntersectLinePlane: Invalid intersection of ZLine with a Plane";
-    }
+class IntersectException : public std::exception {
+public:
+  const char* what() const noexcept override {
+    return "IntersectLinePlane: Invalid intersection of ZLine with a Plane";
+  }
 };
 
-class DREndcapTubeHelper
-{
-  public:
-    // Constructor and de-constructor
-    DREndcapTubeHelper() = default;
-    ~DREndcapTubeHelper() = default;
+class DREndcapTubeHelper {
+public:
+  // Constructor and de-constructor
+  DREndcapTubeHelper() = default;
+  ~DREndcapTubeHelper() = default;
 
-  private:
-    // Class fields
-    //
-    // Fields to be set
-    double fTubeRadius;  // Radius of tubes (same for Scin and Cher)
-    double fPhiZRot;  // tower phi dimension
-    bool fRbool;  // set to true to build right endcap
-    bool fCalBasicBool;  // has CalBasic already being called?
-    double fInnerR;  // inner radius at theta = 0. rad
-    double fTowerHeight;  // tower height/length
-    double fNumZRot;  // number of rotations around Z axis
-    double fDeltaTheta;  // theta dimension of current tower
-    double fDeltaTheta2;  // theta dimension of next tower
-    double fThetaOfCenter;  // theta angle pointing to center of current tower
-    double fThetaOfCenter2;  // theta angle pointing to center of next tower
-    // Fields to be computed
-    double finnerR_new;
-    double finnerR_new2;
-    double fTrns_Length;
-    Vector3D fTrns_Vector;
-    Vector3D fV1;
-    Vector3D fV2;
-    Vector3D fV3;
-    Vector3D fV4;
-    double Ratio;
-    double Ratio2;
+private:
+  // Class fields
+  //
+  // Fields to be set
+  double fTubeRadius;     // Radius of tubes (same for Scin and Cher)
+  double fPhiZRot;        // tower phi dimension
+  bool fRbool;            // set to true to build right endcap
+  bool fCalBasicBool;     // has CalBasic already being called?
+  double fInnerR;         // inner radius at theta = 0. rad
+  double fTowerHeight;    // tower height/length
+  double fNumZRot;        // number of rotations around Z axis
+  double fDeltaTheta;     // theta dimension of current tower
+  double fDeltaTheta2;    // theta dimension of next tower
+  double fThetaOfCenter;  // theta angle pointing to center of current tower
+  double fThetaOfCenter2; // theta angle pointing to center of next tower
+  // Fields to be computed
+  double finnerR_new;
+  double finnerR_new2;
+  double fTrns_Length;
+  Vector3D fTrns_Vector;
+  Vector3D fV1;
+  Vector3D fV2;
+  Vector3D fV3;
+  Vector3D fV4;
+  double Ratio;
+  double Ratio2;
 
-  public:
-    // Methods to set class fields
-    void SetRbool(bool rBool) { fRbool = rBool; }  // set to True if building right endcap
-    void SetInnerR(double innerR) { fInnerR = innerR; }
-    void SetTowerHeight(double towerHeight) { fTowerHeight = towerHeight; }
-    void SetNumZRot(int num)
-    {
-      fNumZRot = num;
-      fPhiZRot = 2 * M_PI / (double)num;
-    }
-    void SetDeltaTheta(double theta) { fDeltaTheta = theta; }
-    void SetThetaOfCenter(double theta) { fThetaOfCenter = theta; }
-    void SetDeltaTheta2(double theta) { fDeltaTheta2 = theta; }
-    void SetThetaOfCenter2(double theta) { fThetaOfCenter2 = theta; }
-    void SetTubeRadius(double tubeRadius) { fTubeRadius = tubeRadius; }
+public:
+  // Methods to set class fields
+  void SetRbool(bool rBool) { fRbool = rBool; } // set to True if building right endcap
+  void SetInnerR(double innerR) { fInnerR = innerR; }
+  void SetTowerHeight(double towerHeight) { fTowerHeight = towerHeight; }
+  void SetNumZRot(int num) {
+    fNumZRot = num;
+    fPhiZRot = 2 * M_PI / (double)num;
+  }
+  void SetDeltaTheta(double theta) { fDeltaTheta = theta; }
+  void SetThetaOfCenter(double theta) { fThetaOfCenter = theta; }
+  void SetDeltaTheta2(double theta) { fDeltaTheta2 = theta; }
+  void SetThetaOfCenter2(double theta) { fThetaOfCenter2 = theta; }
+  void SetTubeRadius(double tubeRadius) { fTubeRadius = tubeRadius; }
 
-    // Methods to calculate towers parameters
-    //
-    void CalBasic();
-    // Get origin on tower within its phi slice/stave
-    Vector3D GetOrigin(int i);
-    // Get 8 vector/points for the tower Trap edges
-    void Getpt(Vector3D* pt);
+  // Methods to calculate towers parameters
+  //
+  void CalBasic();
+  // Get origin on tower within its phi slice/stave
+  Vector3D GetOrigin(int i);
+  // Get 8 vector/points for the tower Trap edges
+  void Getpt(Vector3D* pt);
 
-    // Methods to calculate tubes lengths
-    //
-    // This method finds the "intersection" between a ZLine (tube) and a Plane (tower face)
-    void IntersectLinePlane(const ZLine& line, const Plane& plane, Vector3D& intersection);
-    // This method calculates a tube length given the cylindrical structure of the tube
-    // and each tower face
-    double GetTubeLength(const Vector3D (&pt)[8], const Vector3D& point);
+  // Methods to calculate tubes lengths
+  //
+  // This method finds the "intersection" between a ZLine (tube) and a Plane (tower face)
+  void IntersectLinePlane(const ZLine& line, const Plane& plane, Vector3D& intersection);
+  // This method calculates a tube length given the cylindrical structure of the tube
+  // and each tower face
+  double GetTubeLength(const Vector3D (&pt)[8], const Vector3D& point);
 };
 
-inline void DREndcapTubeHelper::CalBasic()
-{
+inline void DREndcapTubeHelper::CalBasic() {
   fCalBasicBool = 1;
 
   // distance from center to front face of first tower
@@ -133,10 +126,9 @@ inline void DREndcapTubeHelper::CalBasic()
 
   // Vector from origin to center of first tower
   // Remember towers are placed starting from the one laying on the x-axis
-  fTrns_Vector = dd4hep::rec::Vector3D(cos(fThetaOfCenter) * fTrns_Length, 0,
-                                       sin(fThetaOfCenter) * fTrns_Length);
+  fTrns_Vector = dd4hep::rec::Vector3D(cos(fThetaOfCenter) * fTrns_Length, 0, sin(fThetaOfCenter) * fTrns_Length);
 
-  double dx1 = fInnerR;  // inner radius hardcoded in detector construction
+  double dx1 = fInnerR; // inner radius hardcoded in detector construction
   double dxi = sin(fThetaOfCenter) * finnerR_new + innerSide_half * cos(fThetaOfCenter);
   double dxi2 = sin(fThetaOfCenter2) * finnerR_new2 + innerSide_half2 * cos(fThetaOfCenter2);
   Ratio = dxi / dx1;
@@ -145,89 +137,59 @@ inline void DREndcapTubeHelper::CalBasic()
   // These vectors are distributed over the plane of the tower closest to the barrel
   // The difference between fV1 and fV2 (fV3 and fV4) is the correction of finnerR_new+fTowerHeight
   // that meake the vector start at the begin and end of the tower surface
-  fV1 = dd4hep::rec::Vector3D((Ratio2)
-                                * (cos(fThetaOfCenter) * finnerR_new
-                                   + sin(fThetaOfCenter) * finnerR_new * tan(fDeltaTheta / 2.)),
+  fV1 = dd4hep::rec::Vector3D(
+      (Ratio2) * (cos(fThetaOfCenter) * finnerR_new + sin(fThetaOfCenter) * finnerR_new * tan(fDeltaTheta / 2.)), 0,
+      sin(fThetaOfCenter) * finnerR_new - sin(fThetaOfCenter) * finnerR_new * tan(fDeltaTheta / 2.));
+
+  fV2 = dd4hep::rec::Vector3D((Ratio2) * (cos(fThetaOfCenter) * (finnerR_new + fTowerHeight) +
+                                          sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) * tan(fDeltaTheta / 2.)),
                               0,
-                              sin(fThetaOfCenter) * finnerR_new
-                                - sin(fThetaOfCenter) * finnerR_new * tan(fDeltaTheta / 2.));
+                              sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) -
+                                  sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) * tan(fDeltaTheta / 2.));
 
-  fV2 = dd4hep::rec::Vector3D(
-    (Ratio2)
-      * (cos(fThetaOfCenter) * (finnerR_new + fTowerHeight)
-         + sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) * tan(fDeltaTheta / 2.)),
-    0,
-    sin(fThetaOfCenter) * (finnerR_new + fTowerHeight)
-      - sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) * tan(fDeltaTheta / 2.));
+  fV3 = dd4hep::rec::Vector3D(
+      (Ratio) * (cos(fThetaOfCenter) * finnerR_new - sin(fThetaOfCenter) * finnerR_new * tan(fDeltaTheta / 2.)), 0,
+      sin(fThetaOfCenter) * finnerR_new + sin(fThetaOfCenter) * finnerR_new * tan(fDeltaTheta / 2.));
 
-  fV3 = dd4hep::rec::Vector3D((Ratio)
-                                * (cos(fThetaOfCenter) * finnerR_new
-                                   - sin(fThetaOfCenter) * finnerR_new * tan(fDeltaTheta / 2.)),
+  fV4 = dd4hep::rec::Vector3D((Ratio) * (cos(fThetaOfCenter) * (finnerR_new + fTowerHeight) -
+                                         sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) * tan(fDeltaTheta / 2.)),
                               0,
-                              sin(fThetaOfCenter) * finnerR_new
-                                + sin(fThetaOfCenter) * finnerR_new * tan(fDeltaTheta / 2.));
-
-  fV4 = dd4hep::rec::Vector3D(
-    (Ratio)
-      * (cos(fThetaOfCenter) * (finnerR_new + fTowerHeight)
-         - sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) * tan(fDeltaTheta / 2.)),
-    0,
-    sin(fThetaOfCenter) * (finnerR_new + fTowerHeight)
-      + sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) * tan(fDeltaTheta / 2.));
+                              sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) +
+                                  sin(fThetaOfCenter) * (finnerR_new + fTowerHeight) * tan(fDeltaTheta / 2.));
 }
 
 // Get 8 vector/points for the tower Trap edges
-inline void DREndcapTubeHelper::Getpt(dd4hep::rec::Vector3D* pt)
-{
+inline void DREndcapTubeHelper::Getpt(dd4hep::rec::Vector3D* pt) {
   double innerSide_half = finnerR_new * tan(fDeltaTheta / 2.);
   double outerSide_half = (finnerR_new + fTowerHeight) * tan(fDeltaTheta / 2.);
 
   if (fRbool == 1) {
-    pt[0] =
-      dd4hep::rec::Vector3D(-(fV1.x() * tan(fPhiZRot / 2.)), -innerSide_half, -fTowerHeight / 2.);
-    pt[1] =
-      dd4hep::rec::Vector3D((fV1.x() * tan(fPhiZRot / 2.)), -innerSide_half, -fTowerHeight / 2.);
-    pt[2] =
-      dd4hep::rec::Vector3D(-(fV3.x() * tan(fPhiZRot / 2.)), innerSide_half, -fTowerHeight / 2.);
-    pt[3] =
-      dd4hep::rec::Vector3D((fV3.x() * tan(fPhiZRot / 2.)), innerSide_half, -fTowerHeight / 2.);
-    pt[4] =
-      dd4hep::rec::Vector3D(-(fV2.x() * tan(fPhiZRot / 2.)), -outerSide_half, fTowerHeight / 2.);
-    pt[5] =
-      dd4hep::rec::Vector3D((fV2.x() * tan(fPhiZRot / 2.)), -outerSide_half, fTowerHeight / 2.);
-    pt[6] =
-      dd4hep::rec::Vector3D(-(fV4.x() * tan(fPhiZRot / 2.)), outerSide_half, fTowerHeight / 2.);
-    pt[7] =
-      dd4hep::rec::Vector3D((fV4.x() * tan(fPhiZRot / 2.)), outerSide_half, fTowerHeight / 2.);
-  }
-  else {
-    pt[0] =
-      dd4hep::rec::Vector3D(-(fV1.x() * tan(fPhiZRot / 2.)), -innerSide_half, -fTowerHeight / 2.);
-    pt[1] =
-      dd4hep::rec::Vector3D((fV1.x() * tan(fPhiZRot / 2.)), -innerSide_half, -fTowerHeight / 2.);
-    pt[2] =
-      dd4hep::rec::Vector3D(-(fV3.x() * tan(fPhiZRot / 2.)), innerSide_half, -fTowerHeight / 2.);
-    pt[3] =
-      dd4hep::rec::Vector3D((fV3.x() * tan(fPhiZRot / 2.)), innerSide_half, -fTowerHeight / 2.);
-    pt[4] =
-      dd4hep::rec::Vector3D(-(fV2.x() * tan(fPhiZRot / 2.)), -outerSide_half, fTowerHeight / 2.);
-    pt[5] =
-      dd4hep::rec::Vector3D((fV2.x() * tan(fPhiZRot / 2.)), -outerSide_half, fTowerHeight / 2.);
-    pt[6] =
-      dd4hep::rec::Vector3D(-(fV4.x() * tan(fPhiZRot / 2.)), outerSide_half, fTowerHeight / 2.);
-    pt[7] =
-      dd4hep::rec::Vector3D((fV4.x() * tan(fPhiZRot / 2.)), outerSide_half, fTowerHeight / 2.);
+    pt[0] = dd4hep::rec::Vector3D(-(fV1.x() * tan(fPhiZRot / 2.)), -innerSide_half, -fTowerHeight / 2.);
+    pt[1] = dd4hep::rec::Vector3D((fV1.x() * tan(fPhiZRot / 2.)), -innerSide_half, -fTowerHeight / 2.);
+    pt[2] = dd4hep::rec::Vector3D(-(fV3.x() * tan(fPhiZRot / 2.)), innerSide_half, -fTowerHeight / 2.);
+    pt[3] = dd4hep::rec::Vector3D((fV3.x() * tan(fPhiZRot / 2.)), innerSide_half, -fTowerHeight / 2.);
+    pt[4] = dd4hep::rec::Vector3D(-(fV2.x() * tan(fPhiZRot / 2.)), -outerSide_half, fTowerHeight / 2.);
+    pt[5] = dd4hep::rec::Vector3D((fV2.x() * tan(fPhiZRot / 2.)), -outerSide_half, fTowerHeight / 2.);
+    pt[6] = dd4hep::rec::Vector3D(-(fV4.x() * tan(fPhiZRot / 2.)), outerSide_half, fTowerHeight / 2.);
+    pt[7] = dd4hep::rec::Vector3D((fV4.x() * tan(fPhiZRot / 2.)), outerSide_half, fTowerHeight / 2.);
+  } else {
+    pt[0] = dd4hep::rec::Vector3D(-(fV1.x() * tan(fPhiZRot / 2.)), -innerSide_half, -fTowerHeight / 2.);
+    pt[1] = dd4hep::rec::Vector3D((fV1.x() * tan(fPhiZRot / 2.)), -innerSide_half, -fTowerHeight / 2.);
+    pt[2] = dd4hep::rec::Vector3D(-(fV3.x() * tan(fPhiZRot / 2.)), innerSide_half, -fTowerHeight / 2.);
+    pt[3] = dd4hep::rec::Vector3D((fV3.x() * tan(fPhiZRot / 2.)), innerSide_half, -fTowerHeight / 2.);
+    pt[4] = dd4hep::rec::Vector3D(-(fV2.x() * tan(fPhiZRot / 2.)), -outerSide_half, fTowerHeight / 2.);
+    pt[5] = dd4hep::rec::Vector3D((fV2.x() * tan(fPhiZRot / 2.)), -outerSide_half, fTowerHeight / 2.);
+    pt[6] = dd4hep::rec::Vector3D(-(fV4.x() * tan(fPhiZRot / 2.)), outerSide_half, fTowerHeight / 2.);
+    pt[7] = dd4hep::rec::Vector3D((fV4.x() * tan(fPhiZRot / 2.)), outerSide_half, fTowerHeight / 2.);
   }
 }
 
 // Get origin on tower within its phi slice/stave
-inline dd4hep::rec::Vector3D DREndcapTubeHelper::GetOrigin(int i)
-{
+inline dd4hep::rec::Vector3D DREndcapTubeHelper::GetOrigin(int i) {
   if (fCalBasicBool == 0) {
     std::cout << "fCalBasicBool = 0" << std::endl;
     return dd4hep::rec::Vector3D();
-  }
-  else {
+  } else {
     if (fRbool == 1) {
       double x, y, z;
       x = cos(i * fPhiZRot) * fTrns_Vector.x();
@@ -235,8 +197,7 @@ inline dd4hep::rec::Vector3D DREndcapTubeHelper::GetOrigin(int i)
       z = fTrns_Vector.z();
 
       return dd4hep::rec::Vector3D(x, y, z);
-    }
-    else {
+    } else {
       double x, y, z;
       x = cos(i * fPhiZRot) * fTrns_Vector.x();
       y = sin(i * fPhiZRot) * fTrns_Vector.x();
@@ -253,9 +214,7 @@ inline dd4hep::rec::Vector3D DREndcapTubeHelper::GetOrigin(int i)
 // Exceptions are handled by this function if the line is parallel to the plane or the
 // intersection is behind the line origin, i.e. below the backface of the tower.
 // Both cases are to be considered errors.
-inline void DREndcapTubeHelper::IntersectLinePlane(const ZLine& line, const Plane& plane,
-                                                   Vector3D& intersection)
-{
+inline void DREndcapTubeHelper::IntersectLinePlane(const ZLine& line, const Plane& plane, Vector3D& intersection) {
   Vector3D p0 = plane.P1;
   Vector3D p1 = plane.P2;
   Vector3D p2 = plane.P3;
@@ -263,23 +222,21 @@ inline void DREndcapTubeHelper::IntersectLinePlane(const ZLine& line, const Plan
   // Compute the plane normal
   Vector3D u = Vector3D(p1.x() - p0.x(), p1.y() - p0.y(), p1.z() - p0.z());
   Vector3D v = Vector3D(p2.x() - p0.x(), p2.y() - p0.y(), p2.z() - p0.z());
-  Vector3D normal = Vector3D(u.y() * v.z() - u.z() * v.y(), u.z() * v.x() - u.x() * v.z(),
-                             u.x() * v.y() - u.y() * v.x());
+  Vector3D normal =
+      Vector3D(u.y() * v.z() - u.z() * v.y(), u.z() * v.x() - u.x() * v.z(), u.x() * v.y() - u.y() * v.x());
 
-  double denominator =
-    normal.x() * line.fuZ.x() + normal.y() * line.fuZ.y() + normal.z() * line.fuZ.z();
+  double denominator = normal.x() * line.fuZ.x() + normal.y() * line.fuZ.y() + normal.z() * line.fuZ.z();
 
   if (std::fabs(denominator) < 1e-6) {
-    throw IntersectException();  // The line is parallel to the plane
+    throw IntersectException(); // The line is parallel to the plane
   }
 
   double d = normal.x() * p0.x() + normal.y() * p0.y() + normal.z() * p0.z();
   double t =
-    (d - normal.x() * line.origin.x() - normal.y() * line.origin.y() - normal.z() * line.origin.z())
-    / denominator;
+      (d - normal.x() * line.origin.x() - normal.y() * line.origin.y() - normal.z() * line.origin.z()) / denominator;
 
   if (t < 0) {
-    throw IntersectException();  // The intersection is behind the line origin
+    throw IntersectException(); // The intersection is behind the line origin
   }
 
   intersection = Vector3D(line.origin.x() + t * line.fuZ.x(), line.origin.y() + t * line.fuZ.y(),
@@ -291,27 +248,26 @@ inline void DREndcapTubeHelper::IntersectLinePlane(const ZLine& line, const Plan
 // The intersection is calculated over 5 planes (tower front, up, down, left and right faces).
 // For each plane the intersection is calculated over four points on the tube surface (up, down,
 // left, right). The shortest intersection is the one to be used.
-inline double DREndcapTubeHelper::GetTubeLength(const Vector3D (&pt)[8], const Vector3D& point)
-{
+inline double DREndcapTubeHelper::GetTubeLength(const Vector3D (&pt)[8], const Vector3D& point) {
   Plane FirstPlane(pt[0], pt[1], pt[2], pt[3]);  // front plane (smallest one)
-  Plane SecondPlane(pt[1], pt[5], pt[3], pt[7]);  // right plane (looking at the front face)
+  Plane SecondPlane(pt[1], pt[5], pt[3], pt[7]); // right plane (looking at the front face)
   Plane ThirdPlane(pt[2], pt[3], pt[6], pt[7]);  // top plane
-  Plane FourthPlane(pt[0], pt[4], pt[2], pt[6]);  // left plane
+  Plane FourthPlane(pt[0], pt[4], pt[2], pt[6]); // left plane
   Plane FifthPlane(pt[0], pt[1], pt[5], pt[4]);  // bottom plane
   std::array<Plane, 5> Planes{FirstPlane, SecondPlane, ThirdPlane, FourthPlane, FifthPlane};
 
-  ZLine PointZLine(point);  // Axis of the tube with origin on tower back plane
+  ZLine PointZLine(point); // Axis of the tube with origin on tower back plane
   ZLine UpPointZLine(Vector3D(point.x(), point.y() + fTubeRadius, point.z()));
   ZLine DownPointZLine(Vector3D(point.x(), point.y() - fTubeRadius, point.z()));
   ZLine LeftPointZLine(Vector3D(point.x() - fTubeRadius, point.y(), point.z()));
   ZLine RightPointZLine(Vector3D(point.x() + fTubeRadius, point.y(), point.z()));
   std::array<ZLine, 4> Lines{UpPointZLine, DownPointZLine, LeftPointZLine, RightPointZLine};
 
-  Vector3D intersection;  // intersection to be found
-  double tubeLength{0.};  // tube length to be returned
+  Vector3D intersection; // intersection to be found
+  double tubeLength{0.}; // tube length to be returned
 
-  for (std::size_t k = 0; k < Lines.size(); k++) {  // loop over cylinder surface points
-    for (std::size_t i = 0; i < Planes.size(); i++) {  // loop over tower's planes
+  for (std::size_t k = 0; k < Lines.size(); k++) {    // loop over cylinder surface points
+    for (std::size_t i = 0; i < Planes.size(); i++) { // loop over tower's planes
       IntersectLinePlane(Lines.at(k), Planes.at(i), intersection);
       double fiberLengthPlane = (Lines.at(k).origin - intersection).r();
       if (k == 0 && i == 0)
@@ -321,12 +277,12 @@ inline double DREndcapTubeHelper::GetTubeLength(const Vector3D (&pt)[8], const V
       else {
         ;
       }
-    }  // end of loop over tower's planes
-  }  // end of loop over cylinder surface points
+    } // end of loop over tower's planes
+  }   // end of loop over cylinder surface points
 
   return tubeLength;
 };
 
-#endif  // DREndcapTube_H
+#endif // DREndcapTube_H
 
 //**************************************************************************

--- a/detector/calorimeter/dual-readout/src/FiberDualReadoutCalo_o1_v01.cpp
+++ b/detector/calorimeter/dual-readout/src/FiberDualReadoutCalo_o1_v01.cpp
@@ -76,12 +76,12 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h xmlEle
   // rmin, rmax, zmin, zmax, rmin2, rmax2
   // inner r & z are avg values (for track extrapolation)
   // outer r & z are envelope values
-  extensionData->extent[0] = x_barrel.rmin(); // barrel rmin
-  extensionData->extent[1] = x_worldTube.rmax(); // barrel rmax
-  extensionData->extent[2] = x_endcap.rmin(); // endcap zmin
+  extensionData->extent[0] = x_barrel.rmin();      // barrel rmin
+  extensionData->extent[1] = x_worldTube.rmax();   // barrel rmax
+  extensionData->extent[2] = x_endcap.rmin();      // endcap zmin
   extensionData->extent[3] = x_worldTube.height(); // endcap zmax
-  extensionData->extent[4] = x_worldTube.rmin(); // endcap rmin
-  extensionData->extent[5] = x_worldTube.rmax(); // endcap rmax
+  extensionData->extent[4] = x_worldTube.rmin();   // endcap rmin
+  extensionData->extent[5] = x_worldTube.rmax();   // endcap rmax
 
   // TODO separate barrel & endcap
   // type is barrel for the moment

--- a/detector/fcal/LHCal_v01_geo.cpp
+++ b/detector/fcal/LHCal_v01_geo.cpp
@@ -99,8 +99,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
   std::cout << " - Main crossing angle: " << mradFullCrossingAngle << " radian" << std::endl;
   std::cout << " - LHCal begin Z         " << lhcalInnerZ / dd4hep::mm << " mm" << std::endl;
   std::cout << " - LHCal end Z           " << (lhcalInnerZ + lhcalThickness) / dd4hep::mm << " mm" << std::endl;
-  std::cout << " - LHCal center (X,Y,Z)  " << "( " << lhcaloffset / dd4hep::mm << ",0 ," << lhcalCentreZ / dd4hep::mm
-            << " ) mm" << std::endl;
+  std::cout << " - LHCal center (X,Y,Z)  "
+            << "( " << lhcaloffset / dd4hep::mm << ",0 ," << lhcalCentreZ / dd4hep::mm << " ) mm" << std::endl;
   std::cout << " - LHCal inner R         " << lhcalInnerR / dd4hep::mm << " mm" << std::endl;
   std::cout << " - LHCal thickness       " << lhcalThickness / dd4hep::mm << " mm" << std::endl;
 

--- a/detector/fcal/LumiCal_o1_v03_geo.cpp
+++ b/detector/fcal/LumiCal_o1_v03_geo.cpp
@@ -126,8 +126,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
   std::cout << " The crossing angle is:  " << fullCrossingAngle << " radian" << std::endl;
   std::cout << "     " << detName << " z-begin : " << lcalInnerZ / dd4hep::mm << " mm" << std::endl;
   std::cout << "     " << detName << " z-end   : " << (lcalInnerZ + lcalThickness) / dd4hep::mm << " mm" << std::endl;
-  std::cout << "   (x,y,z)-center : " << "( " << lcalXoffset / dd4hep::mm << ",0 ,+- " << lcalCentreZ / dd4hep::mm
-            << " ) mm" << std::endl;
+  std::cout << "   (x,y,z)-center : "
+            << "( " << lcalXoffset / dd4hep::mm << ",0 ,+- " << lcalCentreZ / dd4hep::mm << " ) mm" << std::endl;
   std::cout << "     sensorInnerR : " << sensInnerR / dd4hep::mm << " mm" << std::endl;
   std::cout << "     sensorouterR : " << sensOuterR / dd4hep::mm << " mm" << std::endl;
   std::cout << "        thickness : " << lcalThickness / dd4hep::mm << " mm" << std::endl;

--- a/detector/include/LcgeoExceptions.h
+++ b/detector/include/LcgeoExceptions.h
@@ -15,7 +15,9 @@ class GeometryException : public std::exception {
 
 protected:
   std::string message;
-  GeometryException() { /*no_op*/ ; }
+  GeometryException() { /*no_op*/
+    ;
+  }
 
 public:
   GeometryException(std::string text) { message = "GeometryException: " + text; }

--- a/detector/muonSystem/muonSystemMuRWELL_o1_v01.cpp
+++ b/detector/muonSystem/muonSystemMuRWELL_o1_v01.cpp
@@ -173,10 +173,11 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd, dd4h
   dd4hep::Volume detectorVolume(name, systemEnvelope, mat);
 
   dd4hep::Position detectorTrans(0., 0., 0.);
-  dd4hep::PlacedVolume detectorPhys = experimentalHall.placeVolume(detectorVolume, dd4hep::Transform3D(dd4hep::RotationZ(shapeAngle_radians), detectorTrans));
+  dd4hep::PlacedVolume detectorPhys = experimentalHall.placeVolume(
+      detectorVolume, dd4hep::Transform3D(dd4hep::RotationZ(shapeAngle_radians), detectorTrans));
   detectorPhys.addPhysVolID("system", xmlDet.id());
   detElement.setPlacement(detectorPhys);
-  detectorVolume.setVisAttributes(lcdd.visAttributes("no_vis")); 
+  detectorVolume.setVisAttributes(lcdd.visAttributes("no_vis"));
 
   // ----------------------------------------------------------------------------------------------------
   // ------------------------------// B A R R E L // ----------------------------------------------------
@@ -999,9 +1000,7 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd, dd4h
           dd4hep::Position rectangeEnvelopeTrans(rectangleEnvXPos, rectangleEnvYPos, rectangleEnvZPos);
           dd4hep::PlacedVolume rectangleEnvelopePhys = endcapDetectorSideEnvVol.placeVolume(
               rectangleEnvVol, dd4hep::Transform3D(rotationY, rectangeEnvelopeTrans));
-          dd4hep::DetElement rectangleEnvelopeDE(
-              endcapDetectorSideEnvDE, rectangleEnvelopeName + "DE",
-              rectangle);
+          dd4hep::DetElement rectangleEnvelopeDE(endcapDetectorSideEnvDE, rectangleEnvelopeName + "DE", rectangle);
           rectangleEnvelopeDE.setPlacement(rectangleEnvelopePhys);
           rectangleEnvVol.setVisAttributes(lcdd, xmlDet.visStr());
 
@@ -1248,8 +1247,8 @@ static dd4hep::Ref_t createmuonSystemMuRWELL_o1_v01(dd4hep::Detector& lcdd, dd4h
       }
     }
   }
-  
-  // ------------------------------------------------------------------------------------------- 
+
+  // -------------------------------------------------------------------------------------------
   return detElement;
 }
 

--- a/detector/other/Beampipe_o1_v01_geo.cpp
+++ b/detector/other/Beampipe_o1_v01_geo.cpp
@@ -617,7 +617,7 @@ static Ref_t create_element(Detector& theDetector, xml_h element, SensitiveDetec
     }
 
     } // end switch
-  } // for all xmlSections
+  }   // for all xmlSections
 
   // ######################################################################################################################################################################
 

--- a/detector/other/Mask_o1_v01_geo.cpp
+++ b/detector/other/Mask_o1_v01_geo.cpp
@@ -214,7 +214,7 @@ static Ref_t create_element(Detector& theDetector, xml_h xmlHandle, SensitiveDet
     }
 
     } // end switch
-  } // for all xmlSections
+  }   // for all xmlSections
 
   //--------------------------------------
   Volume mother = theDetector.pickMotherVolume(tube);

--- a/detector/other/SServices00.h
+++ b/detector/other/SServices00.h
@@ -14,8 +14,8 @@
 
 class BuildTPCEndplateServices {
 public:
-  BuildTPCEndplateServices() {};
-  ~BuildTPCEndplateServices() {};
+  BuildTPCEndplateServices(){};
+  ~BuildTPCEndplateServices(){};
 
   void setMaterial(dd4hep::Material copper4cooling) { cooling_Material = copper4cooling; };
   void sethalfZ(double TPC_Ecal_Hcal_barrel_halfZ) { TPC_barrel_halfZ = TPC_Ecal_Hcal_barrel_halfZ; };
@@ -38,8 +38,8 @@ private:
 class BuildEcalBarrelServices {
 
 public:
-  BuildEcalBarrelServices() {};
-  ~BuildEcalBarrelServices() {};
+  BuildEcalBarrelServices(){};
+  ~BuildEcalBarrelServices(){};
 
   void setMaterialAir(dd4hep::Material air4container) { air = air4container; };
   void setMaterialAluminium(dd4hep::Material al) { aluminium = al; };
@@ -115,8 +115,8 @@ private:
 class BuildEcalBarrel_EndCapServices {
 
 public:
-  BuildEcalBarrel_EndCapServices() {};
-  ~BuildEcalBarrel_EndCapServices() {};
+  BuildEcalBarrel_EndCapServices(){};
+  ~BuildEcalBarrel_EndCapServices(){};
 
   void setMaterialAir(dd4hep::Material air4container) { air = air4container; };
   void setMaterialPolyethylene(dd4hep::Material PE) { polyethylene = PE; };
@@ -172,8 +172,8 @@ private:
 class BuildSitCables {
 
 public:
-  BuildSitCables(dd4hep::DetElement det) : detElt(det) {};
-  ~BuildSitCables() {};
+  BuildSitCables(dd4hep::DetElement det) : detElt(det){};
+  ~BuildSitCables(){};
 
   void setMaterialAluminium(dd4hep::Material al) { aluminium = al; };
   void setSit_cables_cylinder_thickness(double cables_cylinder_thickness) {
@@ -236,8 +236,8 @@ private:
 class BuildHcalBarrel_EndCapServices {
 
 public:
-  BuildHcalBarrel_EndCapServices() {};
-  ~BuildHcalBarrel_EndCapServices() {};
+  BuildHcalBarrel_EndCapServices(){};
+  ~BuildHcalBarrel_EndCapServices(){};
 
 public:
   void setMaterialAir(dd4hep::Material Air) { air = Air; };
@@ -377,8 +377,8 @@ private:
 class BuildVXDCables {
 
 public:
-  BuildVXDCables(dd4hep::DetElement det) : detElt(det) {};
-  ~BuildVXDCables() {};
+  BuildVXDCables(dd4hep::DetElement det) : detElt(det){};
+  ~BuildVXDCables(){};
 
   void setMaterialCopper(dd4hep::Material Cu) { copper = Cu; };
   void setVXD_cable_cross_section_area(double cable_area) { VXD_cable_cross_section_area = cable_area; };

--- a/detector/other/SimpleCylinder_geo_o1_v02.cpp
+++ b/detector/other/SimpleCylinder_geo_o1_v02.cpp
@@ -3,8 +3,8 @@
 #include "DDRec/MaterialManager.h"
 #include "DDRec/Vector3D.h"
 #include "XML/Utilities.h"
-#include <DDRec/DetectorData.h>
 #include "detectorSegmentations/FCCSWGridPhiTheta_k4geo.h"
+#include <DDRec/DetectorData.h>
 
 using dd4hep::_toString;
 
@@ -39,8 +39,7 @@ static dd4hep::Ref_t createSimpleCylinder(dd4hep::Detector& lcdd, xml_h e, dd4he
     }
     layersTotalDepth += layer.repeat() * layer.thickness();
   }
-  dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
-                   "Number of layers: %d", nLayers);
+  dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02", "Number of layers: %d", nLayers);
   dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
                    "Total thickness from sum of layers in xml description (cm): %f", layersTotalDepth / dd4hep::cm);
   dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
@@ -99,13 +98,12 @@ static dd4hep::Ref_t createSimpleCylinder(dd4hep::Detector& lcdd, xml_h e, dd4he
 
       // segment the endcap into layers
       double dzLayer = cylinderDim.dz() * 2.0 / nLayers;
-      dd4hep::printout(dd4hep::DEBUG, "SimpleCylinder_o1_v02",
-                       "dZ of each layer : %f", dzLayer);
+      dd4hep::printout(dd4hep::DEBUG, "SimpleCylinder_o1_v02", "dZ of each layer : %f", dzLayer);
       for (int iLayer = 0; iLayer < nLayers; iLayer++) {
         // calculate z extent
         double zMiddle = -cylinderDim.dz() + dzLayer / 2.0 + iLayer * dzLayer;
-        dd4hep::printout(dd4hep::DEBUG, "SimpleCylinder_o1_v02",
-                         "Layer : %d , z offset wrt center of detector : %f", iLayer, zMiddle);
+        dd4hep::printout(dd4hep::DEBUG, "SimpleCylinder_o1_v02", "Layer : %d , z offset wrt center of detector : %f",
+                         iLayer, zMiddle);
 
         // create detector element as daughter of endcap
         dd4hep::DetElement layer(endcap);
@@ -157,20 +155,18 @@ static dd4hep::Ref_t createSimpleCylinder(dd4hep::Detector& lcdd, xml_h e, dd4he
     // try to retrieve segmentation itself so that we can order cell size as desired by pandora
     // if we do not want this, then we'll have to handle it elsewhere i.e. when creating pandora's calo hits
     // in DDMarlinPandora
-    dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo* seg = dynamic_cast<dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo*>(segHandle.segmentation());
+    dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo* seg =
+        dynamic_cast<dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo*>(segHandle.segmentation());
     if (seg) {
-      dd4hep::printout(dd4hep::DEBUG, "SimpleCylinder_o1_v02",
-                       "Segmentation is of type FCCSWGridPhiTheta");
+      dd4hep::printout(dd4hep::DEBUG, "SimpleCylinder_o1_v02", "Segmentation is of type FCCSWGridPhiTheta");
     }
 
     dd4hep::rec::LayeredCalorimeterData::Layer caloLayer;
     double dzLayer = cylinderDim.dz() * 2.0 / nLayers;
     auto mat = lcdd.material(cylinderDim.materialStr());
-    dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
-                     "Layer structure information:");
+    dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02", "Layer structure information:");
     for (int idxLayer = 0; idxLayer < nLayers; ++idxLayer) {
-      dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
-                       "  Layer %d", idxLayer);
+      dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02", "  Layer %d", idxLayer);
       double zIn = zmin + idxLayer * dzLayer;
       // double zOut = zIn + dzLayer;
 
@@ -198,16 +194,15 @@ static dd4hep::Ref_t createSimpleCylinder(dd4hep::Detector& lcdd, xml_h e, dd4he
         std::vector<double> cellSizeVector = seg->cellDimensions(0);
         double cellSizeTheta = cellSizeVector[1];
         double cellSizePhi = cellSizeVector[0];
-        dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
-                         "    cell sizes in theta, phi: %f, %f", cellSizeTheta, cellSizePhi);
+        dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02", "    cell sizes in theta, phi: %f, %f", cellSizeTheta,
+                         cellSizePhi);
         caloLayer.cellSize0 = cellSizeTheta;
         caloLayer.cellSize1 = cellSizePhi;
-      }
-      else {
+      } else {
         // otherwise we just assume that the segmentation (handle) returns the sizes in the proper order
         std::vector<double> cellSizeVector = segHandle.cellDimensions(0);
-        dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
-                         "    cell sizes: %f , %f", cellSizeVector[0], cellSizeVector[1]);
+        dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02", "    cell sizes: %f , %f", cellSizeVector[0],
+                         cellSizeVector[1]);
         caloLayer.cellSize0 = cellSizeVector[0];
         caloLayer.cellSize1 = cellSizeVector[1];
       }
@@ -293,19 +288,17 @@ static dd4hep::Ref_t createSimpleCylinder(dd4hep::Detector& lcdd, xml_h e, dd4he
     // try to retrieve segmentation itself so that we can order cell size as desired by pandora
     // if we do not want this, then we'll have to handle it elsewhere i.e. when creating pandora's calo hits
     // in DDMarlinPandora
-    dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo* seg = dynamic_cast<dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo*>(segHandle.segmentation());
+    dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo* seg =
+        dynamic_cast<dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo*>(segHandle.segmentation());
     if (seg) {
-      dd4hep::printout(dd4hep::DEBUG, "SimpleCylinder_o1_v02",
-                       "Segmentation is of type FCCSWGridPhiTheta");
+      dd4hep::printout(dd4hep::DEBUG, "SimpleCylinder_o1_v02", "Segmentation is of type FCCSWGridPhiTheta");
     }
 
     auto mat = lcdd.material(cylinderDim.materialStr());
     dd4hep::rec::LayeredCalorimeterData::Layer caloLayer;
-    dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
-                     "Layer structure information:");
+    dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02", "Layer structure information:");
     for (int idxLayer = 0; idxLayer < nLayers; ++idxLayer) {
-      dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
-                       "  Layer %d", idxLayer);
+      dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02", "  Layer %d", idxLayer);
 
       rIn = cylinderDim.rmin() + idxLayer * drLayer;
       // double rOut = rIn + drLayer;
@@ -334,16 +327,15 @@ static dd4hep::Ref_t createSimpleCylinder(dd4hep::Detector& lcdd, xml_h e, dd4he
         std::vector<double> cellSizeVector = seg->cellDimensions(0);
         double cellSizeTheta = cellSizeVector[1];
         double cellSizePhi = cellSizeVector[0];
-        dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
-                         "    cell sizes in theta, phi: %f, %f", cellSizeTheta, cellSizePhi);
+        dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02", "    cell sizes in theta, phi: %f, %f", cellSizeTheta,
+                         cellSizePhi);
         caloLayer.cellSize0 = cellSizeTheta;
         caloLayer.cellSize1 = cellSizePhi;
-      }
-      else {
+      } else {
         // otherwise we just assume that the segmentation (handle) returns the sizes in the proper order
         std::vector<double> cellSizeVector = segHandle.cellDimensions(0);
-        dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02",
-                         "    cell sizes: %f , %f", cellSizeVector[0], cellSizeVector[1]);
+        dd4hep::printout(dd4hep::INFO, "SimpleCylinder_o1_v02", "    cell sizes: %f , %f", cellSizeVector[0],
+                         cellSizeVector[1]);
         caloLayer.cellSize0 = cellSizeVector[0];
         caloLayer.cellSize1 = cellSizeVector[1];
       }

--- a/detector/other/TubeX01_geo.cpp
+++ b/detector/other/TubeX01_geo.cpp
@@ -698,7 +698,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector /*
       return 0; // fatal failure
     }
     } // switch (crossType)
-  } // while (db->getTuple())
+  }   // while (db->getTuple())
 
   // ######################################################################################################################################################################
 

--- a/detector/tracker/DriftChamber_o1_v01.cpp
+++ b/detector/tracker/DriftChamber_o1_v01.cpp
@@ -256,7 +256,8 @@ void CDCHBuild::build_layer(DetElement parent, Volume parentVol, dd4hep::Sensiti
   string wirecol, gascol, wholeHyperboloidVolumeName;
   string lvFwireName, lvSwireName;
 
-  struct wire guard_wires{}, field_wires_bottom{}, field_wires_center{}, field_wires_top{}, sense_wires{};
+  struct wire guard_wires {
+  }, field_wires_bottom{}, field_wires_center{}, field_wires_top{}, sense_wires{};
 
   for (int SL = 0; SL < nSuperLayer; ++SL) {
 

--- a/detector/tracker/DriftChamber_o1_v02.cpp
+++ b/detector/tracker/DriftChamber_o1_v02.cpp
@@ -452,7 +452,7 @@ static dd4hep::Ref_t create_DCH_o1_v02(dd4hep::Detector& desc, dd4hep::xml::Hand
           cell_v.placeVolume(fwire_v, fwireTr);
         }
       } // end building field wires
-    } /// end building wires
+    }   /// end building wires
     int maxphi = ncells;
     if (debugGeometry)
       maxphi = 3;

--- a/detector/tracker/FTD_Simple_Staggered_geo.cpp
+++ b/detector/tracker/FTD_Simple_Staggered_geo.cpp
@@ -30,8 +30,8 @@ using namespace rec;
 /// helper to wrap access to global constants
 struct EnvDetector {
   Detector* _theDetector;
-  EnvDetector() : _theDetector(0) {};
-  EnvDetector(Detector& theDetector) : _theDetector(&theDetector) {};
+  EnvDetector() : _theDetector(0){};
+  EnvDetector(Detector& theDetector) : _theDetector(&theDetector){};
   inline double GetParameterAsDouble(const std::string& name) const { return _theDetector->constant<double>(name); }
 };
 
@@ -695,7 +695,8 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
     pv.addPhysVolID("layer", disk_number - 1).addPhysVolID("side", 1);
 
 #ifdef DEBUG_VALUES
-    cout << "===================================================================== " << "\n"
+    cout << "===================================================================== "
+         << "\n"
          << "FTDAirDisk:\n"
          << " Inner Radius= " << _inner_radius << "\n"
          << " Outer Radius= " << _outer_radius << "\n"
@@ -736,7 +737,8 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
     pv.addPhysVolID("layer", disk_number - 1).addPhysVolID("side", -1);
 
 #ifdef DEBUG_VALUES
-    cout << "===================================================================== " << "\n"
+    cout << "===================================================================== "
+         << "\n"
          << "FTDAirDisk:\n"
          << " Inner Radius= " << _inner_radius << "\n"
          << " Outer Radius= " << _outer_radius << "\n"
@@ -884,7 +886,8 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
       petVecnegZ[i] = petalDEnegZ;
 
 #ifdef DEBUG_VALUES
-      cout << "===================================================================== " << "\n"
+      cout << "===================================================================== "
+           << "\n"
            << "FTDPetalAir:\n"
            << " Petal Offset = " << zsign * _dbParDisk.petal_support_zoffset << " Inner Radius= " << _inner_radius
            << "\n"
@@ -1419,7 +1422,8 @@ void petalSupport(Detector& theDetector, DetElement ftd, std::map<std::string, d
   //-END--------------------------- Central Part ----------------------------------END-/
 
 #ifdef DEBUG_VALUES
-  cout << "===================================================================== " << "\n"
+  cout << "===================================================================== "
+       << "\n"
        << "FTDPetalSupport:\n"
        << " Inner Radius= " << _inner_radius_petal << "\n"
        << " Outer Radius= " << _outer_radius << "\n"
@@ -1507,7 +1511,8 @@ VolVec petalSensor(Detector& theDetector, DetElement ftd, SensitiveDetector sens
   volV.push_back(std::make_pair(FTDPetalSensitiveLogical, pv));
 
 #ifdef DEBUG_VALUES
-  cout << "===================================================================== " << "\n"
+  cout << "===================================================================== "
+       << "\n"
        << "FTDPetalSensitive:\n"
        << " Inner Radius= " << _inner_radius_petalSensor << "\n"
        << " Outer Radius= " << _outer_radius << "\n"
@@ -1515,7 +1520,8 @@ VolVec petalSensor(Detector& theDetector, DetElement ftd, SensitiveDetector sens
        << " xMin = " << 2.0 * petal_half_dxMin << "\n"
        << " dy =   " << petal_dy << "\n"
        << " thickness =   " << _dbParDisk.disks_Si_thickness << "\n"
-       << " placed at\n " << " x =   " << Ta.X() << "\n"
+       << " placed at\n "
+       << " x =   " << Ta.X() << "\n"
        << " y =   " << Ta.Y() << "\n"
        << " z =   " << Ta.Z() << "\n"
        << endl;
@@ -1543,7 +1549,8 @@ VolVec petalSensor(Detector& theDetector, DetElement ftd, SensitiveDetector sens
     // registerPV(Phys_rear);
 
 #ifdef DEBUG_VALUES
-    cout << "===================================================================== " << "\n"
+    cout << "===================================================================== "
+         << "\n"
          << "FTDPetalSensitive:\n"
          << " Inner Radius= " << _inner_radius_petalSensor << "\n"
          << " Outer Radius= " << _outer_radius << "\n"
@@ -1551,7 +1558,8 @@ VolVec petalSensor(Detector& theDetector, DetElement ftd, SensitiveDetector sens
          << " xMin = " << 2.0 * petal_half_dxMin << "\n"
          << " dy =   " << petal_dy << "\n"
          << " thickness =   " << _dbParDisk.disks_Si_thickness << "\n"
-         << " placed at\n " << " x =   " << Ta.X() << "\n"
+         << " placed at\n "
+         << " x =   " << Ta.X() << "\n"
          << " y =   " << Ta.Y() << "\n"
          << " z =   " << Ta.Z() << "\n"
          << endl;

--- a/detector/tracker/VXD04_geo.cpp
+++ b/detector/tracker/VXD04_geo.cpp
@@ -361,10 +361,9 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
         // 			ThreeVector((layer_radius + metal_traces_thickness +
         // (flex_cable_thickness/2.))*sin(phirot2)+offset_phi*cos(phirot2),
         // 				      -(layer_radius + metal_traces_thickness +
-        // (flex_cable_thickness/2.))*cos(phirot2)+offset_phi*sin(phirot2), 				      0.), 			FlexCableLogical, 			"FlexCable",
-        // 			worldLog,
-        // 			false,
-        // 			0);
+        // (flex_cable_thickness/2.))*cos(phirot2)+offset_phi*sin(phirot2), 				      0.),
+        // FlexCableLogical, 			"FlexCable", 			worldLog, 			false,
+        // 0);
 
         supp_assembly.placeVolume(
             FoamSpacerLogical,
@@ -944,7 +943,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 
       //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       //**fg, NB:  TGeoConeSeg( dz,rmin0,rmax0,rmin1,rmax1, phi0, phi1 )  -  G4Cons( rmin0,rmin1,rmax0,rmax1, dz, phi0,
-      //delta_phi ) !!!!!!!!!!!!!!!!!!!!
+      // delta_phi ) !!!!!!!!!!!!!!!!!!!!
       //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       Volume KaptonLinesLogical(_toString(LayerId, "KaptonLines_%02d"), KaptonLinesSolid, flexCableMaterial);
@@ -1562,7 +1561,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 
   //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   //**fg, NB:  TGeoConeSeg( dz,rmin0,rmax0,rmin1,rmax1, phi0, phi1 )  -  G4Cons( rmin0,rmin1,rmax0,rmax1, dz, phi0,
-  //delta_phi ) !!!!!!!!!!!!!!!!!!!!
+  // delta_phi ) !!!!!!!!!!!!!!!!!!!!
   //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   Volume SupportConeLogical("SupportCone", SupportShellCone, theDetector.material("G4_Be")); //"beryllium") ) ;
@@ -1746,7 +1745,8 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
   // 			   gearHelpLadders[i].distance , gearHelpLadders[i].offset,gearHelpLadders[i].thickness ,
   // 			   gearHelpLadders[i].length , gearHelpLadders[i].width , gearHelpLadders[i].radLength ,
   // 			   gearHelpSensitives[i].distance, gearHelpSensitives[i].offset , gearHelpSensitives[i].
-  // thickness , 			   gearHelpSensitives[i].length , gearHelpSensitives[i].width , gearHelpSensitives[i].radLength ) ;
+  // thickness , 			   gearHelpSensitives[i].length , gearHelpSensitives[i].width ,
+  // gearHelpSensitives[i].radLength ) ;
   //       gearMgr->setVXDParameters( vxdParams ) ;
   //     }
 

--- a/detectorSegmentations/include/detectorSegmentations/DRparamBase_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/DRparamBase_k4geo.h
@@ -62,7 +62,7 @@ namespace DDSegmentation {
     int GetCurrentTowerNum() { return fCurrentTowerNum; }
     void SetCurrentTowerNum(int numEta) { fCurrentTowerNum = numEta; }
 
-    virtual void init() {};
+    virtual void init(){};
     void filled() { fFilled = true; }
     void finalized() { fFinalized = true; }
     bool IsFinalized() { return fFinalized; }

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h
@@ -8,9 +8,9 @@
 
 /** FCCSWEndcapTurbine_k4geo
  *
- *  Segmentation for turbine-style endcap calorimeter, allowing for 
+ *  Segmentation for turbine-style endcap calorimeter, allowing for
  *  modules to be merged to reduce the readout channel count
-*
+ *
  */
 
 namespace dd4hep {
@@ -172,9 +172,7 @@ namespace DDSegmentation {
     /** return the number of unit cells in each wheel
      * @param[in] iWheel wheel identifier
      */
-    inline int nModules(int iWheel) {
-      return m_nUnitCells[iWheel]/m_mergedModules[iWheel];
-    }
+    inline int nModules(int iWheel) { return m_nUnitCells[iWheel] / m_mergedModules[iWheel]; }
     /** return the expected value of the layer index
      * @param[in] iWheel wheel identifier
      * @param[in] iRho rho readout cell identifier

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWGridModuleThetaMerged_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWGridModuleThetaMerged_k4geo.h
@@ -111,10 +111,10 @@ namespace DDSegmentation {
      *  in natural order of dimensions (nModules, dTheta)
      *  @param[in] cellID
      *  return a std::vector of size 2 with the cellDimensions of the given cell ID(modules, theta)
-    */
+     */
     inline std::vector<double> cellDimensions(const CellID& id) const {
       const int aLayer = layer(id);
-      return {(double) mergedModules(aLayer), gridSizeTheta()*mergedThetaCells(aLayer)};
+      return {(double)mergedModules(aLayer), gridSizeTheta() * mergedThetaCells(aLayer)};
     }
 
   protected:

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWGridPhiTheta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWGridPhiTheta_k4geo.h
@@ -75,10 +75,9 @@ namespace DDSegmentation {
      *  in natural order of dimensions (dPhi, dTheta)
      *  @param[in] cellID
      *  return a std::vector of size 2 with the cellDimensions of the given cell ID (phi, theta)
-    */
-    inline std::vector<double> cellDimensions(const CellID& /* id */) const {
-      return {gridSizePhi(), gridSizeTheta()};
-    }
+     */
+    inline std::vector<double> cellDimensions(const CellID& /* id */) const { return {gridSizePhi(), gridSizeTheta()}; }
+
   protected:
     /// determine the azimuthal angle phi based on the current cell ID
     double phi() const;

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
@@ -186,9 +186,7 @@ namespace DDSegmentation {
      *   @param[in] aCellID the cell ID
      *   return The layer number
      */
-    inline int layer(const CellID& aCellID) const {
-      return _decoder->get(aCellID, fieldNameLayer());
-    }
+    inline int layer(const CellID& aCellID) const { return _decoder->get(aCellID, fieldNameLayer()); }
 
     /**  Set the number of bins in azimuthal angle.
      *   @param[in] aNumberBins Number of bins in phi.
@@ -249,10 +247,10 @@ namespace DDSegmentation {
      *  in natural order of dimensions (phi, z)
      *  @param[in] cellID
      *  return a std::vector of size 2 with the cellDimensions of the given cell ID (phi, z)
-    */
+     */
     inline std::vector<double> cellDimensions(const CellID& id) const {
       const int aLayer = layer(id);
-      return {gridSizePhi(), m_gridSizeRow[aLayer]*m_dz_row};
+      return {gridSizePhi(), m_gridSizeRow[aLayer] * m_dz_row};
     }
 
   protected:

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
@@ -204,10 +204,8 @@ namespace DDSegmentation {
      *  in natural order of dimensions (phi, theta)
      *  @param[in] cellID
      *  return a std::vector of size 2 with the cellDimensions of the given cell ID (phi, theta)
-    */
-    inline std::vector<double> cellDimensions(const CellID& /* id */) const {
-      return {gridSizePhi(), gridSizeTheta()};
-    }
+     */
+    inline std::vector<double> cellDimensions(const CellID& /* id */) const { return {gridSizePhi(), gridSizeTheta()}; }
 
   protected:
     /// determine the azimuthal angle phi based on the current cell ID

--- a/detectorSegmentations/src/FCCSWEndcapTurbine_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWEndcapTurbine_k4geo.cpp
@@ -23,21 +23,22 @@ namespace DDSegmentation {
 
     // register all necessary parameters
     registerParameter("offset_rho", "Offset in rho", m_offsetRho, std::vector<double>());
-    
+
     registerIdentifier("identifier_rho", "Cell ID identifier for rho", m_rhoID, "rho");
-    
-    registerParameter("grid_size_rho", "Grid size in rho", m_gridSizeRho, std::vector<double>());  
+
+    registerParameter("grid_size_rho", "Grid size in rho", m_gridSizeRho, std::vector<double>());
     registerParameter("grid_size_z", "Grid size in z", m_gridSizeZ, std::vector<double>());
     registerParameter("offset_z", "Offset in z1", m_offsetZ, std::vector<double>());
-    registerParameter("offset_theta", "Angular offset in theta", m_offsetTheta, 0., SegmentationParameter::AngleUnit, true);
+    registerParameter("offset_theta", "Angular offset in theta", m_offsetTheta, 0., SegmentationParameter::AngleUnit,
+                      true);
     registerParameter("mergedModules", "Number of merged modules per wheel", m_mergedModules, std::vector<int>());
     registerIdentifier("identifier_z", "Cell ID identifier for z", m_zID, "z");
     registerIdentifier("identifier_side", "Cell ID identifier for side", m_sideID, "side");
     registerIdentifier("identifier_wheel", "Cell ID identifier for wheel", m_wheelID, "wheel");
     registerIdentifier("identifier_module", "Cell ID identifier for module", m_moduleID, "module");
-    registerIdentifier("identifier_layer", "Cell ID identifier for layer", m_layerID, "layer");  
+    registerIdentifier("identifier_layer", "Cell ID identifier for layer", m_layerID, "layer");
     dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
- 
+
     m_bladeAngle.clear();
 
     try {
@@ -181,30 +182,36 @@ namespace DDSegmentation {
     CellID iWheel = _decoder->get(cID, m_wheelID);
     CellID iLayer = _decoder->get(cID, m_layerID);
     CellID iModule = _decoder->get(cID, m_moduleID);
-    
+
     double lRho = rhoFromXYZ(globalPosition);
-    int iRho = positionToBin(lRho, m_gridSizeRho[iWheel], m_offsetRho[iWheel]+m_gridSizeRho[iWheel]/2.);
-    if (iRho < 0) iRho = 0;
+    int iRho = positionToBin(lRho, m_gridSizeRho[iWheel], m_offsetRho[iWheel] + m_gridSizeRho[iWheel] / 2.);
+    if (iRho < 0) {
+      iRho = 0;
+    }
     if (iRho >= m_numReadoutRhoLayers[iWheel]) {
-      iRho = m_numReadoutRhoLayers[iWheel]-1;
+      iRho = m_numReadoutRhoLayers[iWheel] - 1;
     }
     _decoder->set(cID, m_rhoID, iRho);
-    
+
     double lZ = TMath::Abs(globalPosition.Z);
-    int iZ = positionToBin(lZ, m_gridSizeZ[iWheel], m_offsetZ[iWheel]+m_gridSizeZ[iWheel]/2.);
-    if (iZ < 0) iZ = 0;
-    if (iZ >= m_numReadoutZLayers[iWheel]) iZ = m_numReadoutZLayers[iWheel]-1;
+    int iZ = positionToBin(lZ, m_gridSizeZ[iWheel], m_offsetZ[iWheel] + m_gridSizeZ[iWheel] / 2.);
+    if (iZ < 0) {
+      iZ = 0;
+    }
+    if (iZ >= m_numReadoutZLayers[iWheel]) {
+      iZ = m_numReadoutZLayers[iWheel] - 1;
+    }
     _decoder->set(cID, m_zID, iZ);
-    
+
     if (expLayer(iWheel, iRho, iZ) != iLayer) {
       _decoder->set(cID, m_layerID, expLayer(iWheel, iRho, iZ));
     }
-    
+
     // adjust module number to account for merging
-    iModule = iModule/m_mergedModules[iWheel];
-    
+    iModule = iModule / m_mergedModules[iWheel];
+
     _decoder->set(cID, m_moduleID, iModule);
-    
+
     return cID;
   }
 
@@ -213,27 +220,27 @@ namespace DDSegmentation {
     CellID rhoValue = _decoder->get(cID, m_rhoID);
     CellID iWheel = _decoder->get(cID, m_wheelID);
 
-    return binToPosition(rhoValue,m_gridSizeRho[iWheel], m_offsetRho[iWheel])+m_gridSizeRho[iWheel]/2.;
+    return binToPosition(rhoValue, m_gridSizeRho[iWheel], m_offsetRho[iWheel]) + m_gridSizeRho[iWheel] / 2.;
   }
 
   /// determine the azimuthal angle phi based on the cell ID
   double FCCSWEndcapTurbine_k4geo::phi(const CellID& cID) const {
     CellID iModule = _decoder->get(cID, m_moduleID);
     CellID iWheel = _decoder->get(cID, m_wheelID);
-    
-    double phiCent = twopi*(iModule+0.5)/(m_nUnitCells[iWheel]/m_mergedModules[iWheel]);
+
+    double phiCent = twopi * (iModule + 0.5) / (m_nUnitCells[iWheel] / m_mergedModules[iWheel]);
     double rhoLoc = rho(cID);
-    
-    double zdepth = m_numReadoutZLayers[iWheel]*m_gridSizeZ[iWheel];
-    
-    double zLoc = TMath::Abs(z(cID))-m_offsetZ[iWheel]-zdepth/2;
-    double x = zLoc/TMath::Tan(m_bladeAngle[iWheel]);
-    double y = TMath::Sqrt(rhoLoc*rhoLoc - x*x);
+
+    double zdepth = m_numReadoutZLayers[iWheel] * m_gridSizeZ[iWheel];
+
+    double zLoc = TMath::Abs(z(cID)) - m_offsetZ[iWheel] - zdepth / 2;
+    double x = zLoc / TMath::Tan(m_bladeAngle[iWheel]);
+    double y = TMath::Sqrt(rhoLoc * rhoLoc - x * x);
     // rotate about z axis by phiCent
-    double xprime = x*TMath::Cos(phiCent) +y*TMath::Sin(phiCent);
-    double yprime = y*TMath::Cos(phiCent) -x*TMath::Sin(phiCent);
-    
-    return TMath::ATan2(xprime,yprime);
+    double xprime = x * TMath::Cos(phiCent) + y * TMath::Sin(phiCent);
+    double yprime = y * TMath::Cos(phiCent) - x * TMath::Sin(phiCent);
+
+    return TMath::ATan2(xprime, yprime);
   }
 
   /// determine local x in plane of blade based on the cell ID
@@ -241,7 +248,8 @@ namespace DDSegmentation {
     CellID zValue = _decoder->get(cID, m_zID);
     CellID sideValue = _decoder->get(cID, m_sideID);
     CellID iWheel = _decoder->get(cID, m_wheelID);
-    return ((long long int)sideValue)*(binToPosition(zValue,m_gridSizeZ[iWheel],m_offsetZ[iWheel])+m_gridSizeZ[iWheel]/2.);
+    return ((long long int)sideValue) *
+           (binToPosition(zValue, m_gridSizeZ[iWheel], m_offsetZ[iWheel]) + m_gridSizeZ[iWheel] / 2.);
   }
 
   /// determine expected layer value based on wheel, rho, and z indices
@@ -249,11 +257,12 @@ namespace DDSegmentation {
     unsigned layerOffset = 0;
     if (iWheel == 1) {
       layerOffset = m_numCalibZLayers[0] * m_numCalibRhoLayers[0];
+    } else if (iWheel == 2) {
+      layerOffset =
+          m_numCalibZLayers[0] * m_numCalibRhoLayers[0] + layerOffset + m_numCalibZLayers[1] * m_numCalibRhoLayers[1];
     }
-    else if (iWheel == 2) {
-      layerOffset = m_numCalibZLayers[0]*m_numCalibRhoLayers[0]+layerOffset + m_numCalibZLayers[1]*m_numCalibRhoLayers[1];
-    }
-    return layerOffset + iZ/(m_numReadoutZLayers[iWheel]/m_numCalibZLayers[iWheel]) + m_numCalibZLayers[iWheel]*(iRho/(m_numReadoutRhoLayers[iWheel]/m_numCalibRhoLayers[iWheel]));
+    return layerOffset + iZ / (m_numReadoutZLayers[iWheel] / m_numCalibZLayers[iWheel]) +
+           m_numCalibZLayers[iWheel] * (iRho / (m_numReadoutRhoLayers[iWheel] / m_numCalibRhoLayers[iWheel]));
   }
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/plugins/DRCaloFastSimModel.h
+++ b/plugins/DRCaloFastSimModel.h
@@ -355,6 +355,6 @@ public:
       G4cout << G4endl;
     }
   } // print
-}; // end of the class
+};  // end of the class
 
 #endif

--- a/plugins/DRTubesSDAction.cpp
+++ b/plugins/DRTubesSDAction.cpp
@@ -201,7 +201,7 @@ namespace sim {
              : (IsRight && !IsScin) ? collection(m_userData.collection_cher_right)
              : (!IsRight && IsScin) ? collection(m_userData.collection_scin_left)
                                     : collection(m_userData.collection_cher_left);
-    } // end of encap VolumeID and hit collection creation
+    }      // end of encap VolumeID and hit collection creation
     else { // create VolumeID and hit collection for the barrel
 
       // We recreate the TubeID from the tube copynumber:
@@ -298,7 +298,7 @@ namespace sim {
           aStep->GetTrack()->SetTrackStatus(fStopAndKill);
           return true;
         } // end of swich cases
-      } // end of optical photon
+      }   // end of optical photon
       else {
         return true;
       }

--- a/plugins/DRTubesSglHpr.hh
+++ b/plugins/DRTubesSglHpr.hh
@@ -9,94 +9,88 @@
 // the DREndcapTubes signals in scintillating and Cherenkov fibers
 
 #ifndef DRTubesSglHpr_h
-#  define DRTubesSglHpr_h 1
+#define DRTubesSglHpr_h 1
 
 // Includers from Geant4
 //
-#  include "G4Tubs.hh"
-#  include "globals.hh"
+#include "G4Tubs.hh"
+#include "globals.hh"
 
-#  include "CLHEP/Units/SystemOfUnits.h"
+#include "CLHEP/Units/SystemOfUnits.h"
 
-class DRTubesSglHpr
-{
-  public:
-    DRTubesSglHpr() = delete;
+class DRTubesSglHpr {
+public:
+  DRTubesSglHpr() = delete;
 
-  private:
-    // Fields
-    //
-    static constexpr G4double fk_B = 0.126;  // Birks constant
-    static constexpr G4double fSAttenuationLength = 1000.0 * CLHEP::m;
-    static constexpr G4double fCAttenuationLength = 1000.0 * CLHEP::m;
+private:
+  // Fields
+  //
+  static constexpr G4double fk_B = 0.126; // Birks constant
+  static constexpr G4double fSAttenuationLength = 1000.0 * CLHEP::m;
+  static constexpr G4double fCAttenuationLength = 1000.0 * CLHEP::m;
 
-  public:
-    // Methods
-    //
-    // Apply Briks Law
-    static constexpr G4double ApplyBirks(const G4double& de, const G4double& steplength)
-    {
-      return (de / steplength) / (1 + fk_B * (de / steplength)) * steplength;
-    }
+public:
+  // Methods
+  //
+  // Apply Briks Law
+  static constexpr G4double ApplyBirks(const G4double& de, const G4double& steplength) {
+    return (de / steplength) / (1 + fk_B * (de / steplength)) * steplength;
+  }
 
-    // Smear S signal according to Poissonian fluctuations and light yield
-    //
-    // This method calculates how many Scintillation photo electrons are
-    // detected given an energy deposited in MeV (satde). 9.5 is a convertion
-    // factor that translates the average energy deposited in MonteCarlo
-    // to the average Scintillating photo electrons observed (from 2023 test-beam).
-    // A Poissonian smearing is applyed at every step to include poissonian
-    // fluctuations of light emission.
-    static G4int SmearSSignal(const G4double& satde) { return G4Poisson(satde * 9.5); }
+  // Smear S signal according to Poissonian fluctuations and light yield
+  //
+  // This method calculates how many Scintillation photo electrons are
+  // detected given an energy deposited in MeV (satde). 9.5 is a convertion
+  // factor that translates the average energy deposited in MonteCarlo
+  // to the average Scintillating photo electrons observed (from 2023 test-beam).
+  // A Poissonian smearing is applyed at every step to include poissonian
+  // fluctuations of light emission.
+  static G4int SmearSSignal(const G4double& satde) { return G4Poisson(satde * 9.5); }
 
-    // Smear C signal according to Poissonian fluctuations and light yield
-    //
-    // This method calculates how many cherenkov photo electrons are detected
-    // per single Cherenkov photon trapped inside a fiber in the simulation.
-    // Given the average number of Cherenkov photons emitted by Geant4 this
-    // number is converted in average number of Cherenkov photons as measured
-    // in test-beams (0.177 comes from 2023 test-beam).
-    // A poissonian smearing is added at every calculation to include
-    // poissonian light fluctuations.
-    static G4int SmearCSignal() { return G4Poisson(0.177); }
+  // Smear C signal according to Poissonian fluctuations and light yield
+  //
+  // This method calculates how many cherenkov photo electrons are detected
+  // per single Cherenkov photon trapped inside a fiber in the simulation.
+  // Given the average number of Cherenkov photons emitted by Geant4 this
+  // number is converted in average number of Cherenkov photons as measured
+  // in test-beams (0.177 comes from 2023 test-beam).
+  // A poissonian smearing is added at every calculation to include
+  // poissonian light fluctuations.
+  static G4int SmearCSignal() { return G4Poisson(0.177); }
 
-    // Calculate distance from step in fiber to SiPM
-    inline static G4double GetDistanceToSiPM(const G4Step* step, bool prestep);
-    static G4double GetDistanceToSiPM(const G4Step* step) { return GetDistanceToSiPM(step, true); }
+  // Calculate distance from step in fiber to SiPM
+  inline static G4double GetDistanceToSiPM(const G4Step* step, bool prestep);
+  static G4double GetDistanceToSiPM(const G4Step* step) { return GetDistanceToSiPM(step, true); }
 
-    // Calculate how many photons survived after light attenuation
-    inline static G4int AttenuateHelper(const G4int& signal, const G4double& distance,
-                                        const G4double& attenuation_length);
+  // Calculate how many photons survived after light attenuation
+  inline static G4int AttenuateHelper(const G4int& signal, const G4double& distance,
+                                      const G4double& attenuation_length);
 
-    // Attenuate light in fibers
-    static G4int AttenuateSSignal(const G4int& signal, const G4double& distance)
-    {
-      return AttenuateHelper(signal, distance, fSAttenuationLength);
-    }
+  // Attenuate light in fibers
+  static G4int AttenuateSSignal(const G4int& signal, const G4double& distance) {
+    return AttenuateHelper(signal, distance, fSAttenuationLength);
+  }
 
-    static G4int AttenuateCSignal(const G4int& signal, const G4double& distance)
-    {
-      return AttenuateHelper(signal, distance, fCAttenuationLength);
-    }
+  static G4int AttenuateCSignal(const G4int& signal, const G4double& distance) {
+    return AttenuateHelper(signal, distance, fCAttenuationLength);
+  }
 
-    inline static G4ThreeVector CalculateFiberPosition(const G4Step* step);
+  inline static G4ThreeVector CalculateFiberPosition(const G4Step* step);
 
-    // Check if photon is travelling towards SiPM
-    inline static bool IsReflectedForward(const G4Step* step);
+  // Check if photon is travelling towards SiPM
+  inline static bool IsReflectedForward(const G4Step* step);
 
-    // Print step info for debugging purposes
-    inline static void PrintStepInfo(const G4Step* aStep);
+  // Print step info for debugging purposes
+  inline static void PrintStepInfo(const G4Step* aStep);
 };
 
-inline G4double DRTubesSglHpr::GetDistanceToSiPM(const G4Step* step, bool prestep)
-{
+inline G4double DRTubesSglHpr::GetDistanceToSiPM(const G4Step* step, bool prestep) {
   // Get the pre-step point
   const G4StepPoint* StepPoint = prestep ? step->GetPreStepPoint() : step->GetPostStepPoint();
   // Get the global position of the step point
   G4ThreeVector globalPos = StepPoint->GetPosition();
   // Get the local position of the step point in the current volume's coordinate system
-  G4ThreeVector localPos =
-    StepPoint->GetTouchableHandle()->GetHistory()->GetTopTransform().TransformPoint(globalPos);
+  G4ThreeVector localPos = StepPoint->GetTouchableHandle()->GetHistory()->GetTopTransform().TransformPoint(globalPos);
 
   // Get the logical volume of the current step
   G4LogicalVolume* currentVolume = StepPoint->GetTouchableHandle()->GetVolume()->GetLogicalVolume();
@@ -110,31 +104,27 @@ inline G4double DRTubesSglHpr::GetDistanceToSiPM(const G4Step* step, bool preste
 }
 
 inline G4int DRTubesSglHpr::AttenuateHelper(const G4int& signal, const G4double& distance,
-                                            const G4double& attenuation_length)
-{
+                                            const G4double& attenuation_length) {
   double probability_of_survival = exp(-distance / attenuation_length);
 
   G4int survived_photons = 0;
   for (int i = 0; i < signal; i++) {
     // Simulate drawing between 0 and 1 with probability x of getting 1
-    if (G4UniformRand() <= probability_of_survival) survived_photons++;
+    if (G4UniformRand() <= probability_of_survival)
+      survived_photons++;
   }
   return survived_photons;
 }
 
-inline G4ThreeVector DRTubesSglHpr::CalculateFiberPosition(const G4Step* step)
-{
+inline G4ThreeVector DRTubesSglHpr::CalculateFiberPosition(const G4Step* step) {
   G4TouchableHandle theTouchable = step->GetPreStepPoint()->GetTouchableHandle();
   G4ThreeVector origin(0., 0., 0.);
   G4ThreeVector zdir(0., 0., 1.);
-  G4ThreeVector vectPos =
-    theTouchable->GetHistory()->GetTopTransform().Inverse().TransformPoint(origin);
-  G4ThreeVector direction =
-    theTouchable->GetHistory()->GetTopTransform().Inverse().TransformAxis(zdir);
+  G4ThreeVector vectPos = theTouchable->GetHistory()->GetTopTransform().Inverse().TransformPoint(origin);
+  G4ThreeVector direction = theTouchable->GetHistory()->GetTopTransform().Inverse().TransformAxis(zdir);
 
   // Get the logical volume of the current step
-  G4LogicalVolume* currentVolume =
-    step->GetPreStepPoint()->GetTouchableHandle()->GetVolume()->GetLogicalVolume();
+  G4LogicalVolume* currentVolume = step->GetPreStepPoint()->GetTouchableHandle()->GetVolume()->GetLogicalVolume();
   // Get the solid associated with the logical volume
   G4Tubs* solid = dynamic_cast<G4Tubs*>(currentVolume->GetSolid());
   // Get the dimensions of the solid (size of the volume)
@@ -154,33 +144,28 @@ inline G4ThreeVector DRTubesSglHpr::CalculateFiberPosition(const G4Step* step)
 // it might travel towards the SiPM or the inner finer tip.
 // As we do not consider reflections at the inner fiber tip
 // photons travelling backwards should be killed.
-inline bool DRTubesSglHpr::IsReflectedForward(const G4Step* step)
-{
+inline bool DRTubesSglHpr::IsReflectedForward(const G4Step* step) {
   double PreStepDistance = GetDistanceToSiPM(step, true);
   double PostStepDistance = GetDistanceToSiPM(step, false);
   bool IsReflectedForward = (PostStepDistance < PreStepDistance) ? true : false;
   return IsReflectedForward;
 }
 
-inline void DRTubesSglHpr::PrintStepInfo(const G4Step* aStep)
-{
+inline void DRTubesSglHpr::PrintStepInfo(const G4Step* aStep) {
   std::cout << "-------------------------------" << std::endl;
   std::cout << "--> DRTubesSglHpr: track info: " << std::endl;
   std::cout << "----> Track #: " << aStep->GetTrack()->GetTrackID() << " "
             << "Step #: " << aStep->GetTrack()->GetCurrentStepNumber() << " "
-            << "Volume: " << aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume()->GetName()
-            << " " << std::endl;
+            << "Volume: " << aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume()->GetName() << " " << std::endl;
   std::cout << "--> DRTubesSglHpt:: position info(mm): " << std::endl;
   std::cout << "----> x: " << aStep->GetPreStepPoint()->GetPosition().x()
             << " y: " << aStep->GetPreStepPoint()->GetPosition().y()
             << " z: " << aStep->GetPreStepPoint()->GetPosition().z() << std::endl;
   std::cout << "--> DRTubesSglHpr: particle info: " << std::endl;
-  std::cout << "----> Particle " << aStep->GetTrack()->GetParticleDefinition()->GetParticleName()
-            << " "
+  std::cout << "----> Particle " << aStep->GetTrack()->GetParticleDefinition()->GetParticleName() << " "
             << "Dep(MeV) " << aStep->GetTotalEnergyDeposit() << " "
             << "Mat " << aStep->GetPreStepPoint()->GetMaterial()->GetName() << " "
-            << "Vol " << aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume()->GetName()
-            << " "
+            << "Vol " << aStep->GetPreStepPoint()->GetTouchableHandle()->GetVolume()->GetName() << " "
             << "CpNo " << aStep->GetPreStepPoint()->GetTouchable()->GetCopyNumber() << " "
             << "CpNo1 " << aStep->GetPreStepPoint()->GetTouchable()->GetCopyNumber(1) << " "
             << "CpNo2 " << aStep->GetPreStepPoint()->GetTouchable()->GetCopyNumber(2) << " "
@@ -188,6 +173,6 @@ inline void DRTubesSglHpr::PrintStepInfo(const G4Step* aStep)
             << "CpNo4 " << aStep->GetPreStepPoint()->GetTouchable()->GetCopyNumber(4) << std::endl;
 }
 
-#endif  // DRTubesSglHpr_h
+#endif // DRTubesSglHpr_h
 
 //**************************************************************************

--- a/plugins/FiberDRCaloSDAction.cpp
+++ b/plugins/FiberDRCaloSDAction.cpp
@@ -232,7 +232,7 @@ namespace sim {
         if (!drHit) {
           drHit = new Geant4DRCalorimeter::Hit(m_userData.fWavlenStep, m_userData.fTimeStep);
           drHit->cellID = cID;
-          drHit->position = m_segmentation->position(cID)*CLHEP::mm/dd4hep::mm; // segmentation gives dd4hep unit
+          drHit->position = m_segmentation->position(cID) * CLHEP::mm / dd4hep::mm; // segmentation gives dd4hep unit
           drHit->SetSiPMnum(cID);
           drHit->SetTimeStart(m_userData.fTimeStart);
           drHit->SetTimeEnd(m_userData.fTimeEnd);
@@ -275,7 +275,7 @@ namespace sim {
         if (!caloHit) {
           caloHit = new Geant4Calorimeter::Hit(glob);
           caloHit->cellID = cID;
-          caloHit->position = m_segmentation->position(cID)*CLHEP::mm/dd4hep::mm; // segmentation gives dd4hep unit
+          caloHit->position = m_segmentation->position(cID) * CLHEP::mm / dd4hep::mm; // segmentation gives dd4hep unit
           coll_scint->add(cID, caloHit);
         }
 
@@ -319,7 +319,7 @@ namespace sim {
       if (!hit) {
         hit = new Geant4DRCalorimeter::Hit(m_userData.fWavlenStep, m_userData.fTimeStep);
         hit->cellID = cID;
-        hit->position = m_segmentation->position(cID)*CLHEP::mm/dd4hep::mm; // segmentation gives dd4hep unit
+        hit->position = m_segmentation->position(cID) * CLHEP::mm / dd4hep::mm; // segmentation gives dd4hep unit
         hit->SetSiPMnum(cID);
         hit->SetTimeStart(m_userData.fTimeStart);
         hit->SetTimeEnd(m_userData.fTimeEnd);
@@ -336,7 +336,7 @@ namespace sim {
 
       return true;
     } // !skipScint
-  } // Geant4SensitiveAction::process
+  }   // Geant4SensitiveAction::process
 
   typedef Geant4SensitiveAction<DRCData> DRCaloSDAction;
 } // namespace sim

--- a/plugins/FiberDRCaloSDAction.h
+++ b/plugins/FiberDRCaloSDAction.h
@@ -70,7 +70,7 @@ namespace sim {
       /// Standard constructor
       Hit(const Position& cell_pos);
       /// Default destructor
-      virtual ~Hit() {};
+      virtual ~Hit(){};
       /// Move assignment operator
       Hit& operator=(Hit&& c) = delete;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a `clang-format` hook to our pre-commit configuration to actually enforce the formatting that we expect via `.clang-format`.

ENDRELEASENOTES

I am not entirely sure whether these files have gone out of conformance due to changes after the `.clang-format` file was added in https://github.com/key4hep/k4geo/commit/b53e9c6d4eb3aa47838d237654ba204f6a952022 or whether these were not included in the formatting in https://github.com/key4hep/k4geo/commit/221a469b46992dba67ed902455876b4ffb46ce5b . Anyhow, I think there is little meaning for having a `.clang-format` config if we don't enforce it.

This has the potential to introduce merge conflicts in other PRs that also touch these files, I haven't yet checked whether that is the case.