### PR TITLE
For tile HCAL barrel, take number of segments from the XML file.

### DIFF
--- a/detector/calorimeter/HCalTileBarrel_o1_v02_geo.cpp
+++ b/detector/calorimeter/HCalTileBarrel_o1_v02_geo.cpp
@@ -59,8 +59,8 @@ static dd4hep::Ref_t createHCal(dd4hep::Detector& lcdd, xml_det_t xmlDet, dd4hep
   double dzSequence = dimensionsB.dz();
   dd4hep::printout(dd4hep::DEBUG, "HCalTileBarrel_o1_v02", "sequence thickness %.2f", dzSequence);
 
-  // calculate the number of sequences fitting in Z
-  unsigned int numSequencesZ = static_cast<unsigned>((2 * xDimensions.dz() - 2 * dZEndPlate - 2 * space) / dzSequence);
+  // number of sequences fitting in Z
+  unsigned int numSequencesZ = lcdd.constant<unsigned>("BarHCal_numSequencesZ");
 
   // get all 'layer' children of the 'layers' tag
   std::vector<xml_comp_t> Layers;


### PR DESCRIPTION
For HCalTileBarrel_o1_v02_geo, the number of segments along Z is already calculated in the XML file.  Take it from there rather then duplicating in the C++ code.

BEGINRELEASENOTES
- Small cleanup of HCalTileBarrel_01_v02_geo: take the number of segments from the XML file rather than recalculating in C++.
ENDRELEASENOTES

