### PR TITLE
Fix build failure when `K4GEO_USE_LCIO=OFF`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,13 @@ if(NOT K4GEO_USE_LCIO)
     TrackerBarrel_o1_v03_geo.cpp
     TrackerBarrel_o1_v04_geo.cpp
     TrackerBarrel_o1_v05_geo.cpp
+    TrackerBarrel_o1_v06_geo.cpp
     TrackerEndcap_o1_v05_geo.cpp
     TrackerEndcap_o2_v06_geo.cpp
     VertexBarrel_detailed_o1_v01_geo.cpp
     VertexEndcap_o1_v05_geo.cpp
     ZPlanarTracker_geo.cpp
+    ZSegmentedPlanarTracker_geo.cpp
     )
   foreach(lcio_source ${lcio_sources})
     list(FILTER sources EXCLUDE REGEX "${lcio_source}")


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix build failure when `K4GEO_USE_LCIO=OFF`

ENDRELEASENOTES

Fixing build failure because of the two source files requiring `UTIL/LCTrackerConf.h` that are still included even if `K4GEO_USE_LCIO=OFF`.