### PR TITLE
Follow up fix of #471 (DRC neighboring CellID finding algo)

### DIFF
--- a/detectorSegmentations/src/GridDRcalo_k4geo.cpp
+++ b/detectorSegmentations/src/GridDRcalo_k4geo.cpp
@@ -263,7 +263,7 @@ namespace DDSegmentation {
 
       // next tower
       for (int idx = totY - 1; idx >= fl.rmax - margin; idx--)
-        nb.insert(setCellID(isRHS, systemId, noEta, nextPhi, nextX, idx));
+        nb.insert(setCellID(!isRHS, systemId, noEta, nextPhi, nextX, idx));
 
       removeDifferentChannel(isCeren, nb);
       neighbours = nb;
@@ -290,15 +290,17 @@ namespace DDSegmentation {
       for (int idx = nY - 1; idx >= 0; idx--)
         nb.insert(setCellID(isRHS, systemId, noEta, noPhi, nX, idx));
 
-      // for different noEta rmin and rmax can be different
-      auto flNext = paramBase->GetFullLengthFibers(noEta + 1);
-
       // next tower
       // in principle totY is also different
       // but to southbound the next totY is always smaller
       // than the current one
-      for (int idx = totY - 1; idx >= flNext.rmax - margin; idx--)
-        nb.insert(setCellID(isRHS, systemId, noEta + 1, noPhi, nX, idx));
+      // also protect from looking for a tower with numEta greater than the total # of towers
+      if (noEta+1 < fParamEndcap->GetTotTowerNum() + fParamBarrel->GetTotTowerNum()) {
+        auto flNext = paramBase->GetFullLengthFibers(noEta + 1);
+
+        for (int idx = totY - 1; idx >= flNext.rmax - margin; idx--)
+          nb.insert(setCellID(isRHS, systemId, noEta + 1, noPhi, nX, idx));
+      }
     }
 
     // finalize

--- a/detectorSegmentations/src/GridDRcalo_k4geo.cpp
+++ b/detectorSegmentations/src/GridDRcalo_k4geo.cpp
@@ -295,7 +295,7 @@ namespace DDSegmentation {
       // but to southbound the next totY is always smaller
       // than the current one
       // also protect from looking for a tower with numEta greater than the total # of towers
-      if (noEta+1 < fParamEndcap->GetTotTowerNum() + fParamBarrel->GetTotTowerNum()) {
+      if (noEta + 1 < fParamEndcap->GetTotTowerNum() + fParamBarrel->GetTotTowerNum()) {
         auto flNext = paramBase->GetFullLengthFibers(noEta + 1);
 
         for (int idx = totY - 1; idx >= flNext.rmax - margin; idx--)


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Follow up fix of #471 & protecting from an exception by `std::map::at`

ENDRELEASENOTES

Protecting the DRC neighboring CellID finding algo from throwing exception due to the `noEta` being greater than the total number of tower available in the geometry. Also taking into account the reflection properly (`isRHS`) when looking for a neighborhood.
