### PR TITLE
Remove a default destructor that is not needed in DRparamBase_k4geo.h

### DIFF
--- a/detectorSegmentations/include/detectorSegmentations/DRparamBase_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/DRparamBase_k4geo.h
@@ -100,7 +100,6 @@ namespace DDSegmentation {
     struct shortFibers {
     public:
       shortFibers(const double towerH) : fTowerH(towerH) {}
-      ~shortFibers() = default;
 
       void addShortFibers(const int row, const int col, const double len) {
         m_fiberLengths_.insert(std::make_pair(std::make_pair(row, col), len));


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove a default destructor that is not needed in `DRparamBase_k4geo.h`

ENDRELEASENOTES

Can be seen with Clang:

``` c
/k4geo/detectorSegmentations/include/detectorSegmentations/DRparamBase_k4geo.h:103:7: warning: definition of implicit copy constructor for 'shortFibers' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-with-dtor]
  103 |       ~shortFibers() = default;
```

In this case it doesn't need to be defined, `default` is the default.


Tagging @SanghyunKo