### PR TITLE
A neighboring CellID finding algorithm for IDEA_o1 DRC

### DIFF
--- a/detector/calorimeter/dual-readout/src/DRconstructor.cpp
+++ b/detector/calorimeter/dual-readout/src/DRconstructor.cpp
@@ -53,8 +53,7 @@ void ddDRcalo::DRconstructor::construct() {
   // this causes a discontinuity of the neighboring cells at eta=0
   // we handle this explicitly in the segmentation
   if (fX_det.reflect()) {
-    auto refl_pos =
-        dd4hep::Transform3D(dd4hep::RotationX(M_PI), dd4hep::Position(0, 0, -(fX_worldTube.height() / 2.)));
+    auto refl_pos = dd4hep::Transform3D(dd4hep::RotationX(M_PI), dd4hep::Position(0, 0, -(fX_worldTube.height() / 2.)));
     dd4hep::PlacedVolume PlacedAssemblyTubeVol_refl = fExperimentalHall->placeVolume(AssemblyTubeVol, 1, refl_pos);
     PlacedAssemblyTubeVol_refl.addPhysVolID("assembly", 1);
   }
@@ -249,7 +248,7 @@ void ddDRcalo::DRconstructor::implementFibers(xml_comp_t& x_theta, dd4hep::Volum
   }
 
   // store rows & columns of full length fibers to the segmentation
-  param->SetFullLengthFibers(rmin,rmax,cmin,cmax);
+  param->SetFullLengthFibers(rmin, rmax, cmin, cmax);
 }
 
 // Remove cap (mirror or black paint in front of the fiber)

