### PR TITLE
Add a CODEOWNERS file for declaring ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,8 @@
 # Owners for FCC geometries
 /FCCee  @BrieucF
 /FCCee/CLD @andresailer @jmcarcell 
-
+/FCCee/ALLEGRO @BrieucF @giovannimarchiori @scott-snyder
+/FCCee/IDEA @lopezzot @patriziaazzi @ndefilip
 # Owners for CLIC geometries
 /CLIC   @andresailer
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,6 @@
 
 # Owners for CLIC geometries
 /CLIC   @andresailer
+
+# Ownvers for muon collider geometries
+/MuColl @madbaron @bartosik-hep @tmadlener

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 *       @andresailer @jmcarcell @tmadlener @gaede @BrieucF
 
 # Owners for ILD geometries
-/ILD/   @tmadlener @gaede @danieljeans 
+/ILD/   @tmadlener @gaede
 
 # Owners for FCC geometries
 /FCCee  @BrieucF

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,10 +5,10 @@
 *       @andresailer @jmcarcell @tmadlener @gaede @BrieucF
 
 # Owners for ILD geometries
-/ILD/   @tmadlener @gaede
+/ILD/   @tmadlener @gaede @danieljeans
 
 # Owners for FCC geometries
-/FCCee  @BrieucF @SanghyunKo @s6anloes @kjvbrt
+/FCCee  @BrieucF @SanghyunKo @kjvbrt
 /FCCee/CLD @andresailer @jmcarcell @Zehvogel
 /FCCee/ALLEGRO @BrieucF @giovannimarchiori @scott-snyder 
 /FCCee/IDEA @lopezzot

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # for more details and the explanation of the rules
 
 # Global owners (will get notified if no other rule applies)
-*       @andresailer @jmcarcell @tmadlener @gaede
+*       @andresailer @jmcarcell @tmadlener @gaede @BrieucF
 
 # Owners for ILD geometries
 /ILD/   @tmadlener @gaede @danieljeans 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# for more details and the explanation of the rules
+
+# Global owners (will get notified if no other rule applies)
+*       @atolosadelgado @andresailer @jmcarcell @tmadlener @gaede
+
+# Owners for ILD geometries
+/ILD/   @tmadlener @gaede
+
+# Owners for FCC geometries
+/FCCee  @atolosadelgado @BrieucF
+
+# Owners for CLIC geometries
+/CLIC   @andresailer

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 /ILD/   @tmadlener @gaede
 
 # Owners for FCC geometries
-/FCCee  @BrieucF
+/FCCee  @BrieucF @SanghyunKo @s6anloes @kjvbrt
 /FCCee/CLD @andresailer @jmcarcell @Zehvogel
 /FCCee/ALLEGRO @BrieucF
 /FCCee/IDEA @lopezzot

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,5 +13,5 @@
 # Owners for CLIC geometries
 /CLIC   @andresailer
 
-# Ownvers for muon collider geometries
+# Owners for muon collider geometries
 /MuColl @madbaron @bartosik-hep @tmadlener

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,13 +2,14 @@
 # for more details and the explanation of the rules
 
 # Global owners (will get notified if no other rule applies)
-*       @atolosadelgado @andresailer @jmcarcell @tmadlener @gaede
+*       @andresailer @jmcarcell @tmadlener @gaede
 
 # Owners for ILD geometries
-/ILD/   @tmadlener @gaede
+/ILD/   @tmadlener @gaede @danieljeans 
 
 # Owners for FCC geometries
-/FCCee  @atolosadelgado @BrieucF
+/FCCee  @BrieucF
+/FCCee/CLD @andresailer @jmcarcell 
 
 # Owners for CLIC geometries
 /CLIC   @andresailer

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 # Owners for FCC geometries
 /FCCee  @BrieucF @SanghyunKo @s6anloes @kjvbrt
 /FCCee/CLD @andresailer @jmcarcell @Zehvogel
-/FCCee/ALLEGRO @BrieucF
+/FCCee/ALLEGRO @BrieucF @giovannimarchiori @scott-snyder 
 /FCCee/IDEA @lopezzot
 # Owners for CLIC geometries
 /CLIC   @andresailer

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 
 # Owners for FCC geometries
 /FCCee  @BrieucF
-/FCCee/CLD @andresailer @jmcarcell 
+/FCCee/CLD @andresailer @jmcarcell @zehvogel
 /FCCee/ALLEGRO @BrieucF @giovannimarchiori @scott-snyder
 /FCCee/IDEA @lopezzot @patriziaazzi @ndefilip
 # Owners for CLIC geometries

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,8 +10,8 @@
 # Owners for FCC geometries
 /FCCee  @BrieucF
 /FCCee/CLD @andresailer @jmcarcell @Zehvogel
-/FCCee/ALLEGRO @BrieucF @giovannimarchiori @scott-snyder
-/FCCee/IDEA @lopezzot @patriziaazzi @ndefilip
+/FCCee/ALLEGRO @BrieucF
+/FCCee/IDEA @lopezzot
 # Owners for CLIC geometries
 /CLIC   @andresailer
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 
 # Owners for FCC geometries
 /FCCee  @BrieucF
-/FCCee/CLD @andresailer @jmcarcell @zehvogel
+/FCCee/CLD @andresailer @jmcarcell @Zehvogel
 /FCCee/ALLEGRO @BrieucF @giovannimarchiori @scott-snyder
 /FCCee/IDEA @lopezzot @patriziaazzi @ndefilip
 # Owners for CLIC geometries


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a `CODEOWNERS` file to designate ownership to different parts of the repository in order to facilitate review and approval processes.

ENDRELEASENOTES

This adds a [`CODEOWNERS` file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) and a first draft of ownership for different parts that almost certainly require refinement.

@atolosadelgado @andresailer @jmcarcell @tmadlener @gaede @BrieucF please have a look and check whether you are happy with this assignment or comment on how it should be changed (e.g. adding other people, adding  / removing yourself from a category, etc.). For now I have only added some of the compact files, but in principle this can be made as fine-grained as we want down to the file level.
