### PR TITLE
Improve ALLEGRO ECAL visual rendering

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ECalBarrel_thetamodulemerged.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ECalBarrel_thetamodulemerged.xml
@@ -82,6 +82,10 @@
 
   <display>
     <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughers="false" visible="true"/>
+    <vis name="service_bath" r="0." g="1" b="0." alpha="1" showDaughers="true" visible="true"/>
+    <vis name="sensitive_bath" r="0.0" g="0." b="1" alpha="1" showDaughers="true" visible="true"/>
+    <vis name="absorbers" r="1" g="0." b="0." alpha="1" showDaughers="true" visible="true"/>
+    <vis name="pcb" r="0." g="1." b="0." alpha="1" showDaughers="true" visible="true"/>
   </display>
 
   <readouts>

--- a/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03_geo.cpp
+++ b/detector/calorimeter/ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v03_geo.cpp
@@ -191,7 +191,9 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
                      cryoDim.rmax1() / dd4hep::cm, caloDim.dz() / dd4hep::cm);
 
     dd4hep::Volume servicesFrontVol("services_front", servicesFrontShape, aLcdd.material(activeMaterial));
+    servicesFrontVol.setVisAttributes(aLcdd, "service_bath");
     dd4hep::Volume servicesBackVol("services_back", servicesBackShape, aLcdd.material(activeMaterial));
+    servicesBackVol.setVisAttributes(aLcdd, "service_bath");
     dd4hep::PlacedVolume servicesFrontPhysVol = envelopeVol.placeVolume(servicesFrontVol);
     dd4hep::PlacedVolume servicesBackPhysVol = envelopeVol.placeVolume(servicesBackVol);
 
@@ -456,14 +458,19 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   dd4hep::Box passiveOuterShape(passiveOuterThickness / 4., caloDim.dz(), planeLength / 2. / cosPassiveAngle);
   dd4hep::Box passiveGlueShape(passiveGlueThickness / 4., caloDim.dz(), planeLength / 2. / cosPassiveAngle);
   dd4hep::Volume passiveVol("passive", passiveShape, aLcdd.material("Air"));
+  passiveVol.setVisAttributes(aLcdd, "absorbers");
   dd4hep::Volume passiveInnerVol(passiveInnerMaterial + "_passive", passiveInnerShape,
                                  aLcdd.material(passiveInnerMaterial));
+  passiveInnerVol.setVisAttributes(aLcdd, "absorbers");
   dd4hep::Volume passiveInnerVolFirstLayer(passiveInnerMaterialFirstLayer + "_passive", passiveInnerShapeFirstLayer,
                                            aLcdd.material(passiveInnerMaterialFirstLayer));
+  passiveInnerVolFirstLayer.setVisAttributes(aLcdd, "absorbers");
   dd4hep::Volume passiveOuterVol(passiveOuterMaterial + "_passive", passiveOuterShape,
                                  aLcdd.material(passiveOuterMaterial));
+  passiveOuterVol.setVisAttributes(aLcdd, "absorbers");
   dd4hep::Volume passiveGlueVol(passiveGlueMaterial + "_passive", passiveGlueShape,
                                 aLcdd.material(passiveGlueMaterial));
+  passiveGlueVol.setVisAttributes(aLcdd, "absorbers");
 
   // translate and rotate the elements of the module appropriately
   // the Pb absorber does not need to be rotated, but the glue and
@@ -596,6 +603,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
   //////////////////////////////
   dd4hep::Box readoutShape(readoutThickness / 2., caloDim.dz(), planeLength / 2.);
   dd4hep::Volume readoutVol(readoutMaterial, readoutShape, aLcdd.material(readoutMaterial));
+  readoutVol.setVisAttributes(aLcdd, "pcb");
   // if the readout is sensitive (to study energy deposited in it, for calculation of per-layer
   // sampling fraction), then it is divided in layer volumes, and each layer volume is set as sensitive
   if (readout.isSensitive()) {
@@ -660,6 +668,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
 
   // - create the active volume, which will contain the layers filled with LAr
   dd4hep::Volume activeVol("active", activeShape, aLcdd.material("Air"));
+  activeVol.setVisAttributes(aLcdd, "sensitive_bath");
 
   // place layers within active volume
   std::vector<dd4hep::PlacedVolume> layerPhysVols;
@@ -701,6 +710,7 @@ static dd4hep::detail::Ref_t createECalBarrelInclined(dd4hep::Detector& aLcdd, d
 
     // create the volume, filled with active material, set as sensitive, and position it properly within active volume
     dd4hep::Volume layerVol("layer", layerShape, aLcdd.material(activeMaterial));
+    layerVol.setVisAttributes(aLcdd, "sensitive_bath");
     layerVol.setSensitiveDetector(aSensDet);
     layerPhysVols.push_back(activeVol.placeVolume(layerVol, dd4hep::Position(0, 0, layerOffset)));
     layerPhysVols.back().addPhysVolID("layer", iLayer);


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [ ] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [ ] the PR does not contain any additions or modifications that do not belong to it
- [ ] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Improve ALLEGRO_o1_v03 ECAL visual rendering

ENDRELEASENOTES

It would look like this with the JSROOT web based viewer:

![Screenshot 2025-06-27 at 4 24 17 PM](https://github.com/user-attachments/assets/c974334e-2c6c-418f-82fc-ca37dcce6f28)

![Screenshot 2025-06-27 at 4 24 08 PM](https://github.com/user-attachments/assets/fd6e4d81-41c5-4b47-bf7f-905e2a860ff2)


![Screenshot 2025-06-27 at 4 23 17 PM](https://github.com/user-attachments/assets/6816c238-ef1f-42cd-88c4-7e52d474c34f)