--- a/detectorSegmentations/include/detectorSegmentations/DRparamBase_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/DRparamBase_k4geo.h
@@ -26,6 +26,7 @@ namespace DDSegmentation {
     void SetSipmHeight(double SipmHeight) { fSipmHeight = SipmHeight; }
 
     bool GetIsRHS() { return fIsRHS; }
+    int GetNumZRot() { return fNumZRot; }
     double GetCurrentInnerR() { return fCurrentInnerR; }
     double GetTowerH() { return fTowerH; }
     double GetSipmHeight() { return fSipmHeight; }
@@ -62,10 +63,29 @@ namespace DDSegmentation {
     int GetCurrentTowerNum() { return fCurrentTowerNum; }
     void SetCurrentTowerNum(int numEta) { fCurrentTowerNum = numEta; }
 
-    virtual void init(){};
+    virtual void init() {};
     void filled() { fFilled = true; }
     void finalized() { fFinalized = true; }
     bool IsFinalized() { return fFinalized; }
+
+    // store information of which fibers have full length or not
+    // full length fibers within rmin <= n_row <= rmax and cmin <= n_column <= cmax
+    struct fullLengthFibers {
+    public:
+      fullLengthFibers(int rmin_, int rmax_, int cmin_, int cmax_)
+      : rmin(rmin_), rmax(rmax_), cmin(cmin_), cmax(cmax_) {}
+
+      fullLengthFibers() // default constructor
+      : rmin(0), rmax(0), cmin(0), cmax(0) {}
+
+      int rmin; // min n_row with full length fibers
+      int rmax; // max n_row
+      int cmin; // min n_column with full length fibers
+      int cmax; // max n_column
+    };
+
+    fullLengthFibers GetFullLengthFibers(int numEta) { return fFullLengthFibers.at( unsignedTowerNo(numEta) ); }
+    void SetFullLengthFibers(int rmin, int rmax, int cmin, int cmax);
 
   protected:
     bool fIsRHS;
@@ -93,6 +113,7 @@ namespace DDSegmentation {
     int fCurrentTowerNum;
     std::vector<double> fDeltaThetaVec;
     std::vector<double> fThetaOfCenterVec;
+    std::map<int,fullLengthFibers> fFullLengthFibers;
     bool fFilled;
     bool fFinalized;
   };

--- a/detectorSegmentations/include/detectorSegmentations/DRparamBase_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/DRparamBase_k4geo.h
@@ -63,7 +63,7 @@ namespace DDSegmentation {
     int GetCurrentTowerNum() { return fCurrentTowerNum; }
     void SetCurrentTowerNum(int numEta) { fCurrentTowerNum = numEta; }
 
-    virtual void init() {};
+    virtual void init(){};
     void filled() { fFilled = true; }
     void finalized() { fFinalized = true; }
     bool IsFinalized() { return fFinalized; }
@@ -73,10 +73,10 @@ namespace DDSegmentation {
     struct fullLengthFibers {
     public:
       fullLengthFibers(int rmin_, int rmax_, int cmin_, int cmax_)
-      : rmin(rmin_), rmax(rmax_), cmin(cmin_), cmax(cmax_) {}
+          : rmin(rmin_), rmax(rmax_), cmin(cmin_), cmax(cmax_) {}
 
       fullLengthFibers() // default constructor
-      : rmin(0), rmax(0), cmin(0), cmax(0) {}
+          : rmin(0), rmax(0), cmin(0), cmax(0) {}
 
       int rmin; // min n_row with full length fibers
       int rmax; // max n_row
@@ -84,7 +84,7 @@ namespace DDSegmentation {
       int cmax; // max n_column
     };
 
-    fullLengthFibers GetFullLengthFibers(int numEta) { return fFullLengthFibers.at( unsignedTowerNo(numEta) ); }
+    fullLengthFibers GetFullLengthFibers(int numEta) { return fFullLengthFibers.at(unsignedTowerNo(numEta)); }
     void SetFullLengthFibers(int rmin, int rmax, int cmin, int cmax);
 
   protected:
@@ -113,7 +113,7 @@ namespace DDSegmentation {
     int fCurrentTowerNum;
     std::vector<double> fDeltaThetaVec;
     std::vector<double> fThetaOfCenterVec;
-    std::map<int,fullLengthFibers> fFullLengthFibers;
+    std::map<int, fullLengthFibers> fFullLengthFibers;
     bool fFilled;
     bool fFinalized;
   };

--- a/detectorSegmentations/include/detectorSegmentations/GridDRcaloHandle_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridDRcaloHandle_k4geo.h
@@ -46,12 +46,16 @@ public:
     return access()->implementation->cellID(local, global, volID);
   }
 
-  inline VolumeID setVolumeID(int numEta, int numPhi) const {
-    return access()->implementation->setVolumeID(numEta, numPhi);
+  inline VolumeID setVolumeID(int systemId, int numEta, int numPhi) const {
+    return access()->implementation->setVolumeID(systemId, numEta, numPhi);
   }
-  inline CellID setCellID(int numEta, int numPhi, int x, int y) const {
-    return access()->implementation->setCellID(numEta, numPhi, x, y);
+  inline CellID setCellID(bool isRHS, int systemId, int numEta, int numPhi, int x, int y) const {
+    return access()->implementation->setCellID(isRHS, systemId, numEta, numPhi, x, y);
   }
+
+  inline void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const {
+    return access()->implementation->neighbours(cellID, neighbours);
+  };
 
   inline void setGridSize(double grid) { access()->implementation->setGridSize(grid); }
 
@@ -72,6 +76,7 @@ public:
 
   inline bool IsTower(const CellID& aCellID) const { return access()->implementation->IsTower(aCellID); }
   inline bool IsSiPM(const CellID& aCellID) const { return access()->implementation->IsSiPM(aCellID); }
+  inline bool IsRHS(const CellID& aCellID) const { return access()->implementation->IsRHS(aCellID); }
 
   inline int getFirst32bits(const CellID& aCellID) const { return access()->implementation->getFirst32bits(aCellID); }
   inline int getLast32bits(const CellID& aCellID) const { return access()->implementation->getLast32bits(aCellID); }

--- a/detectorSegmentations/include/detectorSegmentations/GridDRcalo_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridDRcalo_k4geo.h
@@ -25,8 +25,10 @@ namespace DDSegmentation {
     virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
                           const VolumeID& aVolumeID) const override;
 
-    VolumeID setVolumeID(int numEta, int numPhi) const;
-    CellID setCellID(int numEta, int numPhi, int x, int y) const;
+    VolumeID setVolumeID(int systemId, int numEta, int numPhi) const;
+    CellID setCellID(bool isRHS, int systemId, int numEta, int numPhi, int x, int y) const;
+
+    void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const override;
 
     void setGridSize(double grid) { fGridSize = grid; }
     void setSipmSize(double sipm) { fSipmSize = sipm; }
@@ -40,14 +42,15 @@ namespace DDSegmentation {
     int numY(const CellID& aCellID) const;
 
     // Get the identifier number of a SiPM in x or y direction (local coordinate)
-    int x(const CellID& aCellID) const; // approx eta direction
-    int y(const CellID& aCellID) const; // approx phi direction
+    int x(const CellID& aCellID) const; // approx phi direction
+    int y(const CellID& aCellID) const; // approx eta direction
 
     bool IsCerenkov(const CellID& aCellID) const;
     bool IsCerenkov(int col, int row) const;
 
     bool IsTower(const CellID& aCellID) const;
     bool IsSiPM(const CellID& aCellID) const;
+    bool IsRHS(const CellID& aCellID) const;
 
     int getFirst32bits(const CellID& aCellID) const { return (int)aCellID; }
     int getLast32bits(const CellID& aCellID) const;

--- a/detectorSegmentations/src/DRparamBase_k4geo.cpp
+++ b/detectorSegmentations/src/DRparamBase_k4geo.cpp
@@ -103,10 +103,9 @@ namespace DDSegmentation {
   void DRparamBase_k4geo::SetFullLengthFibers(int rmin, int rmax, int cmin, int cmax) {
     if (fFilled)
       throw std::runtime_error(
-        "DRparamBase_k4geo: An attempt to modify the geometry outside the detector construction is forbidden!"
-      );
+          "DRparamBase_k4geo: An attempt to modify the geometry outside the detector construction is forbidden!");
 
-    fFullLengthFibers.insert( std::make_pair(fCurrentTowerNum, fullLengthFibers(rmin,rmax,cmin,cmax)) );
+    fFullLengthFibers.insert(std::make_pair(fCurrentTowerNum, fullLengthFibers(rmin, rmax, cmin, cmax)));
   }
 
 } // namespace DDSegmentation

--- a/detectorSegmentations/src/DRparamBase_k4geo.cpp
+++ b/detectorSegmentations/src/DRparamBase_k4geo.cpp
@@ -2,6 +2,8 @@
 
 #include "Math/GenVector/RotationZYX.h"
 
+#include <stdexcept>
+
 namespace dd4hep {
 namespace DDSegmentation {
 
@@ -96,6 +98,15 @@ namespace DDSegmentation {
     auto pos = GetSipmLayerPos(numPhi);
 
     return dd4hep::Transform3D(rot, pos);
+  }
+
+  void DRparamBase_k4geo::SetFullLengthFibers(int rmin, int rmax, int cmin, int cmax) {
+    if (fFilled)
+      throw std::runtime_error(
+        "DRparamBase_k4geo: An attempt to modify the geometry outside the detector construction is forbidden!"
+      );
+
+    fFullLengthFibers.insert( std::make_pair(fCurrentTowerNum, fullLengthFibers(rmin,rmax,cmin,cmax)) );
   }
 
 } // namespace DDSegmentation

--- a/detectorSegmentations/src/GridDRcalo_k4geo.cpp
+++ b/detectorSegmentations/src/GridDRcalo_k4geo.cpp
@@ -175,26 +175,23 @@ namespace DDSegmentation {
     // and the second-closest (dist=2) cells in the checkerboard
     // in the same tower
     // dist=sqrt(2) cells
-    auto northEast = setCellID(isRHS,systemId,noEta,noPhi,nX+1,nY+1);
-    auto southEast = setCellID(isRHS,systemId,noEta,noPhi,nX+1,nY-1);
-    auto southWest = setCellID(isRHS,systemId,noEta,noPhi,nX-1,nY-1);
-    auto northWest = setCellID(isRHS,systemId,noEta,noPhi,nX-1,nY+1);
+    auto northEast = setCellID(isRHS, systemId, noEta, noPhi, nX + 1, nY + 1);
+    auto southEast = setCellID(isRHS, systemId, noEta, noPhi, nX + 1, nY - 1);
+    auto southWest = setCellID(isRHS, systemId, noEta, noPhi, nX - 1, nY - 1);
+    auto northWest = setCellID(isRHS, systemId, noEta, noPhi, nX - 1, nY + 1);
     // dist=2 cells
-    auto north = setCellID(isRHS,systemId,noEta,noPhi,nX,nY+2);
-    auto east = setCellID(isRHS,systemId,noEta,noPhi,nX+2,nY);
-    auto south = setCellID(isRHS,systemId,noEta,noPhi,nX,nY-2);
-    auto west = setCellID(isRHS,systemId,noEta,noPhi,nX-2,nY);
+    auto north = setCellID(isRHS, systemId, noEta, noPhi, nX, nY + 2);
+    auto east = setCellID(isRHS, systemId, noEta, noPhi, nX + 2, nY);
+    auto south = setCellID(isRHS, systemId, noEta, noPhi, nX, nY - 2);
+    auto west = setCellID(isRHS, systemId, noEta, noPhi, nX - 2, nY);
 
     // the minimal neighborhood
-    std::set<CellID> nb = {
-      north, northEast, east, southEast,
-      south, southWest, west, northWest
-    };
+    std::set<CellID> nb = {north, northEast, east, southEast, south, southWest, west, northWest};
 
     // function to remove different channel in the set
-    auto removeDifferentChannel = [this] (bool isC, std::set<CellID>& input) {
+    auto removeDifferentChannel = [this](bool isC, std::set<CellID>& input) {
       for (auto it = input.begin(); it != input.end();) {
-        if (isC!=IsCerenkov(*it))
+        if (isC != IsCerenkov(*it))
           it = input.erase(it);
         else
           ++it;
@@ -205,9 +202,8 @@ namespace DDSegmentation {
     int margin = 2;
 
     // if the seed fiber is not on the edge of the tower, return the minimal neighborhood
-    if (nX > fl.cmin + margin && nX < fl.cmax - margin
-        && nY > fl.rmin + margin && nY < fl.rmax - margin) {
-      removeDifferentChannel(isCeren,nb);
+    if (nX > fl.cmin + margin && nX < fl.cmax - margin && nY > fl.rmin + margin && nY < fl.rmax - margin) {
+      removeDifferentChannel(isCeren, nb);
       neighbours = nb;
       return;
     }
@@ -222,44 +218,42 @@ namespace DDSegmentation {
     // then stitch the short length fibers
     // up to the closest full length fiber in the neighboring tower
     // first stitch phi direction first (it's easier)
-    auto modulo = [] (int in, int n) -> int {
-      return (in % n + n) % n;
-    };
+    auto modulo = [](int in, int n) -> int { return (in % n + n) % n; };
 
     if (nX >= fl.cmax - margin) { // to east
       // same tower
-      for (int idx = nX+1; idx < totX; idx++)
-        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,idx,nY) );
+      for (int idx = nX + 1; idx < totX; idx++)
+        nb.insert(setCellID(isRHS, systemId, noEta, noPhi, idx, nY));
 
-      int nextPhi = modulo(noPhi-1,numZRot);
+      int nextPhi = modulo(noPhi - 1, numZRot);
 
       // next tower
       for (int idx = 0; idx <= fl.cmin + margin; idx++)
-        nb.insert( setCellID(isRHS,systemId,noEta,nextPhi,idx,nY) );
+        nb.insert(setCellID(isRHS, systemId, noEta, nextPhi, idx, nY));
     }
 
     if (nX <= fl.cmin + margin) { // to west
       // same tower
-      for (int idx = nX-1; idx >= 0; idx--)
-        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,idx,nY) );
+      for (int idx = nX - 1; idx >= 0; idx--)
+        nb.insert(setCellID(isRHS, systemId, noEta, noPhi, idx, nY));
 
-      int nextPhi = modulo(noPhi+1,numZRot);
+      int nextPhi = modulo(noPhi + 1, numZRot);
 
       // next tower
-      for (int idx = totX-1; idx >= fl.cmax - margin; idx--)
-        nb.insert( setCellID(isRHS,systemId,noEta,nextPhi,idx,nY) );
+      for (int idx = totX - 1; idx >= fl.cmax - margin; idx--)
+        nb.insert(setCellID(isRHS, systemId, noEta, nextPhi, idx, nY));
     }
 
     // now stitch in eta direction
     // but first we need an explicit treatment at eta=0
     // because we use rotation instead of reflection
     // hence cellID is not consistent
-    bool isBarrelCenter = (noEta==0 && nY>=fl.rmax - margin);
+    bool isBarrelCenter = (noEta == 0 && nY >= fl.rmax - margin);
 
     if (isBarrelCenter) {
       // same tower
-      for (int idx = nY+1; idx < totY; idx++)
-        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,nX,idx) );
+      for (int idx = nY + 1; idx < totY; idx++)
+        nb.insert(setCellID(isRHS, systemId, noEta, noPhi, nX, idx));
 
       // since we rotate by 180 deg, nextPhi is numZRot - noPhi
       int nextPhi = modulo(numZRot - noPhi, numZRot);
@@ -268,10 +262,10 @@ namespace DDSegmentation {
       int nextX = totX - nX;
 
       // next tower
-      for (int idx = totY-1; idx >= fl.rmax - margin; idx--)
-        nb.insert( setCellID(isRHS,systemId,noEta,nextPhi,nextX,idx) );
+      for (int idx = totY - 1; idx >= fl.rmax - margin; idx--)
+        nb.insert(setCellID(isRHS, systemId, noEta, nextPhi, nextX, idx));
 
-      removeDifferentChannel(isCeren,nb);
+      removeDifferentChannel(isCeren, nb);
       neighbours = nb;
       return;
     }
@@ -280,35 +274,35 @@ namespace DDSegmentation {
     // and treat the north & south bound case
     if (nY >= fl.rmax) { // to north
       // same tower
-      for (int idx = nY+1; idx < totY; idx++)
-        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,nX,idx) );
+      for (int idx = nY + 1; idx < totY; idx++)
+        nb.insert(setCellID(isRHS, systemId, noEta, noPhi, nX, idx));
 
       // for different noEta rmin and rmax can be different
-      auto flNext = paramBase->GetFullLengthFibers(noEta-1);
+      auto flNext = paramBase->GetFullLengthFibers(noEta - 1);
 
       // next tower
       for (int idx = 0; idx <= flNext.rmin + margin; idx++)
-        nb.insert( setCellID(isRHS,systemId,noEta-1,noPhi,nX,idx) );
+        nb.insert(setCellID(isRHS, systemId, noEta - 1, noPhi, nX, idx));
     }
 
     if (nY <= fl.rmin) { // to south
       // same tower
-      for (int idx = nY-1; idx >= 0; idx--)
-        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,nX,idx) );
+      for (int idx = nY - 1; idx >= 0; idx--)
+        nb.insert(setCellID(isRHS, systemId, noEta, noPhi, nX, idx));
 
       // for different noEta rmin and rmax can be different
-      auto flNext = paramBase->GetFullLengthFibers(noEta+1);
+      auto flNext = paramBase->GetFullLengthFibers(noEta + 1);
 
       // next tower
       // in principle totY is also different
       // but to southbound the next totY is always smaller
       // than the current one
-      for (int idx = totY-1; idx >= flNext.rmax - margin; idx--)
-        nb.insert( setCellID(isRHS,systemId,noEta+1,noPhi,nX,idx) );
+      for (int idx = totY - 1; idx >= flNext.rmax - margin; idx--)
+        nb.insert(setCellID(isRHS, systemId, noEta + 1, noPhi, nX, idx));
     }
 
     // finalize
-    removeDifferentChannel(isCeren,nb);
+    removeDifferentChannel(isCeren, nb);
     neighbours = nb;
     return;
   }
@@ -385,7 +379,7 @@ namespace DDSegmentation {
 
   bool GridDRcalo_k4geo::IsRHS(const CellID& aCellID) const {
     VolumeID assembly = static_cast<VolumeID>(_decoder->get(aCellID, fAssemblyId));
-    return assembly==0;
+    return assembly == 0;
   }
 
   int GridDRcalo_k4geo::getLast32bits(const CellID& aCellID) const {

--- a/detectorSegmentations/src/GridDRcalo_k4geo.cpp
+++ b/detectorSegmentations/src/GridDRcalo_k4geo.cpp
@@ -50,24 +50,32 @@ namespace DDSegmentation {
   }
 
   Vector3D GridDRcalo_k4geo::position(const CellID& cID) const {
-    int noEta = numEta(cID);
+    int noEta = numEta(cID); // always positive since we replicated the RHS
     int noPhi = numPhi(cID);
+    bool isRHS = IsRHS(cID);
 
+    // first get a vector to the center of the wafer (per tower)
     DRparamBase_k4geo* paramBase = setParamBase(noEta);
+    auto waferPos = paramBase->GetSipmLayerPos(noPhi);
 
-    auto transformA = paramBase->GetSipmTransform3D(noPhi);
     dd4hep::Position localPos = dd4hep::Position(0., 0., 0.);
+
+    // get local coordinate
     if (IsSiPM(cID))
       localPos = dd4hep::Position(localPosition(cID));
 
-    dd4hep::RotationZYX rot = dd4hep::RotationZYX(M_PI, 0., 0.); // AdHoc rotation, potentially bug
-    dd4hep::Transform3D transformB = dd4hep::Transform3D(rot, localPos);
-    auto total = transformA * transformB;
+    // rotate the local coordinate on par to the tower
+    auto rot = paramBase->GetRotationZYX(noPhi);
+    auto translation = rot * localPos;
 
-    dd4hep::Position translation = dd4hep::Position(0., 0., 0.);
-    total.GetTranslation(translation);
+    // total vector is sum of the vector to the wafer center + rotated local coordinate
+    auto total = translation + waferPos;
 
-    return Vector3D(translation.x(), translation.y(), translation.z());
+    // if LHS rotate by 180 deg w.r.t. X axis (on par to the DRconstructor)
+    if (!isRHS)
+      total = dd4hep::RotationX(M_PI) * total;
+
+    return Vector3D(total.x(), total.y(), total.z());
   }
 
   Vector3D GridDRcalo_k4geo::localPosition(const CellID& cID) const {
@@ -92,8 +100,12 @@ namespace DDSegmentation {
   /// determine the cell ID based on the position
   CellID GridDRcalo_k4geo::cellID(const Vector3D& localPosition, const Vector3D& globalPosition,
                                   const VolumeID& vID) const {
+    // vID is assume to be the tower's
+    // so we use z position instead to determine isRHS
+    int systemId = static_cast<int>(_decoder->get(vID, "system"));
     int numx = numX(vID);
     int numy = numY(vID);
+    bool isRHS = globalPosition.z() > 0.;
 
     auto localX = localPosition.x();
     auto localY = localPosition.y();
@@ -101,14 +113,15 @@ namespace DDSegmentation {
     int x = std::floor((localX + (numx % 2 == 0 ? 0. : fGridSize / 2.)) / fGridSize) + numx / 2;
     int y = std::floor((localY + (numy % 2 == 0 ? 0. : fGridSize / 2.)) / fGridSize) + numy / 2;
 
-    int signedNumEta = (globalPosition.z() >= 0) ? numEta(vID) : (-numEta(vID) - 1);
-    return setCellID(signedNumEta, numPhi(vID), x, y);
+    return setCellID(isRHS, systemId, numEta(vID), numPhi(vID), x, y);
   }
 
-  VolumeID GridDRcalo_k4geo::setVolumeID(int numEta, int numPhi) const {
+  VolumeID GridDRcalo_k4geo::setVolumeID(int aSystem, int numEta, int numPhi) const {
+    VolumeID systemId = static_cast<VolumeID>(aSystem);
     VolumeID numEtaId = static_cast<VolumeID>(numEta);
     VolumeID numPhiId = static_cast<VolumeID>(numPhi);
     VolumeID vID = 0;
+    _decoder->set(vID, "system", systemId);
     _decoder->set(vID, fNumEtaId, numEtaId);
     _decoder->set(vID, fNumPhiId, numPhiId);
 
@@ -118,12 +131,14 @@ namespace DDSegmentation {
     return vID;
   }
 
-  CellID GridDRcalo_k4geo::setCellID(int numEta, int numPhi, int x, int y) const {
+  CellID GridDRcalo_k4geo::setCellID(bool isRHS, int aSystem, int numEta, int numPhi, int x, int y) const {
+    VolumeID systemId = static_cast<VolumeID>(aSystem);
     VolumeID numEtaId = static_cast<VolumeID>(numEta);
     VolumeID numPhiId = static_cast<VolumeID>(numPhi);
     VolumeID xId = static_cast<VolumeID>(x);
     VolumeID yId = static_cast<VolumeID>(y);
     VolumeID vID = 0;
+    _decoder->set(vID, "system", systemId);
     _decoder->set(vID, fNumEtaId, numEtaId);
     _decoder->set(vID, fNumPhiId, numPhiId);
     _decoder->set(vID, fXId, xId);
@@ -135,10 +150,167 @@ namespace DDSegmentation {
     VolumeID isCeren = IsCerenkov(x, y) ? 1 : 0;
     _decoder->set(vID, fIsCerenkovId, isCeren);
 
-    VolumeID assemblyId = (numEta >= 0) ? 0 : 1;
+    VolumeID assemblyId = isRHS ? 0 : 1;
     _decoder->set(vID, fAssemblyId, assemblyId);
 
     return vID;
+  }
+
+  void GridDRcalo_k4geo::neighbours(const CellID& cID, std::set<CellID>& neighbours) const {
+    int systemId = static_cast<int>(_decoder->get(cID, "system"));
+    int noEta = numEta(cID);
+    int noPhi = numPhi(cID);
+    int nX = x(cID); // col
+    int nY = y(cID); // row
+    int totX = numX(cID);
+    int totY = numY(cID);
+    bool isCeren = IsCerenkov(cID);
+    bool isRHS = IsRHS(cID);
+
+    DRparamBase_k4geo* paramBase = setParamBase(noEta);
+    auto fl = paramBase->GetFullLengthFibers(noEta);
+    int numZRot = paramBase->GetNumZRot();
+
+    // First we look for the closest (dist=sqrt(2))
+    // and the second-closest (dist=2) cells in the checkerboard
+    // in the same tower
+    // dist=sqrt(2) cells
+    auto northEast = setCellID(isRHS,systemId,noEta,noPhi,nX+1,nY+1);
+    auto southEast = setCellID(isRHS,systemId,noEta,noPhi,nX+1,nY-1);
+    auto southWest = setCellID(isRHS,systemId,noEta,noPhi,nX-1,nY-1);
+    auto northWest = setCellID(isRHS,systemId,noEta,noPhi,nX-1,nY+1);
+    // dist=2 cells
+    auto north = setCellID(isRHS,systemId,noEta,noPhi,nX,nY+2);
+    auto east = setCellID(isRHS,systemId,noEta,noPhi,nX+2,nY);
+    auto south = setCellID(isRHS,systemId,noEta,noPhi,nX,nY-2);
+    auto west = setCellID(isRHS,systemId,noEta,noPhi,nX-2,nY);
+
+    // the minimal neighborhood
+    std::set<CellID> nb = {
+      north, northEast, east, southEast,
+      south, southWest, west, northWest
+    };
+
+    // function to remove different channel in the set
+    auto removeDifferentChannel = [this] (bool isC, std::set<CellID>& input) {
+      for (auto it = input.begin(); it != input.end();) {
+        if (isC!=IsCerenkov(*it))
+          it = input.erase(it);
+        else
+          ++it;
+      }
+    };
+
+    // margin to switch the definiton of the neighborhood at the edge of the tower
+    int margin = 2;
+
+    // if the seed fiber is not on the edge of the tower, return the minimal neighborhood
+    if (nX > fl.cmin + margin && nX < fl.cmax - margin
+        && nY > fl.rmin + margin && nY < fl.rmax - margin) {
+      removeDifferentChannel(isCeren,nb);
+      neighbours = nb;
+      return;
+    }
+
+    // WARNING the following edge stitching part has very strict assumption
+    // on the way how geometry is constructed
+    // e.g. how do we replicate the RHS to LHS
+    // if someone wants to change the geometry
+    // then always check that the neighboring algorithm is not broken
+
+    // now the seed fiber is on the edge of the tower
+    // then stitch the short length fibers
+    // up to the closest full length fiber in the neighboring tower
+    // first stitch phi direction first (it's easier)
+    auto modulo = [] (int in, int n) -> int {
+      return (in % n + n) % n;
+    };
+
+    if (nX >= fl.cmax - margin) { // to east
+      // same tower
+      for (int idx = nX+1; idx < totX; idx++)
+        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,idx,nY) );
+
+      int nextPhi = modulo(noPhi-1,numZRot);
+
+      // next tower
+      for (int idx = 0; idx <= fl.cmin + margin; idx++)
+        nb.insert( setCellID(isRHS,systemId,noEta,nextPhi,idx,nY) );
+    }
+
+    if (nX <= fl.cmin + margin) { // to west
+      // same tower
+      for (int idx = nX-1; idx >= 0; idx--)
+        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,idx,nY) );
+
+      int nextPhi = modulo(noPhi+1,numZRot);
+
+      // next tower
+      for (int idx = totX-1; idx >= fl.cmax - margin; idx--)
+        nb.insert( setCellID(isRHS,systemId,noEta,nextPhi,idx,nY) );
+    }
+
+    // now stitch in eta direction
+    // but first we need an explicit treatment at eta=0
+    // because we use rotation instead of reflection
+    // hence cellID is not consistent
+    bool isBarrelCenter = (noEta==0 && nY>=fl.rmax - margin);
+
+    if (isBarrelCenter) {
+      // same tower
+      for (int idx = nY+1; idx < totY; idx++)
+        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,nX,idx) );
+
+      // since we rotate by 180 deg, nextPhi is numZRot - noPhi
+      int nextPhi = modulo(numZRot - noPhi, numZRot);
+
+      // same applies for nX
+      int nextX = totX - nX;
+
+      // next tower
+      for (int idx = totY-1; idx >= fl.rmax - margin; idx--)
+        nb.insert( setCellID(isRHS,systemId,noEta,nextPhi,nextX,idx) );
+
+      removeDifferentChannel(isCeren,nb);
+      neighbours = nb;
+      return;
+    }
+
+    // now we forget about the eta=0 case
+    // and treat the north & south bound case
+    if (nY >= fl.rmax) { // to north
+      // same tower
+      for (int idx = nY+1; idx < totY; idx++)
+        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,nX,idx) );
+
+      // for different noEta rmin and rmax can be different
+      auto flNext = paramBase->GetFullLengthFibers(noEta-1);
+
+      // next tower
+      for (int idx = 0; idx <= flNext.rmin + margin; idx++)
+        nb.insert( setCellID(isRHS,systemId,noEta-1,noPhi,nX,idx) );
+    }
+
+    if (nY <= fl.rmin) { // to south
+      // same tower
+      for (int idx = nY-1; idx >= 0; idx--)
+        nb.insert( setCellID(isRHS,systemId,noEta,noPhi,nX,idx) );
+
+      // for different noEta rmin and rmax can be different
+      auto flNext = paramBase->GetFullLengthFibers(noEta+1);
+
+      // next tower
+      // in principle totY is also different
+      // but to southbound the next totY is always smaller
+      // than the current one
+      for (int idx = totY-1; idx >= flNext.rmax - margin; idx--)
+        nb.insert( setCellID(isRHS,systemId,noEta+1,noPhi,nX,idx) );
+    }
+
+    // finalize
+    removeDifferentChannel(isCeren,nb);
+    neighbours = nb;
+    return;
   }
 
   // Get the identifier number of a mother tower in eta or phi direction
@@ -176,11 +348,11 @@ namespace DDSegmentation {
   }
 
   // Get the identifier number of a SiPM in x or y direction (local coordinate)
-  int GridDRcalo_k4geo::x(const CellID& aCellID) const { // approx eta direction
+  int GridDRcalo_k4geo::x(const CellID& aCellID) const { // approx phi direction
     VolumeID x = static_cast<VolumeID>(_decoder->get(aCellID, fXId));
     return static_cast<int>(x);
   }
-  int GridDRcalo_k4geo::y(const CellID& aCellID) const { // approx phi direction
+  int GridDRcalo_k4geo::y(const CellID& aCellID) const { // approx eta direction
     VolumeID y = static_cast<VolumeID>(_decoder->get(aCellID, fYId));
     return static_cast<int>(y);
   }
@@ -209,6 +381,11 @@ namespace DDSegmentation {
   bool GridDRcalo_k4geo::IsSiPM(const CellID& aCellID) const {
     VolumeID module = static_cast<VolumeID>(_decoder->get(aCellID, fModule));
     return module == 1;
+  }
+
+  bool GridDRcalo_k4geo::IsRHS(const CellID& aCellID) const {
+    VolumeID assembly = static_cast<VolumeID>(_decoder->get(aCellID, fAssemblyId));
+    return assembly==0;
   }
 
   int GridDRcalo_k4geo::getLast32bits(const CellID& aCellID) const {


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Developed neighboring CellID finding algorithm for IDEA_o1 DRC
- Bug fix of the CellID position calculation of `GridDRcalo_k4geo` 

ENDRELEASENOTES

This is a PR for the neighboring CellID finding algorithm for IDEA_o1 DRC. Currently, the topoclustering algorithm collects neighboring CellIDs of a given cell by reading a `TTree`. This is not optimal since the number of channels can reach ~ 100M for DRC and the size of `TTree` can explode.

In this PR, we attempt to retrieve the neighboring CellID by using function overriding (plus corresponding modification to the topoclustering code to utilize `Segmentation::neighbours` function).
