### PR TITLE
Properly override neighbours() virtual methods.

### DIFF
--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
@@ -74,6 +74,11 @@ namespace DDSegmentation {
      */
     void defineCellIndexes(const unsigned int layer) const;
 
+    /**  Find neighbours of the cell.
+     *   Implement the signature from the Segmentation base class.
+     */
+    virtual void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const override;
+
     /**  Determine the azimuthal angle of HCal cell based on the cellID.
      *   @param[in] aCellId ID of a cell.
      *   return Phi.

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
@@ -53,6 +53,11 @@ namespace DDSegmentation {
      */
     std::vector<uint64_t> neighbours(const CellID& cID) const;
 
+    /**  Find neighbours of the cell.
+     *   Implement the signature from the Segmentation base class.
+     */
+    virtual void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const override;
+
     /**  Calculate layer radii and edges in z-axis.
      *    Following member variables are calculated:
      *      m_radii
@@ -73,11 +78,6 @@ namespace DDSegmentation {
      *   @param[in] layer index
      */
     void defineCellIndexes(const unsigned int layer) const;
-
-    /**  Find neighbours of the cell.
-     *   Implement the signature from the Segmentation base class.
-     */
-    virtual void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const override;
 
     /**  Determine the azimuthal angle of HCal cell based on the cellID.
      *   @param[in] aCellId ID of a cell.

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
@@ -52,6 +52,11 @@ namespace DDSegmentation {
      */
     std::vector<uint64_t> neighbours(const CellID& cID, bool aDiagonal) const;
 
+    /**  Find neighbours of the cell.
+     *   Implement the signature from the Segmentation base class.
+     */
+    virtual void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const override;
+
     /**  Calculate layer radii and edges in z-axis, then define cell edges in each layer using defineCellEdges().
      *    Following member variables are calculated:
      *      m_radii
@@ -69,11 +74,6 @@ namespace DDSegmentation {
      *   @param[in] layer index
      */
     void defineCellEdges(const unsigned int layer) const;
-
-    /**  Find neighbours of the cell.
-     *   Implement the signature from the Segmentation base class.
-     */
-    virtual void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const override;
 
     /**  Determine the azimuthal angle of HCal cell based on the cellID.
      *   @param[in] aCellId ID of a cell.

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
@@ -70,6 +70,11 @@ namespace DDSegmentation {
      */
     void defineCellEdges(const unsigned int layer) const;
 
+    /**  Find neighbours of the cell.
+     *   Implement the signature from the Segmentation base class.
+     */
+    virtual void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const override;
+
     /**  Determine the azimuthal angle of HCal cell based on the cellID.
      *   @param[in] aCellId ID of a cell.
      *   return Phi.

--- a/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
@@ -588,6 +588,13 @@ namespace DDSegmentation {
     return cellNeighbours;
   }
 
+  // Implement the signature from the Segmentations base class.
+  void FCCSWHCalPhiRow_k4geo::neighbours(const CellID& cellID, std::set<CellID>& neighbours) const {
+    std::vector<uint64_t> neigh = this->neighbours(cellID);
+    neighbours.clear();
+    neighbours.insert(neigh.begin(), neigh.end());
+  }
+
   /// Determine minimum and maximum polar angle of the cell
   std::array<double, 2> FCCSWHCalPhiRow_k4geo::cellTheta(const CellID& cID) const {
     std::array<double, 2> cTheta = {M_PI, M_PI};

--- a/detectorSegmentations/src/FCCSWHCalPhiTheta_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWHCalPhiTheta_k4geo.cpp
@@ -733,6 +733,13 @@ namespace DDSegmentation {
     return cellNeighbours;
   }
 
+  // Implement the signature from the Segmentations base class.
+  void FCCSWHCalPhiTheta_k4geo::neighbours(const CellID& cellID, std::set<CellID>& neighbours) const {
+    std::vector<uint64_t> neigh = this->neighbours(cellID, false);
+    neighbours.clear();
+    neighbours.insert(neigh.begin(), neigh.end());
+  }
+
   /// Determine minimum and maximum polar angle of the cell
   std::array<double, 2> FCCSWHCalPhiTheta_k4geo::cellTheta(const CellID& cID) const {
     std::array<double, 2> cTheta = {M_PI, M_PI};


### PR DESCRIPTION
Some segmentation classes defined a neighbours() method with a signature different from that defined in the Segmentation base class. In those cases, also override the base class signature in terms of what the derived class provides.

BEGINRELEASENOTES
- Make sure segmentation classes properly override the virtual neighbours() method for the FCCSWHcalPhi segmentations.

ENDRELEASENOTES

