### PR TITLE
Add Birks constant value for Polystyrene

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/materials.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/materials.xml
@@ -59,6 +59,7 @@
     <D value="1.032" unit="g/cm3"/>
     <composite n="19" ref="C"/>
     <composite n="21" ref="H"/>
+    <constant name="BirksConstant" value="0.126*mm/MeV"/>
   </material>
 
   <material name="Steel235">


### PR DESCRIPTION
BEGINRELEASENOTES
- Birks constant value is set for Polystyrene scintillator used by HCal. This fixed the abnormal response to hadrons.

ENDRELEASENOTES

