### PR TITLE
correct dimension (rmax) of muon barrel. fix response type of muon ta…

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/DectDimensions.xml
@@ -158,7 +158,7 @@
     
     <!-- Muon tagger -->
     <constant name="MuonTagger_inner_radius" value="4550*mm"/>
-    <constant name="MuonTagger_outer_radius" value="4650*mm"/>
+    <constant name="MuonTagger_outer_radius" value="5000*mm"/>
     <constant name="MuonTagger_half_length" value="6000*mm"/>
    
     <constant name="MuonTaggerEndcap_inner_radius" value="1100*mm"/>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/MuonTaggerPhiTheta.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/MuonTaggerPhiTheta.xml
@@ -61,7 +61,7 @@
       <!-- added for Pandora -->
       <type_flags type="DetType_CALORIMETER + DetType_MUON + DetType_ENDCAP"/>
       <!-- end -->
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="BirksLawCalorimeterSD"/>
       <dimensions rmin="MuonTaggerEndcap_inner_radius" rmax="MuonTaggerEndcap_outer_radius"
                   dz="(MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" z_offset = "MuonTaggerEndcap_min_z + (MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
       <layers>

--- a/FCCee/ALLEGRO/compact/README.md
+++ b/FCCee/ALLEGRO/compact/README.md
@@ -17,4 +17,4 @@ ALLEGRO_o1_v03:
 - Added HCalEndcaps_ThreeParts_TileCal_v03.xml which uses HCalThreePartsEndcap_o1_v02_geo.cpp. Additionally, wrt v02 the readout was migrated to the theta-phi segmentation; unused readout *Readout_phi was removed; radial dimensions of layers were modified, so the outer radius of all three cylinders is the same.
 - Row-phi segmentation is added for HCalBarrel_TileCal_v03.xml and HCalEndcaps_ThreeParts_TileCal_v03.xml.
 - Birks constant value is set for Polystyrene scintillator used by HCal. This fixed the abnormal response to hadrons that was observed when migrated from k4SimGeant4 to DDSim.
-- For the muon tagger, switched from eta-phi to theta-phi segmentation.
+- For the muon tagger, switched from eta-phi to theta-phi segmentation. Outer R set to 5m as in initial conceptual design (to be replaced in the future by more realistic detector).


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [X] the code is sufficiently well documented (e.g. inline comments)
- [X] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [X] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [X] the PR does not contain any additions or modifications that do not belong to it
- [X] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [X] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Fix Rmax of muon tagger barrel and response type of muon tagger endcap for ALLEGRO
ENDRELEASENOTES

Fixes a crash when running the reconstruction with muons in endcap and trying to create reco hit<->mc particle links because the muon endcap hits do not have associated Contributions 
