### PR TITLE
IDEA DriftChamber cellID fix for stereosign field

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o1_v03/DriftChamber_o1_v02.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/DriftChamber_o1_v02.xml
@@ -128,7 +128,7 @@
       <!--  superlayer: from 0 to 13                  -->
       <!--  layer: from 0 to 7 (within a superlayer)  -->
       <!--  nphi: max of nphi will be 816 (192+13*48) -->
-      <id>system:5,superlayer:5,layer:4,nphi:11,stereosign:-1</id>
+      <id>system:5,superlayer:5,layer:4,nphi:11,stereosign:-2</id>
     </readout>
   </readouts>
 


### PR DESCRIPTION
Hello, 
I have found a bug in the IDEA DriftChamber cellID bitfield, since for the `stereosign` field only one bit was allocated, but two are required to store the correct values (-1 and +1). Therefore, the field was not correctly filled until now.
This does not seem to have introduced any major bugs in the construction or digitisation because all of the relevant implementations rely on the [DCH_info](https://github.com/AIDASoft/DD4hep/blob/master/DDRec/include/DDRec/DCH_info.h) helper class, which includes [functions to calculate the sign of the stereo angle](https://github.com/AIDASoft/DD4hep/blob/master/DDRec/include/DDRec/DCH_info.h#L161C9-L169C10), which do not use the `cellID` at all.

However, anyone who uses the `cellID` to retrieve the `stereosign`  instead of the `DCH_info` class will get incorrect results.
The fix is to simply extend the bitfield to a width of 2.

BEGINRELEASENOTES
- Updated the `stereosign` bitfield in the IDEA DriftChamber to host two bits

ENDRELEASENOTES

