### PR TITLE
[CLD_o2_v08] set tracking_volume parallelworld to not be connected

### DIFF
--- a/FCCee/CLD/compact/CLD_o2_v08/CLD_o2_v08.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/CLD_o2_v08.xml
@@ -262,7 +262,7 @@
        else if the volume is part of the parallelworld:  connected="false"
        The volume is always connected to the top level!
     -->
-    <parallelworld_volume name="tracking_volume" anchor="/world" material="Air" connected="true"
+    <parallelworld_volume name="tracking_volume" anchor="/world" material="Air" connected="false"
         vis="VisibleBlue">
         <shape type="Polycone" material="Air">
             <!-- small-angle approximation for tan(theta) -->


### PR DESCRIPTION
BEGINRELEASENOTES
- fix: [CLD_o2_v08] set tracking_volume parallelworld to not be connected

ENDRELEASENOTES

Somehow, the copy of `CLD_o2_v07` that was used to start `CLD_o2_v08` was missing #453 

I noticed that without it, the whole region disappears from the `materialScan`

before this change
```
 +--------------------------------------------------------------------------------------------------------------------------------------------------
 + Material scan between: x_0 = (   0.00,   0.00,   0.00) [cm] and x_1 = ( 215.00,   0.00,   0.00) [cm] : 
 +--------------------------------------------------------------------------------------------------------------------------------------------------
 |       \   Material                  Atomic               Radiation   Interaction               Path   Integrated  Integrated    Material
 | Num.   \  Name               Number/Z   Mass/A  Density    Length       Length    Thickness   Length      X0        Lambda      Endpoint/Startpoint
 | Layer   \                             [g/mole]  [g/cm3]     [cm]        [cm]          [cm]      [cm]     [cm]        [cm]     (     cm,     cm,     cm)
 +--------------------------------------------------------------------------------------------------------------------------------------------------
 | (start) beam                        5    9.370   0.0000 2.59816e+15  3.31407e+15      0.000     0.00    0.000000    0.000000  (   0.00,   0.00,   0.00)
 |       1 beam -> Air                 7   14.784   0.0012     30528.8      71998.2      1.000     1.00    0.000000    0.000000  (   1.00,   0.00,   0.00)
 |       2 Air -> Air                  7   14.784   0.0012  30528.8462   71998.1725    213.500   214.50    0.006993    0.002965  ( 214.50,   0.00,   0.00)
 |   (end) Air                         7   14.784   0.0012  30528.8462   71998.1725      0.000     0.00    0.000000    0.000000  (   0.00,   0.00,   0.00)
 +--------------------------------------------------------------------------------------------------------------------------------------------------
 |         Average Material            7   14.784   0.0012  30671.4900   72334.5788    215.000   215.00    0.007010    0.002972  ( 215.00,   0.00,   0.00)
 +--------------------------------------------------------------------------------------------------------------------------------------------------
```
after
```
+--------------------------------------------------------------------------------------------------------------------------------------------------
 + Material scan between: x_0 = (   0.00,   0.00,   0.00) [cm] and x_1 = ( 215.00,   0.00,   0.00) [cm] : 
 +--------------------------------------------------------------------------------------------------------------------------------------------------
 |       \   Material                  Atomic               Radiation   Interaction               Path   Integrated  Integrated    Material
 | Num.   \  Name               Number/Z   Mass/A  Density    Length       Length    Thickness   Length      X0        Lambda      Endpoint/Startpoint
 | Layer   \                             [g/mole]  [g/cm3]     [cm]        [cm]          [cm]      [cm]     [cm]        [cm]     (     cm,     cm,     cm)
 +--------------------------------------------------------------------------------------------------------------------------------------------------
 | (start) beam                        5    9.370   0.0000 2.59816e+15  3.31407e+15      0.000     0.00    0.000000    0.000000  (   0.00,   0.00,   0.00)
 |       1 beam -> Air                 7   14.784   0.0012     30528.8      71998.2      1.000     1.00    0.000000    0.000000  (   1.00,   0.00,   0.00)
 |       2 Air -> Silicon             14   28.085   2.3300      9.3661      45.7531      0.300     1.30    0.000010    0.000004  (   1.30,   0.00,   0.00)
 |       3 Silicon -> Silicon         14   28.085   2.3300      9.3661      45.7531      0.023     1.32    0.002519    0.000518  (   1.32,   0.00,   0.00)
 |       4 Silicon -> Air              7   14.784   0.0012  30528.8462   71998.1725      0.005     1.33    0.003053    0.000627  (   1.33,   0.00,   0.00)
 |       5 Air -> Silicon             14   28.085   2.3300      9.3661      45.7531      0.100     1.43    0.003056    0.000628  (   1.43,   0.00,   0.00)
 |       6 Silicon -> Silicon         14   28.085   2.3300      9.3661      45.7531      0.005     1.43    0.003590    0.000738  (   1.43,   0.00,   0.00)
 |       7 Silicon -> Air              7   14.784   0.0012  30528.8462   71998.1725      0.023     1.46    0.006099    0.001251  (   1.46,   0.00,   0.00)
 |       8 Air -> Silicon             14   28.085   2.3300      9.3661      45.7531      2.043     3.50    0.006166    0.001280  (   3.50,   0.00,   0.00)
 |       9 Silicon -> Silicon         14   28.085   2.3300      9.3661      45.7531      0.024     3.52    0.008675    0.001793  (   3.52,   0.00,   0.00)
 |      10 Silicon -> Air              7   14.784   0.0012  30528.8462   71998.1725      0.005     3.53    0.009209    0.001903  (   3.53,   0.00,   0.00)
 |      11 Air -> Silicon             14   28.085   2.3300      9.3661      45.7531      0.100     3.63    0.009212    0.001904  (   3.63,   0.00,   0.00)
 |      12 Silicon -> Silicon         14   28.085   2.3300      9.3661      45.7531      0.005     3.63    0.009746    0.002013  (   3.63,   0.00,   0.00)
 |      13 Silicon -> Air              7   14.784   0.0012  30528.8462   71998.1725      0.024     3.66    0.012255    0.002527  (   3.66,   0.00,   0.00)
 |      14 Air -> Silicon             14   28.085   2.3300      9.3661      45.7531      2.043     5.70    0.012322    0.002555  (   5.70,   0.00,   0.00)
 |      15 Silicon -> Silicon         14   28.085   2.3300      9.3661      45.7531      0.024     5.72    0.014831    0.003069  (   5.72,   0.00,   0.00)
 |      16 Silicon -> Air              7   14.784   0.0012  30528.8462   71998.1725      0.005     5.73    0.015365    0.003178  (   5.73,   0.00,   0.00)
 |      17 Air -> Silicon             14   28.085   2.3300      9.3661      45.7531      0.100     5.83    0.015368    0.003180  (   5.83,   0.00,   0.00)
 |      18 Silicon -> Silicon         14   28.085   2.3300      9.3661      45.7531      0.005     5.83    0.015902    0.003289  (   5.83,   0.00,   0.00)
 |      19 Silicon -> Air              7   14.784   0.0012  30528.8462   71998.1725      0.023     5.86    0.018411    0.003803  (   5.86,   0.00,   0.00)
 |      20 Air -> Air                  7   14.784   0.0012  30528.8462   71998.1725      5.243    11.10    0.018583    0.003875  (  11.10,   0.00,   0.00)
 |      21 Air -> CarbonFiber          6   11.968   1.5000     28.0746      51.2277      0.100    11.20    0.018586    0.003877  (  11.20,   0.00,   0.00)
----8<----
```
