### PR TITLE
Add detector type flags for IDEA o1 v03 dual readout calo

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o1_v03/FiberDualReadoutCalo_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/FiberDualReadoutCalo_o1_v01.xml
@@ -587,6 +587,7 @@
   <detectors>
     <detector id="DetID_FiberDRCalo" name="DRcalo" type="FiberDualReadoutCalo_o1_v01" readout="DRcaloSiPMreadout" region="FastSimOpFiberRegion" reflect="true" vis="DRCInvisible">
       <sensitive type="DRcaloSiPMSD"/>
+      <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_HADRONIC + DetType_BARREL + DetType_ENDCAP"/>
       <sipmDim height="0.3*mm" material="PolyvinylChloride" vis="DRCGenericVis">
         <sipmGlass material="DR_PyrexGlass" vis="DRCGlassVis"/>
         <sipmWafer height="0.3*mm" material="Silicon" vis="DRCWaferVis" sensitive="false"/> <!-- Original height : 0.01 mm, change to 0.3 mm, same as sipmDim (to reduce memory)-->


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [ ] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [ ] the PR does not contain any additions or modifications that do not belong to it
- [ ] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Add detector type flags for IDEA o1 v03 dual readout calorimeter

ENDRELEASENOTES

