### PR TITLE
Installing mucoll compact files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ INSTALL(FILES ${hfiles}
 
 #--- install compact files------------------------------
 if(INSTALL_COMPACT_FILES)
-  INSTALL(DIRECTORY CaloTB CLIC FCalTB FCCee ILD fieldmaps SiD DESTINATION share/k4geo )
+  INSTALL(DIRECTORY CaloTB CLIC FCalTB FCCee ILD fieldmaps MuColl SiD DESTINATION share/k4geo )
 endif()
 
 # create k4geoConfig and friends


### PR DESCRIPTION
This PR adds the installation of the muon collider detector geometries in the share folder (which we forgot to do when we merged the geometries upstream) 

BEGINRELEASENOTES
- Muon collider compact files are installed in k4geo/share

ENDRELEASENOTES

