### PR TITLE
Fix overlaps in HCalTileBarrel

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/HCalBarrel_TileCal_v03.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/HCalBarrel_TileCal_v03.xml
@@ -31,6 +31,9 @@
     <constant name="BarHCal_layer_size1" value="50*mm" />
     <constant name="BarHCal_layer_size2" value="100*mm" />
     <constant name="BarHCal_layer_size3" value="200*mm" />
+    <!-- division into rows -->
+    <constant name="BarHCal_sequence_thickness" value="2*BarHCal_master_plate_thickness + BarHCal_spacer_plate_thickness + BarHCal_scintillator_thickness + 2*BarHCal_air_space_thickness" />
+    <constant name="BarHCal_numSequencesZ" value="floor(2*(BarHCal_dz-BarHCal_end_plate_thickness-BarHCal_plate_space)/BarHCal_sequence_thickness)" />
   </define>
 
   <display>
@@ -67,7 +70,7 @@
       <segmentation type="FCCSWHCalPhiTheta_k4geo" 
          detLayout="0"
          offset_z="0"
-         width_z="BarHCal_dz*2"
+         width_z="BarHCal_numSequencesZ*BarHCal_sequence_thickness"
          offset_r="BarHCal_rmin+BarHCal_face_plate_thickness+BarHCal_plate_space"
          numLayers="4 6 3"
          dRlayer="BarHCal_layer_size1 BarHCal_layer_size2 BarHCal_layer_size3"
@@ -96,7 +99,7 @@
       <segmentation type="FCCSWHCalPhiRow_k4geo" 
          detLayout="0"
          offset_z="0"
-         width_z="2795.5*2*mm"
+         width_z="BarHCal_numSequencesZ*BarHCal_sequence_thickness"
          offset_r="BarHCal_rmin+BarHCal_face_plate_thickness+BarHCal_plate_space"
          numLayers="4 6 3"
          dRlayer="BarHCal_layer_size1 BarHCal_layer_size2 BarHCal_layer_size3"
@@ -140,7 +143,7 @@
 
       <sequence_a id="3" name="sequence_1" material="Air" vis="hcal_barrel_seq1_vis">
         <dimensions
-          dz="2*BarHCal_master_plate_thickness + BarHCal_spacer_plate_thickness + BarHCal_scintillator_thickness + 2*BarHCal_air_space_thickness"
+          dz="BarHCal_sequence_thickness"
           phiBins="BarHCal_n_phi_modules"
           x="BarHCAL_module_spacing_phi"
         />
@@ -159,7 +162,7 @@
       </sequence_a>
       <sequence_b id="4" name="sequence_2" material="Air" vis="hcal_barrel_seq2_vis">
         <dimensions
-          dz="2*BarHCal_master_plate_thickness + BarHCal_spacer_plate_thickness + BarHCal_scintillator_thickness + 2*BarHCal_air_space_thickness"
+          dz="BarHCal_sequence_thickness"
           phiBins="BarHCal_n_phi_modules"
           x="BarHCAL_module_spacing_phi"
         />

--- a/detector/calorimeter/HCalTileBarrel_o1_v02_geo.cpp
+++ b/detector/calorimeter/HCalTileBarrel_o1_v02_geo.cpp
@@ -203,7 +203,7 @@ static dd4hep::Ref_t createHCal(dd4hep::Detector& lcdd, xml_det_t xmlDet, dd4hep
     std::vector<dd4hep::PlacedVolume> sq_vector;
 
     for (uint numSeq = 0; numSeq < numSequencesZ; numSeq++) {
-      double zOffset = -dzDetector + (2 * numSeq + 1) * (dzSequence * 0.5);
+      double zOffset = -dzDetector + numSeq * dzSequence + dzSequence / 2 + dZEndPlate + space;
       dd4hep::Position tileSequencePosition(0, 0, zOffset);
       dd4hep::PlacedVolume placedTileSequenceVolume = layerVolume.placeVolume(tileSequenceVolume, tileSequencePosition);
       placedTileSequenceVolume.addPhysVolID("row", numSeq);


### PR DESCRIPTION
HCalTileBarrel has overlaps between the volumes representing the first (minimum z) row and the end plate.

Specifically, the geometry places the center of each row (also called a sequence, consisting of absorber+scintillator+spacing) by

```
      double zOffset = -dzDetector + (2 * numSeq + 1) * (dzSequence * 0.5);
```

where numSeq is the index of the row/sequence and dzSequence is the z-width of a row/sequence.  This can be rewritten probably more clearly as

```
      double zOffset = -dzDetector + numSeq*dzSequence + dzSequence/2;
```

dzDetector is calculated as

```
  double dzDetector = (numSequencesZ * dzSequence) / 2 + dZEndPlate + space;
```

so this is the total half-length of the barrel, including the sensitive area and the end plate.  But the placement above starts putting the rows right at -dzDetector ... overlapping the end plate.  Further, since (dZEndPlate+space) is not divisible by dzSequence, then the row edges do not line up with z=0, and they are asymmetric with respect to z inversion.

We can fix this by simply changing the offset calculation to

```
      double zOffset = -dzDetector + numSeq*dzSequence + dzSequence/2 + dZEndPlate + space;
```

This gets rid of the overlaps and makes the layout symmetric.

To be consistent, we also need to change the width_z parameter for the FCCSWHCalPhiRow_k4geo segmentation.  This was set to a hardcoded value of 2795.5*2*mm, which is just twice dzDetector.  So we should also subtract (twice) the end plate width + space.  Before this, the segmentation cell edges were also offset --- not lining up with 0 and asymmetric. With this change, they are symmetric.

This will of course change simulation results for the tile hcal barrel.

BEGINRELEASENOTES
- Fix overlaps in the tile hcal barrel.
ENDRELEASENOTES

