### PR TITLE
correct x/y components extracted from Br-Z field map

### DIFF
--- a/detector/other/FieldMapBrBz.cpp
+++ b/detector/other/FieldMapBrBz.cpp
@@ -139,8 +139,8 @@ void FieldMapBrBz::fieldComponents(const double* pos, double* globalField) {
   field[1] = (1.0 - rd) * (1.0 - zd) * B_r0z0.Bz + rd * (1.0 - zd) * B_r1z0.Bz + (1.0 - rd) * zd * B_r0z1.Bz +
              rd * zd * B_r1z1.Bz;
 
-  globalField[0] += field[0] * sin(phi);
-  globalField[1] += field[0] * cos(phi);
+  globalField[0] += field[0] * cos(phi);
+  globalField[1] += field[0] * sin(phi);
   globalField[2] += field[1];
 
   /*


### PR DESCRIPTION
BEGINRELEASENOTES
- FieldMapBrBz: Correct bug in the conversion of a radial field component to x-y components. Previously x and y were interchanged.
ENDRELEASENOTES

