### PR TITLE
Some segmentation cleanup.

### DIFF
--- a/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWEndcapTurbine_k4geo.h
@@ -27,7 +27,7 @@ namespace DDSegmentation {
     virtual ~FCCSWEndcapTurbine_k4geo() = default;
 
     /**  Determine the global position based on the cell ID. **/
-    virtual Vector3D position(const CellID& aCellID) const;
+    virtual Vector3D position(const CellID& aCellID) const override;
     /**  Determine the cell ID based on the position.
      *   @param[in] aLocalPosition (not used).
      *   @param[in] aGlobalPosition position in the global coordinates.
@@ -35,13 +35,13 @@ namespace DDSegmentation {
      *   return Cell ID.
      */
     virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                          const VolumeID& aVolumeID) const;
+                          const VolumeID& aVolumeID) const override;
 
     /**  Determine the transverse distance from the beamline (rho) based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return rho.
      */
-    double rho(const CellID& aCellID) const;
+    double rho(const CellID aCellID) const;
     /** Get the grid size in rho for a given wheel
      * return grid size in rho
      */
@@ -71,7 +71,7 @@ namespace DDSegmentation {
      *   @param[in] aCellId ID of a cell.
      *   return Phi.
      */
-    double phi(const CellID& aCellID) const;
+    double phi(const CellID aCellID) const;
 
     /**  Get the coordinate offset in azimuthal angle.
      *   return The offset in phi.
@@ -114,12 +114,12 @@ namespace DDSegmentation {
      *   @param[in] aCellId ID of a cell.
      *   return x.
      */
-    double x(const CellID& aCellID) const;
+    double x(const CellID aCellID) const;
     /**  Determine the z coordinate based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return z.
      */
-    double z(const CellID& aCellID) const;
+    double z(const CellID aCellID) const;
     /** Get the grid size in z for a given wheel
      * return grid size in z
      */
@@ -180,7 +180,7 @@ namespace DDSegmentation {
      */
     unsigned expLayer(unsigned iWheel, unsigned iRho, unsigned iZ) const;
 
-  protected:
+  private:
     /// turbine blade angle in each wheel
     std::vector<double> m_bladeAngle;
     /// number of unit cells in each wheel
@@ -224,6 +224,19 @@ namespace DDSegmentation {
     std::string m_zID;
     std::string m_sideID;
     std::string m_layerID;
+
+    /// the field index used for rho
+    int m_rhoIndex = -1;
+    /// the field index used for wheel
+    int m_wheelIndex = -1;
+    /// the field index used for module
+    int m_moduleIndex = -1;
+    /// the field index used for z
+    int m_zIndex = -1;
+    /// the field index used for side
+    int m_sideIndex = -1;
+    /// the field index used for layer
+    int m_layerIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWGridModuleThetaMergedHandle_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWGridModuleThetaMergedHandle_k4geo.h
@@ -63,7 +63,7 @@ public:
   bool operator==(const FCCSWGridModuleThetaMerged_k4geo& seg) const { return m_element == seg.m_element; }
 
   /// determine the position based on the cell ID
-  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+  inline Position position(const CellID id) const { return Position(access()->implementation->position(id)); }
 
   /// determine the cell ID based on the position
   inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWGridModuleThetaMerged_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWGridModuleThetaMerged_k4geo.h
@@ -36,7 +36,7 @@ namespace DDSegmentation {
      *   The position is in the local coordinate system of the associated
      *   dd4hep volume.
      */
-    virtual Vector3D position(const CellID& aCellID) const;
+    virtual Vector3D position(const CellID& aCellID) const override;
     /**  Determine the cell ID based on the position.
      *   @param[in] aLocalPosition (not used).
      *   @param[in] aGlobalPosition
@@ -44,22 +44,22 @@ namespace DDSegmentation {
      *   return Cell ID.
      */
     virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                          const VolumeID& aVolumeID) const;
+                          const VolumeID& aVolumeID) const override;
     /**  Determine the azimuthal angle (relative to the G4 volume) based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return Phi.
      */
-    double phi(const CellID& aCellID) const;
+    double phi(const CellID aCellID) const;
     /**  Determine the polar angle (relative to the G4 volume) based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return Theta.
      */
-    double theta(const CellID& aCellID) const;
+    double theta(const CellID aCellID) const;
     /**  Determine the radius based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return Radius.
      */
-    // double radius(const CellID& aCellID) const;
+    // double radius(const CellID aCellID) const;
     /**  Get the number of merged cells in theta for given layer
      *   @param[in] layer
      *   return The number of merged cells in theta
@@ -98,22 +98,22 @@ namespace DDSegmentation {
     inline const std::string& fieldNameModule() const { return m_moduleID; }
 
     /// Extract the layer index fom a cell ID.
-    int layer(const CellID& aCellID) const;
+    int layer(const CellID aCellID) const;
 
     /// Determine the volume ID from the full cell ID by removing all local fields
-    virtual VolumeID volumeID(const CellID& cellID) const;
+    virtual VolumeID volumeID(const CellID& cellID) const override;
 
     /// Return true if this segmentation can have cells that span multiple
     /// volumes.  That is, points from multiple distinct volumes may
     /// be assigned to the same cell.
-    virtual bool cellsSpanVolumes() const { return true; }
+    virtual bool cellsSpanVolumes() const override { return true; }
 
     /** Returns a std::vector<double> of the cellDimensions of the given cell ID
      *  in natural order of dimensions (nModules, dTheta)
      *  @param[in] cellID
      *  return a std::vector of size 2 with the cellDimensions of the given cell ID(modules, theta)
      */
-    inline std::vector<double> cellDimensions(const CellID& id) const {
+    virtual std::vector<double> cellDimensions(const CellID& id) const override {
       const int aLayer = layer(id);
       return {(double)mergedModules(aLayer), gridSizeTheta() * mergedThetaCells(aLayer)};
     }
@@ -150,6 +150,15 @@ namespace DDSegmentation {
     // been created yet.  Instead, build it lazily the first time it's needed.
     // Since that's in a const method, make it thread-safe.
     mutable std::atomic<const std::vector<LayerInfo>*> m_layerInfo = nullptr;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for layer
+    int m_layerIndex = -1;
+    /// the field index used for theta
+    int m_thetaIndex = -1;
+    /// the field index used for module
+    int m_moduleIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWGridPhiEtaHandle_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWGridPhiEtaHandle_k4geo.h
@@ -63,10 +63,10 @@ public:
   /// Equality operator
   bool operator==(const FCCSWGridPhiEta_k4geo& seg) const { return m_element == seg.m_element; }
   /// determine the position based on the cell ID
-  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+  inline Position position(const CellID id) const { return Position(access()->implementation->position(id)); }
 
   /// determine the cell ID based on the position
-  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID volID) const {
     return access()->implementation->cellID(local, global, volID);
   }
 
@@ -109,7 +109,7 @@ public:
       -# size in phi
       -# size in eta
   */
-  inline std::vector<double> cellDimensions(const CellID& /*id*/) const {
+  inline std::vector<double> cellDimensions(const CellID /*id*/) const {
     return {access()->implementation->gridSizePhi(), access()->implementation->gridSizeEta()};
   }
 };

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWGridPhiEta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWGridPhiEta_k4geo.h
@@ -30,7 +30,7 @@ namespace DDSegmentation {
      *   @param[in] aCellId ID of a cell.
      *   return Position (radius = 1).
      */
-    virtual Vector3D position(const CellID& aCellID) const;
+    virtual Vector3D position(const CellID& aCellID) const override;
     /**  Determine the cell ID based on the position.
      *   @param[in] aLocalPosition (not used).
      *   @param[in] aGlobalPosition position in the global coordinates.
@@ -38,12 +38,12 @@ namespace DDSegmentation {
      *   return Cell ID.
      */
     virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                          const VolumeID& aVolumeID) const;
+                          const VolumeID& aVolumeID) const override;
     /**  Determine the azimuthal angle based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return Phi.
      */
-    double phi(const CellID& aCellID) const;
+    double phi(const CellID aCellID) const;
     /**  Get the grid size in phi.
      *   return Grid size in phi.
      */
@@ -73,15 +73,20 @@ namespace DDSegmentation {
      */
     inline void setFieldNamePhi(const std::string& fieldName) { m_phiID = fieldName; }
 
-  protected:
-    /// determine the azimuthal angle phi based on the current cell ID
-    double phi() const;
+  private:
     /// the number of bins in phi
     int m_phiBins;
     /// the coordinate offset in phi
     double m_offsetPhi;
     /// the field name used for phi
     std::string m_phiID;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for eta
+    int m_etaIndex = -1;
+    /// the field index used for phi
+    int m_phiIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWGridPhiTheta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWGridPhiTheta_k4geo.h
@@ -29,7 +29,7 @@ namespace DDSegmentation {
      *   @param[in] aCellId ID of a cell.
      *   return Position (radius = 1).
      */
-    virtual Vector3D position(const CellID& aCellID) const;
+    virtual Vector3D position(const CellID& aCellID) const override;
     /**  Determine the cell ID based on the position.
      *   @param[in] aLocalPosition (not used).
      *   @param[in] aGlobalPosition position in the global coordinates.
@@ -37,12 +37,12 @@ namespace DDSegmentation {
      *   return Cell ID.
      */
     virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                          const VolumeID& aVolumeID) const;
+                          const VolumeID& aVolumeID) const override;
     /**  Determine the azimuthal angle based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return Phi.
      */
-    double phi(const CellID& aCellID) const;
+    double phi(const CellID aCellID) const;
     /**  Get the grid size in phi.
      *   return Grid size in phi.
      */
@@ -76,9 +76,11 @@ namespace DDSegmentation {
      *  @param[in] cellID
      *  return a std::vector of size 2 with the cellDimensions of the given cell ID (phi, theta)
      */
-    inline std::vector<double> cellDimensions(const CellID& /* id */) const { return {gridSizePhi(), gridSizeTheta()}; }
+    virtual std::vector<double> cellDimensions(const CellID& /* id */) const override {
+      return {gridSizePhi(), gridSizeTheta()};
+    }
 
-  protected:
+  private:
     /// determine the azimuthal angle phi based on the current cell ID
     double phi() const;
     /// the number of bins in phi
@@ -87,6 +89,13 @@ namespace DDSegmentation {
     double m_offsetPhi;
     /// the field name used for phi
     std::string m_phiID;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for theta
+    int m_thetaIndex = -1;
+    /// the field index used for phi
+    int m_phiIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRowHandle_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRowHandle_k4geo.h
@@ -61,10 +61,10 @@ public:
   bool operator==(const FCCSWHCalPhiRow_k4geo& seg) const { return m_element == seg.m_element; }
 
   /// determine the position based on the cell ID
-  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+  inline Position position(const CellID id) const { return Position(access()->implementation->position(id)); }
 
   /// determine the cell ID based on the position
-  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID volID) const {
     return access()->implementation->cellID(local, global, volID);
   }
 

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiRow_k4geo.h
@@ -52,7 +52,7 @@ namespace DDSegmentation {
      *   @param[in] cID ID of a cell.
      *   return vector of neighbour cellIDs.
      */
-    std::vector<uint64_t> neighbours(const CellID& cID) const;
+    std::vector<uint64_t> neighbours(const CellID cID) const;
 
     /**  Find neighbours of the cell.
      *   Implement the signature from the Segmentation base class.
@@ -84,7 +84,7 @@ namespace DDSegmentation {
      *   @param[in] aCellID ID of a cell.
      *   return Phi.
      */
-    double phi(const CellID& aCellID) const;
+    double phi(const CellID aCellID) const;
 
     /**  Get the grid size in phi.
      *   return Grid size in phi.
@@ -104,13 +104,13 @@ namespace DDSegmentation {
     /**  Get the grid size in row for each layer.
      *   return Grid size in row.
      */
-    inline std::vector<int> gridSizeRow() const { return m_gridSizeRow; }
+    inline const std::vector<int>& gridSizeRow() const { return m_gridSizeRow; }
 
     /**  Determine the polar angle of HCal cell center based on the cellID.
      *   @param[in] aCellID ID of a cell.
      *   return Theta.
      */
-    inline double theta(const CellID& aCellID) const {
+    inline double theta(const CellID aCellID) const {
       return dd4hep::DDSegmentation::Util::thetaFromXYZ(position(aCellID));
     }
 
@@ -118,7 +118,7 @@ namespace DDSegmentation {
      *   @param[in] cID ID of a cell.
      *   return Theta.
      */
-    std::array<double, 2> cellTheta(const CellID& cID) const;
+    std::array<double, 2> cellTheta(const CellID cID) const;
 
     /**  Get the vector of cell indexes in a given layer.
      */
@@ -146,32 +146,32 @@ namespace DDSegmentation {
      *   For the Barrel, the vector size is 1, while for the Endcap - number of section.
      *   return The offset in z.
      */
-    inline std::vector<double> offsetZ() const { return m_offsetZ; }
+    inline const std::vector<double>& offsetZ() const { return m_offsetZ; }
 
     /**  Get the z length of the layer.
      *   return the z length.
      */
-    inline std::vector<double> widthZ() const { return m_widthZ; }
+    inline const std::vector<double>& widthZ() const { return m_widthZ; }
 
     /**  Get the coordinate offset in radius.
      *   Offset is the inner radius of the first layer in the Barrel or in each section of the Endcap.
      *   For the Barrel, the vector size is 1, while for the Endcap - number of sections.
      *   return the offset in radius.
      */
-    inline std::vector<double> offsetR() const { return m_offsetR; }
+    inline const std::vector<double>& offsetR() const { return m_offsetR; }
 
     /**  Get the number of layers for each different thickness retrieved with dRlayer().
      *   For the Barrel, the vector size equals to the number of different thicknesses used to form the layers.
      *   For the Endcap, the vector size equals to the number of sections in the Endcap times the number of different
      * thicknesses used to form the layers. return the number of layers.
      */
-    inline std::vector<int> numLayers() const { return m_numLayers; }
+    inline const std::vector<int>& numLayers() const { return m_numLayers; }
 
     /**  Get the dR (thickness) of layers.
      *   The size of the vector equals to the number of different thicknesses used to form the layers.
      *   return the dR.
      */
-    inline std::vector<double> dRlayer() const { return m_dRlayer; }
+    inline const std::vector<double>& dRlayer() const { return m_dRlayer; }
 
     /**  Get the field name for azimuthal angle.
      *   return The field name for phi.
@@ -192,7 +192,7 @@ namespace DDSegmentation {
      *   @param[in] aCellID the cell ID
      *   return The layer number
      */
-    inline int layer(const CellID& aCellID) const { return _decoder->get(aCellID, fieldNameLayer()); }
+    inline int layer(const CellID aCellID) const { return _decoder->get(aCellID, fieldNameLayer()); }
 
     /**  Set the number of bins in azimuthal angle.
      *   @param[in] bins Number of bins in phi.
@@ -254,12 +254,12 @@ namespace DDSegmentation {
      *  @param[in] id
      *  return a std::vector of size 2 with the cellDimensions of the given cell ID (phi, z)
      */
-    inline std::vector<double> cellDimensions(const CellID& id) const override {
+    virtual std::vector<double> cellDimensions(const CellID& id) const override {
       const int aLayer = layer(id);
       return {gridSizePhi(), m_gridSizeRow[aLayer] * m_dz_row};
     }
 
-  protected:
+  private:
     /// the number of bins in phi
     int m_phiBins;
     /// the coordinate offset in phi
@@ -296,6 +296,17 @@ namespace DDSegmentation {
     mutable std::vector<std::vector<int>> m_cellIndexes;
     /// z-min and z-max of each cell in each layer
     mutable std::vector<std::unordered_map<int, std::pair<double, double>>> m_cellEdges;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for layer
+    int m_layerIndex = -1;
+    /// the field index used for row
+    int m_rowIndex = -1;
+    /// the field index used for type
+    int m_typeIndex = -1;
+    /// the field index used for phi
+    int m_phiIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiThetaHandle_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiThetaHandle_k4geo.h
@@ -61,10 +61,10 @@ public:
   bool operator==(const FCCSWHCalPhiTheta_k4geo& seg) const { return m_element == seg.m_element; }
 
   /// determine the position based on the cell ID
-  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+  inline Position position(const CellID id) const { return Position(access()->implementation->position(id)); }
 
   /// determine the cell ID based on the position
-  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID volID) const {
     return access()->implementation->cellID(local, global, volID);
   }
 
@@ -128,7 +128,7 @@ public:
       -# size in phi
       -# size in theta
   */
-  inline std::vector<double> cellDimensions(const CellID& /*id*/) const {
+  inline std::vector<double> cellDimensions(const CellID /*id*/) const {
     return {access()->implementation->gridSizePhi(), access()->implementation->gridSizeTheta()};
   }
 };

--- a/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h
@@ -52,7 +52,7 @@ namespace DDSegmentation {
      *   @param[in] aDiagonal if true, will include neighbours from diagonal positions in the next and previous layers.
      *   return vector of neighbour cellIDs.
      */
-    std::vector<uint64_t> neighbours(const CellID& cID, bool aDiagonal) const;
+    std::vector<uint64_t> neighbours(const CellID cID, bool aDiagonal) const;
 
     /**  Find neighbours of the cell.
      *   Implement the signature from the Segmentation base class.
@@ -81,7 +81,7 @@ namespace DDSegmentation {
      *   @param[in] aCellID ID of a cell.
      *   return Phi.
      */
-    double phi(const CellID& aCellID) const;
+    double phi(const CellID aCellID) const;
 
     /**  Get the grid size in phi.
      *   return Grid size in phi.
@@ -114,32 +114,32 @@ namespace DDSegmentation {
      *   For the Barrel, the vector size is 1, while for the Endcap - number of section.
      *   return The offset in z.
      */
-    inline std::vector<double> offsetZ() const { return m_offsetZ; }
+    inline const std::vector<double>& offsetZ() const { return m_offsetZ; }
 
     /**  Get the z length of the layer.
      *   return the z length.
      */
-    inline std::vector<double> widthZ() const { return m_widthZ; }
+    inline const std::vector<double>& widthZ() const { return m_widthZ; }
 
     /**  Get the coordinate offset in radius.
      *   Offset is the inner radius of the first layer in the Barrel or in each section of the Endcap.
      *   For the Barrel, the vector size is 1, while for the Endcap - number of sections.
      *   return the offset in radius.
      */
-    inline std::vector<double> offsetR() const { return m_offsetR; }
+    inline const std::vector<double>& offsetR() const { return m_offsetR; }
 
     /**  Get the number of layers for each different thickness retrieved with dRlayer().
      *   For the Barrel, the vector size equals to the number of different thicknesses used to form the layers.
      *   For the Endcap, the vector size equals to the number of sections in the Endcap times the number of different
      * thicknesses used to form the layers. return the number of layers.
      */
-    inline std::vector<int> numLayers() const { return m_numLayers; }
+    inline const std::vector<int>& numLayers() const { return m_numLayers; }
 
     /**  Get the dR (thickness) of layers.
      *   The size of the vector equals to the number of different thicknesses used to form the layers.
      *   return the dR.
      */
-    inline std::vector<double> dRlayer() const { return m_dRlayer; }
+    inline const std::vector<double>& dRlayer() const { return m_dRlayer; }
 
     /**  Get the field name for azimuthal angle.
      *   return The field name for phi.
@@ -155,7 +155,7 @@ namespace DDSegmentation {
      *   @param[in] cID ID of a cell.
      *   return Theta.
      */
-    std::array<double, 2> cellTheta(const CellID& cID) const;
+    std::array<double, 2> cellTheta(const CellID cID) const;
 
     /**  Get the min and max layer indexes of each HCal part.
      * For Endcap, returns the three elements vector, while for Barrel - single element vector.
@@ -212,11 +212,11 @@ namespace DDSegmentation {
      *  @param[in] cellID
      *  return a std::vector of size 2 with the cellDimensions of the given cell ID (phi, theta)
      */
-    inline std::vector<double> cellDimensions(const CellID& /* id */) const override {
+    virtual std::vector<double> cellDimensions(const CellID& /* id */) const override {
       return {gridSizePhi(), gridSizeTheta()};
     }
 
-  protected:
+  private:
     /// determine the azimuthal angle phi based on the current cell ID
     double phi() const;
     /// the number of bins in phi
@@ -249,6 +249,19 @@ namespace DDSegmentation {
     mutable std::vector<std::vector<int>> m_thetaBins;
     /// z-min and z-max of each cell (theta bin) in each layer
     mutable std::vector<std::unordered_map<int, std::pair<double, double>>> m_cellEdges;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for layer
+    int m_layerIndex = -1;
+    /// the field index used for row
+    int m_rowIndex = -1;
+    /// the field index used for type
+    int m_typeIndex = -1;
+    /// the field index used for theta
+    int m_thetaIndex = -1;
+    /// the field index used for phi
+    int m_phiIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/GridDRcalo_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridDRcalo_k4geo.h
@@ -20,7 +20,7 @@ namespace DDSegmentation {
     // Determine the global (local) position based on the cell ID.
     // position of the front end of the fiber
     virtual Vector3D position(const CellID& aCellID) const override;
-    Vector3D localPosition(const CellID& aCellID) const;
+    Vector3D localPosition(const CellID aCellID) const;
     Vector3D localPosition(int numx, int numy, int x_, int y_) const;
 
     // position of the rear end (readout location) of the fiber
@@ -32,91 +32,110 @@ namespace DDSegmentation {
     VolumeID setVolumeID(int systemId, int numEta, int numPhi) const;
     CellID setCellID(bool isRHS, int systemId, int numEta, int numPhi, int x, int y) const;
 
-    void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const override;
+    virtual void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const override;
 
-    void setGridSize(double grid) { fGridSize = grid; }
-    void setSipmSize(double sipm) { fSipmSize = sipm; }
+    void setGridSize(double grid) { m_gridSize = grid; }
+    void setSipmSize(double sipm) { m_sipmSize = sipm; }
 
     // remove different type of channels in the neighborhood set if set to true
-    void setRemoveDifferentCh(bool rmDiffCh) { fRemoveDifferentCh = rmDiffCh; }
+    void setRemoveDifferentCh(bool rmDiffCh) { m_removeDifferentCh = rmDiffCh; }
 
     // Get the identifier number of a mother tower in eta or phi direction
-    int numEta(const CellID& aCellID) const;
-    int numPhi(const CellID& aCellID) const;
+    int numEta(const CellID aCellID) const;
+    int numPhi(const CellID aCellID) const;
 
     // Get the total number of SiPMs of the mother tower in x or y direction (local coordinate)
-    int numX(const CellID& aCellID) const;
-    int numY(const CellID& aCellID) const;
+    int numX(const CellID aCellID) const;
+    int numY(const CellID aCellID) const;
 
     // Get the identifier number of a SiPM in x or y direction (local coordinate)
-    int x(const CellID& aCellID) const; // approx phi direction
-    int y(const CellID& aCellID) const; // approx eta direction
+    int x(const CellID aCellID) const; // approx phi direction
+    int y(const CellID aCellID) const; // approx eta direction
 
-    bool IsCerenkov(const CellID& aCellID) const;
+    bool IsCerenkov(const CellID aCellID) const;
     bool IsCerenkov(int col, int row) const;
 
-    bool IsTower(const CellID& aCellID) const;
-    bool IsSiPM(const CellID& aCellID) const;
-    bool IsRHS(const CellID& aCellID) const;
+    bool IsTower(const CellID aCellID) const;
+    bool IsSiPM(const CellID aCellID) const;
+    bool IsRHS(const CellID aCellID) const;
 
-    int getFirst32bits(const CellID& aCellID) const { return (int)aCellID; }
-    int getLast32bits(const CellID& aCellID) const;
+    int getFirst32bits(const CellID aCellID) const { return (int)aCellID; }
+    int getLast32bits(const CellID aCellID) const;
     CellID convertFirst32to64(const int aId32) const { return (CellID)aId32; }
     CellID convertLast32to64(const int aId32) const;
 
     // Methods for 32bit to 64bit en/decoder
-    int numEta(const int& aId32) const { return numEta(convertFirst32to64(aId32)); }
-    int numPhi(const int& aId32) const { return numPhi(convertFirst32to64(aId32)); }
+    int numEta(const int aId32) const { return numEta(convertFirst32to64(aId32)); }
+    int numPhi(const int aId32) const { return numPhi(convertFirst32to64(aId32)); }
 
-    int numX(const int& aId32) const { return numX(convertFirst32to64(aId32)); }
-    int numY(const int& aId32) const { return numY(convertFirst32to64(aId32)); }
+    int numX(const int aId32) const { return numX(convertFirst32to64(aId32)); }
+    int numY(const int aId32) const { return numY(convertFirst32to64(aId32)); }
 
-    int x(const int& aId32) const { return x(convertLast32to64(aId32)); }
-    int y(const int& aId32) const { return y(convertLast32to64(aId32)); }
+    int x(const int aId32) const { return x(convertLast32to64(aId32)); }
+    int y(const int aId32) const { return y(convertLast32to64(aId32)); }
 
-    bool IsCerenkov(const int& aId32) const { return IsCerenkov(convertLast32to64(aId32)); }
+    bool IsCerenkov(const int aId32) const { return IsCerenkov(convertLast32to64(aId32)); }
 
-    bool IsTower(const int& aId32) const { return IsTower(convertLast32to64(aId32)); }
+    bool IsTower(const int aId32) const { return IsTower(convertLast32to64(aId32)); }
     bool IsSiPM(const int& aId32) const { return IsSiPM(convertLast32to64(aId32)); }
 
-    inline const std::string& fieldNameAssembly() const { return fAssemblyId; }
-    inline const std::string& fieldNameNumEta() const { return fNumEtaId; }
-    inline const std::string& fieldNameNumPhi() const { return fNumPhiId; }
-    inline const std::string& fieldNameX() const { return fXId; }
-    inline const std::string& fieldNameY() const { return fYId; }
-    inline const std::string& fieldNameIsCerenkov() const { return fIsCerenkovId; }
-    inline const std::string& fieldNameModule() const { return fModule; }
+    inline const std::string& fieldNameAssembly() const { return m_assemblyID; }
+    inline const std::string& fieldNameNumEta() const { return m_numEtaID; }
+    inline const std::string& fieldNameNumPhi() const { return m_numPhiID; }
+    inline const std::string& fieldNameX() const { return m_xID; }
+    inline const std::string& fieldNameY() const { return m_yID; }
+    inline const std::string& fieldNameIsCerenkov() const { return m_isCerenkovID; }
+    inline const std::string& fieldNameModule() const { return m_moduleID; }
 
-    inline void setFieldNameAssembly(const std::string& fieldName) { fAssemblyId = fieldName; }
-    inline void setFieldNameNumEta(const std::string& fieldName) { fNumEtaId = fieldName; }
-    inline void setFieldNameNumPhi(const std::string& fieldName) { fNumPhiId = fieldName; }
-    inline void setFieldNameX(const std::string& fieldName) { fXId = fieldName; }
-    inline void setFieldNameY(const std::string& fieldName) { fYId = fieldName; }
-    inline void setFieldNameIsCerenkov(const std::string& fieldName) { fIsCerenkovId = fieldName; }
-    inline void setFieldNameModule(const std::string& fieldName) { fModule = fieldName; }
+    inline void setFieldNameAssembly(const std::string& fieldName) { m_assemblyID = fieldName; }
+    inline void setFieldNameNumEta(const std::string& fieldName) { m_numEtaID = fieldName; }
+    inline void setFieldNameNumPhi(const std::string& fieldName) { m_numPhiID = fieldName; }
+    inline void setFieldNameX(const std::string& fieldName) { m_xID = fieldName; }
+    inline void setFieldNameY(const std::string& fieldName) { m_yID = fieldName; }
+    inline void setFieldNameIsCerenkov(const std::string& fieldName) { m_isCerenkovID = fieldName; }
+    inline void setFieldNameModule(const std::string& fieldName) { m_moduleID = fieldName; }
 
-    DRparamBarrel_k4geo* paramBarrel() { return fParamBarrel; }
-    DRparamEndcap_k4geo* paramEndcap() { return fParamEndcap; }
+    DRparamBarrel_k4geo* paramBarrel() { return m_paramBarrel; }
+    DRparamEndcap_k4geo* paramEndcap() { return m_paramEndcap; }
 
     DRparamBase_k4geo* setParamBase(int noEta) const;
 
-  protected:
-    std::string fAssemblyId;
-    std::string fNumEtaId;
-    std::string fNumPhiId;
-    std::string fXId;
-    std::string fYId;
-    std::string fIsCerenkovId;
-    std::string fModule;
+  private:
+    std::string m_assemblyID;
+    std::string m_numEtaID;
+    std::string m_numPhiID;
+    std::string m_xID;
+    std::string m_yID;
+    std::string m_isCerenkovID;
+    std::string m_moduleID;
 
-    double fGridSize;
-    double fSipmSize;
+    double m_gridSize;
+    double m_sipmSize;
 
     // switch to remove different type cells from the neighborhood
-    bool fRemoveDifferentCh;
+    bool m_removeDifferentCh;
 
-    DRparamBarrel_k4geo* fParamBarrel;
-    DRparamEndcap_k4geo* fParamEndcap;
+    DRparamBarrel_k4geo* m_paramBarrel;
+    DRparamEndcap_k4geo* m_paramEndcap;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for system
+    int m_systemIndex = -1;
+    /// the field index used for numEta
+    int m_numEtaIndex = -1;
+    /// the field index used for numPhi
+    int m_numPhiIndex = -1;
+    /// the field index used for module
+    int m_moduleIndex = -1;
+    /// the field index used for x
+    int m_xIndex = -1;
+    /// the field index used for y
+    int m_yIndex = -1;
+    /// the field index used for isCerenkov
+    int m_isCerenkovIndex = -1;
+    /// the field index used for assembly
+    int m_assemblyIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/GridDRcalo_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridDRcalo_k4geo.h
@@ -77,7 +77,7 @@ namespace DDSegmentation {
     bool IsCerenkov(const int aId32) const { return IsCerenkov(convertLast32to64(aId32)); }
 
     bool IsTower(const int aId32) const { return IsTower(convertLast32to64(aId32)); }
-    bool IsSiPM(const int& aId32) const { return IsSiPM(convertLast32to64(aId32)); }
+    bool IsSiPM(const int aId32) const { return IsSiPM(convertLast32to64(aId32)); }
 
     inline const std::string& fieldNameAssembly() const { return m_assemblyID; }
     inline const std::string& fieldNameNumEta() const { return m_numEtaID; }

--- a/detectorSegmentations/include/detectorSegmentations/GridEtaHandle_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridEtaHandle_k4geo.h
@@ -35,8 +35,8 @@ typedef Handle<SegmentationWrapper<DDSegmentation::GridEta_k4geo>> GridEtaHandle
  *  fiddled with the handled object directly.....
  *
  *  Note:
- *  The handle base corrsponding to this object in for
- *  conveniance reasons instantiated in DD4hep/src/Segmentations.cpp.
+ *  The handle base corresponding to this object is for
+ *  convenience reasons instantiated in DD4hep/src/Segmentations.cpp.
  *
  *  \author  A. Zaborowska
  *  \version 1.0
@@ -63,10 +63,10 @@ public:
   /// Equality operator
   bool operator==(const GridEta_k4geo& seg) const { return m_element == seg.m_element; }
   /// determine the position based on the cell ID
-  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+  inline Position position(const CellID id) const { return Position(access()->implementation->position(id)); }
 
   /// determine the cell ID based on the position
-  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID volID) const {
     return access()->implementation->cellID(local, global, volID);
   }
 
@@ -93,7 +93,7 @@ public:
       \return std::vector<double> size 1:
       -# size in eta
   */
-  inline std::vector<double> cellDimensions(const CellID& /*id*/) const {
+  inline std::vector<double> cellDimensions(const CellID /*id*/) const {
     return {access()->implementation->gridSizeEta()};
   }
 };

--- a/detectorSegmentations/include/detectorSegmentations/GridEta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridEta_k4geo.h
@@ -30,7 +30,7 @@ namespace DDSegmentation {
      *   @param[in] aCellId ID of a cell.
      *   return Position (radius = 1).
      */
-    virtual Vector3D position(const CellID& aCellID) const;
+    virtual Vector3D position(const CellID& aCellID) const override;
     /**  Determine the cell ID based on the position.
      *   @param[in] aLocalPosition (not used).
      *   @param[in] aGlobalPosition position in the global coordinates.
@@ -38,12 +38,12 @@ namespace DDSegmentation {
      *   return Cell ID.
      */
     virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                          const VolumeID& aVolumeID) const;
+                          const VolumeID& aVolumeID) const override;
     /**  Determine the pseudorapidity based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return Pseudorapidity.
      */
-    double eta(const CellID& aCellID) const;
+    double eta(const CellID aCellID) const;
     /**  Get the grid size in pseudorapidity.
      *   return Grid size in eta.
      */
@@ -88,15 +88,18 @@ namespace DDSegmentation {
       return std::sqrt(aposition.X * aposition.X + aposition.Y * aposition.Y);
     }
 
-  protected:
-    /// determine the pseudorapidity based on the current cell ID
-    double eta() const;
+  private:
     /// the grid size in eta
     double m_gridSizeEta;
     /// the coordinate offset in eta
     double m_offsetEta;
     /// the field name used for eta
     std::string m_etaID;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for eta
+    int m_etaIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/GridRPhiEtaHandle_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridRPhiEtaHandle_k4geo.h
@@ -35,8 +35,8 @@ typedef Handle<SegmentationWrapper<DDSegmentation::GridRPhiEta_k4geo>> GridRPhiE
  *  fiddled with the handled object directly.....
  *
  *  Note:
- *  The handle base corrsponding to this object in for
- *  conveniance reasons instantiated in DD4hep/src/Segmentations.cpp.
+ *  The handle base corresponding to this object is for
+ *  convenience reasons instantiated in DD4hep/src/Segmentations.cpp.
  *
  *  \author  A. Zaborowska
  *  \version 1.0
@@ -63,10 +63,10 @@ public:
   /// Equality operator
   bool operator==(const GridRPhiEta_k4geo& seg) const { return m_element == seg.m_element; }
   /// determine the position based on the cell ID
-  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+  inline Position position(const CellID id) const { return Position(access()->implementation->position(id)); }
 
   /// determine the cell ID based on the position
-  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID volID) const {
     return access()->implementation->cellID(local, global, volID);
   }
 
@@ -124,7 +124,7 @@ public:
       -# size in phi
       -# size in eta
   */
-  inline std::vector<double> cellDimensions(const CellID& /*id*/) const {
+  inline std::vector<double> cellDimensions(const CellID /*id*/) const {
     return {access()->implementation->gridSizeR(), access()->implementation->gridSizePhi(),
             access()->implementation->gridSizeEta()};
   }

--- a/detectorSegmentations/include/detectorSegmentations/GridRPhiEta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridRPhiEta_k4geo.h
@@ -28,7 +28,7 @@ namespace DDSegmentation {
      *   @param[in] aCellId ID of a cell.
      *   return Position.
      */
-    virtual Vector3D position(const CellID& aCellID) const;
+    virtual Vector3D position(const CellID& aCellID) const override;
     /**  Determine the cell ID based on the position.
      *   @param[in] aLocalPosition (not used).
      *   @param[in] aGlobalPosition position in the global coordinates.
@@ -36,12 +36,12 @@ namespace DDSegmentation {
      *   return Cell ID.
      */
     virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                          const VolumeID& aVolumeID) const;
+                          const VolumeID& aVolumeID) const override;
     /**  Determine the radius based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return Radius.
      */
-    double r(const CellID& aCellID) const;
+    double r(const CellID aCellID) const;
     /**  Get the grid size in radial distance from the detector centre.
      *   return Grid size in radial distance.
      */
@@ -68,14 +68,21 @@ namespace DDSegmentation {
     inline void setFieldNameR(const std::string& fieldName) { m_rID = fieldName; }
 
   private:
-    /// determine the radial distance R based on the current cell ID
-    double r() const;
     /// the grid size in r
     double m_gridSizeR;
     /// the coordinate offset in r
     double m_offsetR;
     /// the field name used for r
     std::string m_rID;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for eta
+    int m_etaIndex = -1;
+    /// the field index used for phi
+    int m_phiIndex = -1;
+    /// the field index used for r
+    int m_rIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/GridSimplifiedDriftChamber_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridSimplifiedDriftChamber_k4geo.h
@@ -26,14 +26,14 @@ namespace DDSegmentation {
     /// destructor
     virtual ~GridSimplifiedDriftChamber_k4geo() = default;
 
-    virtual Vector3D position(const CellID& aCellID) const;
+    virtual Vector3D position(const CellID& aCellID) const override;
     virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                          const VolumeID& aVolumeID) const;
-    virtual TVector3 distanceClosestApproach(const CellID& cID, const TVector3& hitPos) const;
-    virtual double distanceTrackWire(const CellID& cID, const TVector3& hit_start, const TVector3& hit_end) const;
-    virtual TVector3 Line_TrackWire(const CellID& cID, const TVector3& hit_start, const TVector3& hit_end) const;
-    virtual TVector3 IntersectionTrackWire(const CellID& cID, const TVector3& hit_start, const TVector3& hit_end) const;
-    virtual TVector3 wirePos_vs_z(const CellID& cID, const double& zpos) const;
+                          const VolumeID& aVolumeID) const override;
+    virtual TVector3 distanceClosestApproach(const CellID cID, const TVector3& hitPos) const;
+    virtual double distanceTrackWire(const CellID cID, const TVector3& hit_start, const TVector3& hit_end) const;
+    virtual TVector3 Line_TrackWire(const CellID cID, const TVector3& hit_start, const TVector3& hit_end) const;
+    virtual TVector3 IntersectionTrackWire(const CellID cID, const TVector3& hit_start, const TVector3& hit_end) const;
+    virtual TVector3 wirePos_vs_z(const CellID cID, const double zpos) const;
 
     inline double epsilon() const { return m_epsilon; }
 
@@ -198,9 +198,9 @@ namespace DDSegmentation {
       return layer;
     }
 
-  protected:
+  private:
     /* *** nalipour *** */
-    double phi(const CellID& cID) const;
+    double phi(const CellID cID) const;
 
     std::map<int, std::vector<double>> layer_params; // <layer, {phi, R, eps}>
     std::map<int, std::vector<std::pair<TVector3, TVector3>>>
@@ -216,6 +216,13 @@ namespace DDSegmentation {
     mutable double _currentGridSizePhi; // current size Phi
     mutable double _currentRadius;      // current size radius
     mutable double m_epsilon;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for layer
+    int m_layerIndex = -1;
+    /// the field index used for phi
+    int m_phiIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/GridThetaHandle_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridThetaHandle_k4geo.h
@@ -35,8 +35,8 @@ typedef Handle<SegmentationWrapper<DDSegmentation::GridTheta_k4geo>> GridThetaHa
  *  fiddled with the handled object directly.....
  *
  *  Note:
- *  The handle base corrsponding to this object in for
- *  conveniance reasons instantiated in DD4hep/src/Segmentations.cpp.
+ *  The handle base corresponding to this object is for
+ *  convenience reasons instantiated in DD4hep/src/Segmentations.cpp.
  *
  *  \author  A. Zaborowska
  *  \version 1.0
@@ -63,10 +63,10 @@ public:
   /// Equality operator
   bool operator==(const GridTheta_k4geo& seg) const { return m_element == seg.m_element; }
   /// determine the position based on the cell ID
-  inline Position position(const CellID& id) const { return Position(access()->implementation->position(id)); }
+  inline Position position(const CellID id) const { return Position(access()->implementation->position(id)); }
 
   /// determine the cell ID based on the position
-  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const {
+  inline dd4hep::CellID cellID(const Position& local, const Position& global, const VolumeID volID) const {
     return access()->implementation->cellID(local, global, volID);
   }
 
@@ -93,7 +93,7 @@ public:
       \return std::vector<double> size 1:
       -# size in theta
   */
-  inline std::vector<double> cellDimensions(const CellID& /*id*/) const {
+  inline std::vector<double> cellDimensions(const CellID /*id*/) const {
     return {access()->implementation->gridSizeTheta()};
   }
 };

--- a/detectorSegmentations/include/detectorSegmentations/GridTheta_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/GridTheta_k4geo.h
@@ -29,7 +29,7 @@ namespace DDSegmentation {
      *   @param[in] aCellId ID of a cell.
      *   return Position (radius = 1).
      */
-    virtual Vector3D position(const CellID& aCellID) const;
+    virtual Vector3D position(const CellID& aCellID) const override;
     /**  Determine the cell ID based on the position.
      *   @param[in] aLocalPosition (not used).
      *   @param[in] aGlobalPosition position in the global coordinates.
@@ -37,12 +37,12 @@ namespace DDSegmentation {
      *   return Cell ID.
      */
     virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
-                          const VolumeID& aVolumeID) const;
+                          const VolumeID& aVolumeID) const override;
     /**  Determine the theta angle based on the cell ID.
      *   @param[in] aCellId ID of a cell.
      *   return Pseudorapidity.
      */
-    double theta(const CellID& aCellID) const;
+    double theta(const CellID aCellID) const;
     /**  Get the grid size in theta angle.
      *   return Grid size in theta.
      */
@@ -81,21 +81,25 @@ namespace DDSegmentation {
     /// calculates the azimuthal angle phi from Cartesian coordinates
     inline double phiFromXYZ(const Vector3D& aposition) const { return std::atan2(aposition.Y, aposition.X); }
     /// from SegmentationUtil
+
     /// to be removed once SegmentationUtil can be included w/o linker error
     /// calculates the radius in the xy-plane from Cartesian coordinates
     inline double radiusFromXYZ(const Vector3D& aposition) const {
       return std::sqrt(aposition.X * aposition.X + aposition.Y * aposition.Y);
     }
 
-  protected:
-    /// determine the theta angle based on the current cell ID
-    double theta() const;
+  private:
     /// the grid size in theta
     double m_gridSizeTheta;
     /// the coordinate offset in theta
     double m_offsetTheta;
     /// the field name used for theta
     std::string m_thetaID;
+
+    /// Initialization common to all ctors.
+    void commonSetup();
+    /// the field index used for theta
+    int m_thetaIndex = -1;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/SCEPCal_MainSegmentation_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/SCEPCal_MainSegmentation_k4geo.h
@@ -17,7 +17,7 @@ namespace DDSegmentation {
   public:
     SCEPCal_MainSegmentation_k4geo(const std::string& aCellEncoding);
     SCEPCal_MainSegmentation_k4geo(const BitFieldCoder* decoder);
-    virtual ~SCEPCal_MainSegmentation_k4geo() override;
+    virtual ~SCEPCal_MainSegmentation_k4geo() = default;
 
     virtual Vector3D position(const CellID& aCellID) const override;
 
@@ -34,12 +34,12 @@ namespace DDSegmentation {
       VolumeID EpsilonId = static_cast<VolumeID>(Epsilon);
       VolumeID DepthId = static_cast<VolumeID>(Depth);
       VolumeID vID = 0;
-      _decoder->set(vID, fSystemId, SystemId);
-      _decoder->set(vID, fPhiId, PhiId);
-      _decoder->set(vID, fThetaId, ThetaId);
-      _decoder->set(vID, fGammaId, GammaId);
-      _decoder->set(vID, fEpsilonId, EpsilonId);
-      _decoder->set(vID, fDepthId, DepthId);
+      decoder()->set(vID, m_systemIndex, SystemId);
+      decoder()->set(vID, m_phiIndex, PhiId);
+      decoder()->set(vID, m_thetaIndex, ThetaId);
+      decoder()->set(vID, m_gammaIndex, GammaId);
+      decoder()->set(vID, m_epsilonIndex, EpsilonId);
+      decoder()->set(vID, m_depthIndex, DepthId);
       return vID;
     }
 
@@ -51,78 +51,87 @@ namespace DDSegmentation {
       VolumeID EpsilonId = static_cast<VolumeID>(Epsilon);
       VolumeID DepthId = static_cast<VolumeID>(Depth);
       VolumeID vID = 0;
-      _decoder->set(vID, fSystemId, SystemId);
-      _decoder->set(vID, fPhiId, PhiId);
-      _decoder->set(vID, fThetaId, ThetaId);
-      _decoder->set(vID, fGammaId, GammaId);
-      _decoder->set(vID, fEpsilonId, EpsilonId);
-      _decoder->set(vID, fDepthId, DepthId);
+      decoder()->set(vID, m_systemIndex, SystemId);
+      decoder()->set(vID, m_phiIndex, PhiId);
+      decoder()->set(vID, m_thetaIndex, ThetaId);
+      decoder()->set(vID, m_gammaIndex, GammaId);
+      decoder()->set(vID, m_epsilonIndex, EpsilonId);
+      decoder()->set(vID, m_depthIndex, DepthId);
       return vID;
     }
 
-    int System(const CellID& aCellID) const {
-      VolumeID System = static_cast<VolumeID>(_decoder->get(aCellID, fSystemId));
+    int System(const CellID aCellID) const {
+      VolumeID System = static_cast<VolumeID>(decoder()->get(aCellID, m_systemIndex));
       return static_cast<int>(System);
     }
 
-    int Phi(const CellID& aCellID) const {
-      VolumeID Phi = static_cast<VolumeID>(_decoder->get(aCellID, fPhiId));
+    int Phi(const CellID aCellID) const {
+      VolumeID Phi = static_cast<VolumeID>(decoder()->get(aCellID, m_phiIndex));
       return static_cast<int>(Phi);
     }
 
-    int Theta(const CellID& aCellID) const {
-      VolumeID Theta = static_cast<VolumeID>(_decoder->get(aCellID, fThetaId));
+    int Theta(const CellID aCellID) const {
+      VolumeID Theta = static_cast<VolumeID>(decoder()->get(aCellID, m_thetaIndex));
       return static_cast<int>(Theta);
     }
 
-    int Gamma(const CellID& aCellID) const {
-      VolumeID Gamma = static_cast<VolumeID>(_decoder->get(aCellID, fGammaId));
+    int Gamma(const CellID aCellID) const {
+      VolumeID Gamma = static_cast<VolumeID>(decoder()->get(aCellID, m_gammaIndex));
       return static_cast<int>(Gamma);
     }
 
-    int Epsilon(const CellID& aCellID) const {
-      VolumeID Epsilon = static_cast<VolumeID>(_decoder->get(aCellID, fEpsilonId));
+    int Epsilon(const CellID aCellID) const {
+      VolumeID Epsilon = static_cast<VolumeID>(decoder()->get(aCellID, m_epsilonIndex));
       return static_cast<int>(Epsilon);
     }
 
-    int Depth(const CellID& aCellID) const {
-      VolumeID Depth = static_cast<VolumeID>(_decoder->get(aCellID, fDepthId));
+    int Depth(const CellID aCellID) const {
+      VolumeID Depth = static_cast<VolumeID>(decoder()->get(aCellID, m_depthIndex));
       return static_cast<int>(Depth);
     }
 
-    int getFirst32bits(const CellID& aCellID) const { return (int)aCellID; }
-    int getLast32bits(const CellID& aCellID) const {
+    int getFirst32bits(const CellID aCellID) const { return static_cast<int>(aCellID); }
+    int getLast32bits(const CellID aCellID) const {
       CellID aId64 = aCellID >> sizeof(int) * CHAR_BIT;
-      int aId32 = (int)aId64;
+      int aId32 = static_cast<int>(aId64);
       return aId32;
     }
 
-    CellID convertFirst32to64(const int aId32) const { return (CellID)aId32; }
+    CellID convertFirst32to64(const int aId32) const { return static_cast<CellID>(aId32); }
     CellID convertLast32to64(const int aId32) const {
-      CellID aId64 = (CellID)aId32;
+      CellID aId64 = static_cast<CellID>(aId32);
       aId64 <<= sizeof(int) * CHAR_BIT;
       return aId64;
     }
 
-    int System(const int& aId32) const { return System(convertFirst32to64(aId32)); }
-    int Phi(const int& aId32) const { return Phi(convertFirst32to64(aId32)); }
-    int Theta(const int& aId32) const { return Theta(convertFirst32to64(aId32)); }
-    int Gamma(const int& aId32) const { return Gamma(convertFirst32to64(aId32)); }
-    int Epsilon(const int& aId32) const { return Epsilon(convertFirst32to64(aId32)); }
-    int Depth(const int& aId32) const { return Depth(convertFirst32to64(aId32)); }
+    int System(const int aId32) const { return System(convertFirst32to64(aId32)); }
+    int Phi(const int aId32) const { return Phi(convertFirst32to64(aId32)); }
+    int Theta(const int aId32) const { return Theta(convertFirst32to64(aId32)); }
+    int Gamma(const int aId32) const { return Gamma(convertFirst32to64(aId32)); }
+    int Epsilon(const int aId32) const { return Epsilon(convertFirst32to64(aId32)); }
+    int Depth(const int aId32) const { return Depth(convertFirst32to64(aId32)); }
 
-    inline void savePosition(int volID_32, Vector3D pos) { fPositionOf.emplace(volID_32, pos); }
-
-  protected:
-    std::string fSystemId;
-    std::string fPhiId;
-    std::string fThetaId;
-    std::string fGammaId;
-    std::string fEpsilonId;
-    std::string fDepthId;
+    inline void savePosition(int volID_32, Vector3D pos) { m_positionOf.emplace(volID_32, pos); }
 
   private:
-    mutable std::unordered_map<int, Vector3D> fPositionOf;
+    /// Initialization common to all ctors.
+    void commonSetup();
+
+    std::string m_systemId;
+    std::string m_phiId;
+    std::string m_thetaId;
+    std::string m_gammaId;
+    std::string m_epsilonId;
+    std::string m_depthId;
+
+    int m_systemIndex = -1;
+    int m_phiIndex = -1;
+    int m_thetaIndex = -1;
+    int m_gammaIndex = -1;
+    int m_epsilonIndex = -1;
+    int m_depthIndex = -1;
+
+    std::unordered_map<int, Vector3D> m_positionOf;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/include/detectorSegmentations/SCEPCal_TimingSegmentation_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/SCEPCal_TimingSegmentation_k4geo.h
@@ -17,7 +17,7 @@ namespace DDSegmentation {
   public:
     SCEPCal_TimingSegmentation_k4geo(const std::string& aCellEncoding);
     SCEPCal_TimingSegmentation_k4geo(const BitFieldCoder* decoder);
-    virtual ~SCEPCal_TimingSegmentation_k4geo() override;
+    virtual ~SCEPCal_TimingSegmentation_k4geo() = default;
 
     virtual Vector3D position(const CellID& aCellID) const override;
 
@@ -32,10 +32,10 @@ namespace DDSegmentation {
       VolumeID ThetaId = static_cast<VolumeID>(Theta);
       VolumeID GammaId = static_cast<VolumeID>(Gamma);
       VolumeID vID = 0;
-      _decoder->set(vID, fSystemId, SystemId);
-      _decoder->set(vID, fPhiId, PhiId);
-      _decoder->set(vID, fThetaId, ThetaId);
-      _decoder->set(vID, fGammaId, GammaId);
+      decoder()->set(vID, m_systemIndex, SystemId);
+      decoder()->set(vID, m_phiIndex, PhiId);
+      decoder()->set(vID, m_thetaIndex, ThetaId);
+      decoder()->set(vID, m_gammaIndex, GammaId);
       return vID;
     }
 
@@ -45,62 +45,69 @@ namespace DDSegmentation {
       VolumeID ThetaId = static_cast<VolumeID>(Theta);
       VolumeID GammaId = static_cast<VolumeID>(Gamma);
       VolumeID vID = 0;
-      _decoder->set(vID, fSystemId, SystemId);
-      _decoder->set(vID, fPhiId, PhiId);
-      _decoder->set(vID, fThetaId, ThetaId);
-      _decoder->set(vID, fGammaId, GammaId);
+      decoder()->set(vID, m_systemIndex, SystemId);
+      decoder()->set(vID, m_phiIndex, PhiId);
+      decoder()->set(vID, m_thetaIndex, ThetaId);
+      decoder()->set(vID, m_gammaIndex, GammaId);
       return vID;
     }
 
-    int System(const CellID& aCellID) const {
-      VolumeID System = static_cast<VolumeID>(_decoder->get(aCellID, fSystemId));
+    int System(const CellID aCellID) const {
+      VolumeID System = static_cast<VolumeID>(decoder()->get(aCellID, m_systemIndex));
       return static_cast<int>(System);
     }
 
-    int Phi(const CellID& aCellID) const {
-      VolumeID Phi = static_cast<VolumeID>(_decoder->get(aCellID, fPhiId));
+    int Phi(const CellID aCellID) const {
+      VolumeID Phi = static_cast<VolumeID>(decoder()->get(aCellID, m_phiIndex));
       return static_cast<int>(Phi);
     }
 
-    int Theta(const CellID& aCellID) const {
-      VolumeID Theta = static_cast<VolumeID>(_decoder->get(aCellID, fThetaId));
+    int Theta(const CellID aCellID) const {
+      VolumeID Theta = static_cast<VolumeID>(decoder()->get(aCellID, m_thetaIndex));
       return static_cast<int>(Theta);
     }
 
-    int Gamma(const CellID& aCellID) const {
-      VolumeID Gamma = static_cast<VolumeID>(_decoder->get(aCellID, fGammaId));
+    int Gamma(const CellID aCellID) const {
+      VolumeID Gamma = static_cast<VolumeID>(decoder()->get(aCellID, m_gammaIndex));
       return static_cast<int>(Gamma);
     }
 
-    int getFirst32bits(const CellID& aCellID) const { return (int)aCellID; }
-    int getLast32bits(const CellID& aCellID) const {
+    int getFirst32bits(const CellID aCellID) const { return static_cast<int>(aCellID); }
+    int getLast32bits(const CellID aCellID) const {
       CellID aId64 = aCellID >> sizeof(int) * CHAR_BIT;
-      int aId32 = (int)aId64;
+      int aId32 = static_cast<int>(aId64);
       return aId32;
     }
 
-    CellID convertFirst32to64(const int aId32) const { return (CellID)aId32; }
+    CellID convertFirst32to64(const int aId32) const { return static_cast<CellID>(aId32); }
     CellID convertLast32to64(const int aId32) const {
-      CellID aId64 = (CellID)aId32;
+      CellID aId64 = static_cast<CellID>(aId32);
       aId64 <<= sizeof(int) * CHAR_BIT;
       return aId64;
     }
 
-    int System(const int& aId32) const { return System(convertFirst32to64(aId32)); }
-    int Phi(const int& aId32) const { return Phi(convertFirst32to64(aId32)); }
-    int Theta(const int& aId32) const { return Theta(convertFirst32to64(aId32)); }
-    int Gamma(const int& aId32) const { return Gamma(convertFirst32to64(aId32)); }
+    int System(const int aId32) const { return System(convertFirst32to64(aId32)); }
+    int Phi(const int aId32) const { return Phi(convertFirst32to64(aId32)); }
+    int Theta(const int aId32) const { return Theta(convertFirst32to64(aId32)); }
+    int Gamma(const int aId32) const { return Gamma(convertFirst32to64(aId32)); }
 
-    inline void savePosition(int volID_32, Vector3D pos) { fPositionOf.emplace(volID_32, pos); }
-
-  protected:
-    std::string fSystemId;
-    std::string fPhiId;
-    std::string fThetaId;
-    std::string fGammaId;
+    inline void savePosition(int volID_32, Vector3D pos) { m_positionOf.emplace(volID_32, pos); }
 
   private:
-    mutable std::unordered_map<int, Vector3D> fPositionOf;
+    /// Initialization common to all ctors.
+    void commonSetup();
+
+    std::string m_systemId;
+    std::string m_phiId;
+    std::string m_thetaId;
+    std::string m_gammaId;
+
+    int m_systemIndex = -1;
+    int m_phiIndex = -1;
+    int m_thetaIndex = -1;
+    int m_gammaIndex = -1;
+
+    std::unordered_map<int, Vector3D> m_positionOf;
   };
 } // namespace DDSegmentation
 } // namespace dd4hep

--- a/detectorSegmentations/src/FCCSWGridPhiEta_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWGridPhiEta_k4geo.cpp
@@ -5,17 +5,13 @@ namespace DDSegmentation {
 
   /// default constructor using an encoding string
   FCCSWGridPhiEta_k4geo::FCCSWGridPhiEta_k4geo(const std::string& cellEncoding) : GridEta_k4geo(cellEncoding) {
-    // define type and description
-    _type = "FCCSWGridPhiEta_k4geo";
-    _description = "Phi-eta segmentation in the global coordinates";
-
-    // register all necessary parameters (additional to those registered in GridEta_k4geo)
-    registerParameter("phi_bins", "Number of bins phi", m_phiBins, 1);
-    registerParameter("offset_phi", "Angular offset in phi", m_offsetPhi, 0., SegmentationParameter::AngleUnit, true);
-    registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
+    commonSetup();
   }
 
-  FCCSWGridPhiEta_k4geo::FCCSWGridPhiEta_k4geo(const BitFieldCoder* decoder) : GridEta_k4geo(decoder) {
+  FCCSWGridPhiEta_k4geo::FCCSWGridPhiEta_k4geo(const BitFieldCoder* decoder) : GridEta_k4geo(decoder) { commonSetup(); }
+
+  /// Initialization common to all ctors.
+  void FCCSWGridPhiEta_k4geo::commonSetup() {
     // define type and description
     _type = "FCCSWGridPhiEta_k4geo";
     _description = "Phi-eta segmentation in the global coordinates";
@@ -24,6 +20,9 @@ namespace DDSegmentation {
     registerParameter("phi_bins", "Number of bins phi", m_phiBins, 1);
     registerParameter("offset_phi", "Angular offset in phi", m_offsetPhi, 0., SegmentationParameter::AngleUnit, true);
     registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
+
+    m_etaIndex = decoder()->index(fieldNameEta());
+    m_phiIndex = decoder()->index(m_phiID);
   }
 
   /// determine the local based on the cell ID
@@ -37,20 +36,14 @@ namespace DDSegmentation {
     CellID cID = vID;
     double lEta = etaFromXYZ(globalPosition);
     double lPhi = phiFromXYZ(globalPosition);
-    _decoder->set(cID, m_etaID, positionToBin(lEta, m_gridSizeEta, m_offsetEta));
-    _decoder->set(cID, m_phiID, positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi));
+    decoder()->set(cID, m_etaIndex, positionToBin(lEta, gridSizeEta(), offsetEta()));
+    decoder()->set(cID, m_phiIndex, positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi));
     return cID;
   }
 
-  /// determine the azimuthal angle phi based on the current cell ID
-  // double FCCSWGridPhiEta_k4geo::phi() const {
-  //   CellID phiValue = (*_decoder)[m_phiID].value();
-  //   return binToPosition(phiValue, 2. * M_PI / (double)m_phiBins, m_offsetPhi);
-  // }
-
   /// determine the azimuthal angle phi based on the cell ID
-  double FCCSWGridPhiEta_k4geo::phi(const CellID& cID) const {
-    CellID phiValue = _decoder->get(cID, m_phiID);
+  double FCCSWGridPhiEta_k4geo::phi(const CellID cID) const {
+    CellID phiValue = decoder()->get(cID, m_phiIndex);
     return binToPosition(phiValue, 2. * M_PI / (double)m_phiBins, m_offsetPhi);
   }
 } // namespace DDSegmentation

--- a/detectorSegmentations/src/FCCSWGridPhiTheta_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWGridPhiTheta_k4geo.cpp
@@ -5,17 +5,15 @@ namespace DDSegmentation {
 
   /// default constructor using an encoding string
   FCCSWGridPhiTheta_k4geo::FCCSWGridPhiTheta_k4geo(const std::string& cellEncoding) : GridTheta_k4geo(cellEncoding) {
-    // define type and description
-    _type = "FCCSWGridPhiTheta_k4geo";
-    _description = "Phi-theta segmentation in the global coordinates";
-
-    // register all necessary parameters (additional to those registered in GridTheta_k4geo)
-    registerParameter("phi_bins", "Number of bins phi", m_phiBins, 1);
-    registerParameter("offset_phi", "Angular offset in phi", m_offsetPhi, 0., SegmentationParameter::AngleUnit, true);
-    registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
+    commonSetup();
   }
 
   FCCSWGridPhiTheta_k4geo::FCCSWGridPhiTheta_k4geo(const BitFieldCoder* decoder) : GridTheta_k4geo(decoder) {
+    commonSetup();
+  }
+
+  /// Initialization common to all ctors.
+  void FCCSWGridPhiTheta_k4geo::commonSetup() {
     // define type and description
     _type = "FCCSWGridPhiTheta_k4geo";
     _description = "Phi-theta segmentation in the global coordinates";
@@ -24,6 +22,9 @@ namespace DDSegmentation {
     registerParameter("phi_bins", "Number of bins phi", m_phiBins, 1);
     registerParameter("offset_phi", "Angular offset in phi", m_offsetPhi, 0., SegmentationParameter::AngleUnit, true);
     registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
+
+    m_thetaIndex = decoder()->index(fieldNameTheta());
+    m_phiIndex = decoder()->index(m_phiID);
   }
 
   /// determine the local based on the cell ID
@@ -37,14 +38,14 @@ namespace DDSegmentation {
     CellID cID = vID;
     double lTheta = thetaFromXYZ(globalPosition);
     double lPhi = phiFromXYZ(globalPosition);
-    _decoder->set(cID, m_thetaID, positionToBin(lTheta, m_gridSizeTheta, m_offsetTheta));
-    _decoder->set(cID, m_phiID, positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi));
+    decoder()->set(cID, m_thetaIndex, positionToBin(lTheta, gridSizeTheta(), offsetTheta()));
+    decoder()->set(cID, m_phiIndex, positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi));
     return cID;
   }
 
   /// determine the azimuthal angle phi based on the cell ID
-  double FCCSWGridPhiTheta_k4geo::phi(const CellID& cID) const {
-    CellID phiValue = _decoder->get(cID, m_phiID);
+  double FCCSWGridPhiTheta_k4geo::phi(const CellID cID) const {
+    CellID phiValue = decoder()->get(cID, m_phiIndex);
     return binToPosition(phiValue, 2. * M_PI / (double)m_phiBins, m_offsetPhi);
   }
 } // namespace DDSegmentation

--- a/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
+++ b/detectorSegmentations/src/FCCSWHCalPhiRow_k4geo.cpp
@@ -6,27 +6,13 @@ namespace DDSegmentation {
 
   /// default constructor using an encoding string
   FCCSWHCalPhiRow_k4geo::FCCSWHCalPhiRow_k4geo(const std::string& cellEncoding) : Segmentation(cellEncoding) {
-    // define type and description
-    _type = "FCCSWHCalPhiRow_k4geo";
-    _description = "Phi-theta segmentation in the global coordinates";
-
-    // register all necessary parameters
-    registerParameter("phi_bins", "Number of bins phi", m_phiBins, 1);
-    registerParameter("offset_phi", "Angular offset in phi", m_offsetPhi, 0., SegmentationParameter::AngleUnit, true);
-    registerParameter("grid_size_row", "Number of rows combined in a cell", m_gridSizeRow, std::vector<int>());
-    registerParameter("dz_row", "dz of row", m_dz_row, 0.);
-    registerParameter("detLayout", "The detector layout (0 = Barrel; 1 = Endcap)", m_detLayout, -1);
-    registerParameter("offset_z", "Offset in z-axis of the layer center", m_offsetZ, std::vector<double>());
-    registerParameter("width_z", "Width in z of the layer", m_widthZ, std::vector<double>());
-    registerParameter("offset_r", "Offset in radius of the layer (Rmin)", m_offsetR, std::vector<double>());
-    registerParameter("numLayers", "Number of layers", m_numLayers, std::vector<int>());
-    registerParameter("dRlayer", "dR of the layer", m_dRlayer, std::vector<double>());
-    registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
-    registerIdentifier("identifier_row", "Cell ID identifier for row", m_rowID, "row");
-    registerIdentifier("identifier_layer", "Cell ID identifier for layer", m_layerID, "layer");
+    commonSetup();
   }
 
-  FCCSWHCalPhiRow_k4geo::FCCSWHCalPhiRow_k4geo(const BitFieldCoder* decoder) : Segmentation(decoder) {
+  FCCSWHCalPhiRow_k4geo::FCCSWHCalPhiRow_k4geo(const BitFieldCoder* decoder) : Segmentation(decoder) { commonSetup(); }
+
+  /// Initialization common to all ctors.
+  void FCCSWHCalPhiRow_k4geo::commonSetup() {
     // define type and description
     _type = "FCCSWHCalPhiRow_k4geo";
     _description = "Phi-theta segmentation in the global coordinates";
@@ -45,11 +31,23 @@ namespace DDSegmentation {
     registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
     registerIdentifier("identifier_row", "Cell ID identifier for row", m_rowID, "row");
     registerIdentifier("identifier_layer", "Cell ID identifier for layer", m_layerID, "layer");
+
+    m_layerIndex = decoder()->index(m_layerID);
+    m_rowIndex = decoder()->index(m_rowID);
+    m_phiIndex = decoder()->index(m_phiID);
+
+    // Only endcap has "type" --- but it's too early to look at m_detLayout.
+    for (const dd4hep::DDSegmentation::BitFieldElement& bfe : decoder()->fields()) {
+      if (bfe.name() == "type") {
+        m_typeIndex = decoder()->index("type");
+        break;
+      }
+    }
   }
 
   /// determine the global position based on the cell ID
   Vector3D FCCSWHCalPhiRow_k4geo::position(const CellID& cID) const {
-    uint layer = _decoder->get(cID, m_layerID);
+    uint layer = decoder()->get(cID, m_layerIndex);
 
     if (m_radii.empty())
       calculateLayerRadii();
@@ -62,7 +60,7 @@ namespace DDSegmentation {
     double minLayerZ = m_layerEdges[layer].first;
 
     // get index of the cell in the layer (index starts from 1!)
-    int idx = _decoder->get(cID, m_rowID);
+    int idx = decoder()->get(cID, m_rowIndex);
     // calculate z-coordinate of the cell center
     double zpos = minLayerZ + (idx - 1) * m_dz_row * m_gridSizeRow[layer] + 0.5 * m_dz_row * m_gridSizeRow[layer];
 
@@ -226,9 +224,9 @@ namespace DDSegmentation {
                                        const VolumeID& vID) const {
 
     // get the row number from volumeID (starts from 0!)
-    int nrow = _decoder->get(vID, m_rowID);
+    int nrow = decoder()->get(vID, m_rowIndex);
     // get the layer number from volumeID
-    uint layer = _decoder->get(vID, m_layerID);
+    uint layer = decoder()->get(vID, m_layerIndex);
 
     CellID cID = vID;
 
@@ -239,22 +237,22 @@ namespace DDSegmentation {
     if (m_detLayout == 1 && globalPosition.z() < 0)
       idx *= -1;
 
-    _decoder->set(cID, m_rowID, idx);
-    _decoder->set(cID, m_phiID,
-                  positionToBin(dd4hep::DDSegmentation::Util::phiFromXYZ(globalPosition), 2 * M_PI / (double)m_phiBins,
-                                m_offsetPhi));
+    decoder()->set(cID, m_rowIndex, idx);
+    decoder()->set(cID, m_phiIndex,
+                   positionToBin(dd4hep::DDSegmentation::Util::phiFromXYZ(globalPosition), 2 * M_PI / (double)m_phiBins,
+                                 m_offsetPhi));
 
     // For endcap, the volume ID comes with "type" field information which would screw up the topo-clustering,
     // therefore, lets set it to zero, as it is for the cell IDs in the neighbours map.
     if (m_detLayout == 1)
-      _decoder->set(cID, "type", 0);
+      decoder()->set(cID, m_typeIndex, 0);
 
     return cID;
   }
 
   /// determine the azimuthal angle phi based on the cell ID
-  double FCCSWHCalPhiRow_k4geo::phi(const CellID& cID) const {
-    CellID phiValue = _decoder->get(cID, m_phiID);
+  double FCCSWHCalPhiRow_k4geo::phi(const CellID cID) const {
+    CellID phiValue = decoder()->get(cID, m_phiIndex);
     return binToPosition(phiValue, 2. * M_PI / (double)m_phiBins, m_offsetPhi);
   }
 
@@ -293,7 +291,7 @@ namespace DDSegmentation {
   }
 
   /// Calculates the neighbours of the given cell ID and adds them to the list of neighbours
-  std::vector<uint64_t> FCCSWHCalPhiRow_k4geo::neighbours(const CellID& cID) const {
+  std::vector<uint64_t> FCCSWHCalPhiRow_k4geo::neighbours(const CellID cID) const {
     std::vector<uint64_t> cellNeighbours;
 
     if (m_radii.empty())
@@ -305,8 +303,8 @@ namespace DDSegmentation {
     int minLayerId = -1;
     int maxLayerId = -1;
 
-    int currentLayerId = _decoder->get(cID, m_layerID);
-    int currentCellId = _decoder->get(cID, m_rowID);
+    int currentLayerId = decoder()->get(cID, m_layerIndex);
+    int currentCellId = decoder()->get(cID, m_rowIndex);
 
     int minCellId = m_cellIndexes[currentLayerId].front();
     int maxCellId = m_cellIndexes[currentLayerId].back();
@@ -364,19 +362,19 @@ namespace DDSegmentation {
     if (currentLayerId > minLayerId) {
       CellID nID = cID;
       int prevLayerId = currentLayerId - 1;
-      _decoder->set(nID, m_layerID, prevLayerId);
+      decoder()->set(nID, m_layerIndex, prevLayerId);
 
       // if the granularity is the same for the previous layer then take the cells with currentCellId, currentCellId -
       // 1, and currentCellId + 1
       if (m_gridSizeRow[prevLayerId] == m_gridSizeRow[currentLayerId]) {
-        _decoder->set(nID, m_rowID, currentCellId);
+        decoder()->set(nID, m_rowIndex, currentCellId);
         cellNeighbours.push_back(nID); // add the cell from the previous layer of the same phi module
         if (currentCellId > minCellId) {
-          _decoder->set(nID, m_rowID, currentCellId - 1);
+          decoder()->set(nID, m_rowIndex, currentCellId - 1);
           cellNeighbours.push_back(nID); // add the cell from the previous layer of the same phi module
         }
         if (currentCellId < maxCellId) {
-          _decoder->set(nID, m_rowID, currentCellId + 1);
+          decoder()->set(nID, m_rowIndex, currentCellId + 1);
           cellNeighbours.push_back(nID); // add the cell from the previous layer of the same phi module
         }
       }
@@ -385,20 +383,20 @@ namespace DDSegmentation {
         // determine the cell index in the previous layer that is below of the current cell
         int idx = (currentCellId > 0) ? ((currentCellId - 1) / m_gridSizeRow[prevLayerId] + 1)
                                       : ((currentCellId + 1) / m_gridSizeRow[prevLayerId] - 1);
-        _decoder->set(nID, m_rowID, idx);
+        decoder()->set(nID, m_rowIndex, idx);
         cellNeighbours.push_back(nID); // add the cell from the previous layer of the same phi module
 
         //
         if ((m_gridSizeRow[prevLayerId] - abs(currentCellId) % m_gridSizeRow[prevLayerId]) ==
                 (m_gridSizeRow[prevLayerId] - 1) &&
             currentCellId > minCellId) {
-          _decoder->set(nID, m_rowID, (idx > 0) ? (idx - 1) : (idx + 1));
+          decoder()->set(nID, m_rowIndex, (idx > 0) ? (idx - 1) : (idx + 1));
           cellNeighbours.push_back(nID); // add the cell from the previous layer of the same phi module
         }
 
         //
         if (abs(currentCellId) % m_gridSizeRow[prevLayerId] == 0 && currentCellId < maxCellId) {
-          _decoder->set(nID, m_rowID, (idx > 0) ? (idx + 1) : (idx - 1));
+          decoder()->set(nID, m_rowIndex, (idx > 0) ? (idx + 1) : (idx - 1));
           cellNeighbours.push_back(nID); // add the cell from the previous layer of the same phi module
         }
       }
@@ -408,19 +406,19 @@ namespace DDSegmentation {
     if (currentLayerId < maxLayerId) {
       CellID nID = cID;
       int nextLayerId = currentLayerId + 1;
-      _decoder->set(nID, m_layerID, nextLayerId);
+      decoder()->set(nID, m_layerIndex, nextLayerId);
 
       // if the granularity is the same for the next layer then take the cells with currentCellId, currentCellId - 1,
       // and currentCellId + 1
       if (m_gridSizeRow[nextLayerId] == m_gridSizeRow[currentLayerId]) {
-        _decoder->set(nID, m_rowID, currentCellId);
+        decoder()->set(nID, m_rowIndex, currentCellId);
         cellNeighbours.push_back(nID); // add the cell from the next layer of the same phi module
         if (currentCellId > minCellId) {
-          _decoder->set(nID, m_rowID, currentCellId - 1);
+          decoder()->set(nID, m_rowIndex, currentCellId - 1);
           cellNeighbours.push_back(nID); // add the cell from the next layer of the same phi module
         }
         if (currentCellId < maxCellId) {
-          _decoder->set(nID, m_rowID, currentCellId + 1);
+          decoder()->set(nID, m_rowIndex, currentCellId + 1);
           cellNeighbours.push_back(nID); // add the cell from the next layer of the same phi module
         }
       }
@@ -429,20 +427,20 @@ namespace DDSegmentation {
         // determine the cell index in the next layer that is below of the current cell
         int idx = (currentCellId > 0) ? ((currentCellId - 1) / m_gridSizeRow[nextLayerId] + 1)
                                       : ((currentCellId + 1) / m_gridSizeRow[nextLayerId] - 1);
-        _decoder->set(nID, m_rowID, idx);
+        decoder()->set(nID, m_rowIndex, idx);
         cellNeighbours.push_back(nID); // add the cell from the next layer of the same phi module
 
         //
         if ((m_gridSizeRow[nextLayerId] - abs(currentCellId) % m_gridSizeRow[nextLayerId]) ==
                 (m_gridSizeRow[nextLayerId] - 1) &&
             currentCellId > minCellId) {
-          _decoder->set(nID, m_rowID, (idx > 0) ? (idx - 1) : (idx + 1));
+          decoder()->set(nID, m_rowIndex, (idx > 0) ? (idx - 1) : (idx + 1));
           cellNeighbours.push_back(nID); // add the cell from the next layer of the same phi module
         }
 
         //
         if (abs(currentCellId) % m_gridSizeRow[nextLayerId] == 0 && currentCellId < maxCellId) {
-          _decoder->set(nID, m_rowID, (idx > 0) ? (idx + 1) : (idx - 1));
+          decoder()->set(nID, m_rowIndex, (idx > 0) ? (idx + 1) : (idx - 1));
           cellNeighbours.push_back(nID); // add the cell from the next layer of the same phi module
         }
       }
@@ -451,13 +449,13 @@ namespace DDSegmentation {
     // if this is not the first cell in the given layer then add the previous cell
     if (currentCellId > minCellId) {
       CellID nID = cID;
-      _decoder->set(nID, m_rowID, currentCellId - 1);
+      decoder()->set(nID, m_rowIndex, currentCellId - 1);
       cellNeighbours.push_back(nID); // add the previous cell from current layer of the same phi module
     }
     // if this is not the last cell in the given layer then add the next cell
     if (currentCellId < maxCellId) {
       CellID nID = cID;
-      _decoder->set(nID, m_rowID, currentCellId + 1);
+      decoder()->set(nID, m_rowIndex, currentCellId + 1);
       cellNeighbours.push_back(nID); // add the next cell from current layer of the same phi module
     }
 
@@ -485,8 +483,8 @@ namespace DDSegmentation {
               (currentLayerRmin >= Rmin && currentLayerRmin <= Rmax) ||
               (currentLayerRmax >= Rmin && currentLayerRmax <= Rmax)) {
             CellID nID = cID;
-            _decoder->set(nID, m_layerID, part2layerId);
-            _decoder->set(nID, m_rowID, minCellId);
+            decoder()->set(nID, m_layerIndex, part2layerId);
+            decoder()->set(nID, m_rowIndex, minCellId);
             cellNeighbours.push_back(nID); // add the first cell from part2 layer
           }
         }
@@ -510,8 +508,8 @@ namespace DDSegmentation {
                 (currentLayerRmin >= Rmin && currentLayerRmin <= Rmax) ||
                 (currentLayerRmax >= Rmin && currentLayerRmax <= Rmax)) {
               CellID nID = cID;
-              _decoder->set(nID, m_layerID, prevPartLayerId);
-              _decoder->set(nID, m_rowID, maxCellId);
+              decoder()->set(nID, m_layerIndex, prevPartLayerId);
+              decoder()->set(nID, m_rowIndex, maxCellId);
               cellNeighbours.push_back(nID); // add the last cell from the previous part layer
             }
           }
@@ -529,8 +527,8 @@ namespace DDSegmentation {
                 (currentLayerRmin >= Rmin && currentLayerRmin <= Rmax) ||
                 (currentLayerRmax >= Rmin && currentLayerRmax <= Rmax)) {
               CellID nID = cID;
-              _decoder->set(nID, m_layerID, nextPartLayerId);
-              _decoder->set(nID, m_rowID, minCellId);
+              decoder()->set(nID, m_layerIndex, nextPartLayerId);
+              decoder()->set(nID, m_rowIndex, minCellId);
               cellNeighbours.push_back(nID); // add the first cell from the next part layer
             }
           }
@@ -550,8 +548,8 @@ namespace DDSegmentation {
               (currentLayerRmin >= Rmin && currentLayerRmin <= Rmax) ||
               (currentLayerRmax >= Rmin && currentLayerRmax <= Rmax)) {
             CellID nID = cID;
-            _decoder->set(nID, m_layerID, prevPartLayerId);
-            _decoder->set(nID, m_rowID, maxCellId);
+            decoder()->set(nID, m_layerIndex, prevPartLayerId);
+            decoder()->set(nID, m_rowIndex, maxCellId);
             cellNeighbours.push_back(nID); // add the last cell from the part2 layer
           }
         }
@@ -563,24 +561,26 @@ namespace DDSegmentation {
     for (auto nID : cellNeighboursCopy) {
       CellID newID = nID;
       // previous: if the current is 0 then previous is the last bin (id = m_phiBins - 1) else current - 1
-      _decoder->set(newID, m_phiID,
-                    (_decoder->get(nID, m_phiID) == 0) ? m_phiBins - 1 : _decoder->get(nID, m_phiID) - 1);
+      decoder()->set(newID, m_phiIndex,
+                     (decoder()->get(nID, m_phiIndex) == 0) ? m_phiBins - 1 : decoder()->get(nID, m_phiIndex) - 1);
       cellNeighbours.push_back(newID);
       // next: if the current is the last bin (id = m_phiBins - 1) then the next is the first bin (id = 0) else current
       // + 1
-      _decoder->set(newID, m_phiID,
-                    (_decoder->get(nID, m_phiID) == (m_phiBins - 1)) ? 0 : _decoder->get(nID, m_phiID) + 1);
+      decoder()->set(newID, m_phiIndex,
+                     (decoder()->get(nID, m_phiIndex) == (m_phiBins - 1)) ? 0 : decoder()->get(nID, m_phiIndex) + 1);
       cellNeighbours.push_back(newID);
     }
 
     // At the end, find neighbours with the same layer/row in next/previous phi module
     CellID nID = cID;
     // previous: if the current is 0 then previous is the last bin (id = m_phiBins - 1) else current - 1
-    _decoder->set(nID, m_phiID, (_decoder->get(cID, m_phiID) == 0) ? m_phiBins - 1 : _decoder->get(cID, m_phiID) - 1);
+    decoder()->set(nID, m_phiIndex,
+                   (decoder()->get(cID, m_phiIndex) == 0) ? m_phiBins - 1 : decoder()->get(cID, m_phiIndex) - 1);
     cellNeighbours.push_back(nID);
     // next: if the current is the last bin (id = m_phiBins - 1) then the next is the first bin (id = 0) else current +
     // 1
-    _decoder->set(nID, m_phiID, (_decoder->get(cID, m_phiID) == (m_phiBins - 1)) ? 0 : _decoder->get(cID, m_phiID) + 1);
+    decoder()->set(nID, m_phiIndex,
+                   (decoder()->get(cID, m_phiIndex) == (m_phiBins - 1)) ? 0 : decoder()->get(cID, m_phiIndex) + 1);
     cellNeighbours.push_back(nID);
 
     return cellNeighbours;
@@ -594,13 +594,13 @@ namespace DDSegmentation {
   }
 
   /// Determine minimum and maximum polar angle of the cell
-  std::array<double, 2> FCCSWHCalPhiRow_k4geo::cellTheta(const CellID& cID) const {
+  std::array<double, 2> FCCSWHCalPhiRow_k4geo::cellTheta(const CellID cID) const {
     std::array<double, 2> cTheta = {M_PI, M_PI};
 
     // get the cell index
-    int idx = _decoder->get(cID, m_rowID);
+    int idx = decoder()->get(cID, m_rowIndex);
     // get the layer index
-    uint layer = _decoder->get(cID, m_layerID);
+    uint layer = decoder()->get(cID, m_layerIndex);
 
     if (m_radii.empty())
       calculateLayerRadii();

--- a/detectorSegmentations/src/GridEta_k4geo.cpp
+++ b/detectorSegmentations/src/GridEta_k4geo.cpp
@@ -4,7 +4,12 @@ namespace dd4hep {
 namespace DDSegmentation {
 
   /// default constructor using an encoding string
-  GridEta_k4geo::GridEta_k4geo(const std::string& cellEncoding) : Segmentation(cellEncoding) {
+  GridEta_k4geo::GridEta_k4geo(const std::string& cellEncoding) : Segmentation(cellEncoding) { commonSetup(); }
+
+  GridEta_k4geo::GridEta_k4geo(const BitFieldCoder* decoder) : Segmentation(decoder) { commonSetup(); }
+
+  /// Initialization common to all ctors.
+  void GridEta_k4geo::commonSetup() {
     // define type and description
     _type = "GridEta_k4geo";
     _description = "Eeta segmentation in the global coordinates";
@@ -13,17 +18,8 @@ namespace DDSegmentation {
     registerParameter("grid_size_eta", "Cell size in eta", m_gridSizeEta, 1., SegmentationParameter::LengthUnit);
     registerParameter("offset_eta", "Angular offset in eta", m_offsetEta, 0., SegmentationParameter::AngleUnit, true);
     registerIdentifier("identifier_eta", "Cell ID identifier for eta", m_etaID, "eta");
-  }
 
-  GridEta_k4geo::GridEta_k4geo(const BitFieldCoder* decoder) : Segmentation(decoder) {
-    // define type and description
-    _type = "GridEta_k4geo";
-    _description = "Eta segmentation in the global coordinates";
-
-    // register all necessary parameters
-    registerParameter("grid_size_eta", "Cell size in eta", m_gridSizeEta, 1., SegmentationParameter::LengthUnit);
-    registerParameter("offset_eta", "Angular offset in eta", m_offsetEta, 0., SegmentationParameter::AngleUnit, true);
-    registerIdentifier("identifier_eta", "Cell ID identifier for eta", m_etaID, "eta");
+    m_etaIndex = decoder()->index(m_etaID);
   }
 
   /// determine the local based on the cell ID
@@ -34,19 +30,13 @@ namespace DDSegmentation {
                                const VolumeID& vID) const {
     CellID cID = vID;
     double lEta = etaFromXYZ(globalPosition);
-    _decoder->set(cID, m_etaID, positionToBin(lEta, m_gridSizeEta, m_offsetEta));
+    decoder()->set(cID, m_etaIndex, positionToBin(lEta, m_gridSizeEta, m_offsetEta));
     return cID;
   }
 
-  /// determine the pseudorapidity based on the current cell ID
-  // double GridEta_k4geo::eta() const {
-  //   CellID etaValue = (*_decoder)[m_etaID].value();
-  //   return binToPosition(etaValue, m_gridSizeEta, m_offsetEta);
-  // }
-
   /// determine the pseudorapidity based on the cell ID
-  double GridEta_k4geo::eta(const CellID& cID) const {
-    CellID etaValue = _decoder->get(cID, m_etaID);
+  double GridEta_k4geo::eta(const CellID cID) const {
+    CellID etaValue = decoder()->get(cID, m_etaIndex);
     return binToPosition(etaValue, m_gridSizeEta, m_offsetEta);
   }
 

--- a/detectorSegmentations/src/GridEta_k4geo.cpp
+++ b/detectorSegmentations/src/GridEta_k4geo.cpp
@@ -12,7 +12,7 @@ namespace DDSegmentation {
   void GridEta_k4geo::commonSetup() {
     // define type and description
     _type = "GridEta_k4geo";
-    _description = "Eeta segmentation in the global coordinates";
+    _description = "Eta segmentation in the global coordinates";
 
     // register all necessary parameters
     registerParameter("grid_size_eta", "Cell size in eta", m_gridSizeEta, 1., SegmentationParameter::LengthUnit);

--- a/detectorSegmentations/src/GridRPhiEta_k4geo.cpp
+++ b/detectorSegmentations/src/GridRPhiEta_k4geo.cpp
@@ -5,19 +5,13 @@ namespace DDSegmentation {
 
   /// default constructor using an encoding string
   GridRPhiEta_k4geo::GridRPhiEta_k4geo(const std::string& cellEncoding) : FCCSWGridPhiEta_k4geo(cellEncoding) {
-    // define type and description
-    _type = "GridRPhiEta_k4geo";
-    _description = "R-phi-eta segmentation in the global coordinates";
-
-    // register all necessary parameters (additional to those registered in FCCSWGridPhiEta_k4geo)
-    registerParameter("grid_size_r", "Cell size in radial distance", m_gridSizeR, 1.,
-                      SegmentationParameter::LengthUnit);
-    registerParameter("offset_r", "Angular offset in radial distance", m_offsetR, 0., SegmentationParameter::LengthUnit,
-                      true);
-    registerIdentifier("identifier_r", "Cell ID identifier for R", m_rID, "r");
+    commonSetup();
   }
 
-  GridRPhiEta_k4geo::GridRPhiEta_k4geo(const BitFieldCoder* decoder) : FCCSWGridPhiEta_k4geo(decoder) {
+  GridRPhiEta_k4geo::GridRPhiEta_k4geo(const BitFieldCoder* decoder) : FCCSWGridPhiEta_k4geo(decoder) { commonSetup(); }
+
+  /// Initialization common to all ctors.
+  void GridRPhiEta_k4geo::commonSetup() {
     // define type and description
     _type = "GridRPhiEta_k4geo";
     _description = "R-phi-eta segmentation in the global coordinates";
@@ -28,6 +22,10 @@ namespace DDSegmentation {
     registerParameter("offset_r", "Angular offset in radial distance", m_offsetR, 0., SegmentationParameter::LengthUnit,
                       true);
     registerIdentifier("identifier_r", "Cell ID identifier for R", m_rID, "r");
+
+    m_etaIndex = decoder()->index(fieldNameEta());
+    m_phiIndex = decoder()->index(fieldNamePhi());
+    m_rIndex = decoder()->index(m_rID);
   }
 
   /// determine the local based on the cell ID
@@ -42,21 +40,15 @@ namespace DDSegmentation {
     double lRadius = radiusFromXYZ(globalPosition);
     double lEta = etaFromXYZ(globalPosition);
     double lPhi = phiFromXYZ(globalPosition);
-    _decoder->set(cID, m_etaID, positionToBin(lEta, m_gridSizeEta, m_offsetEta));
-    _decoder->set(cID, m_phiID, positionToBin(lPhi, 2 * M_PI / (double)m_phiBins, m_offsetPhi));
-    _decoder->set(cID, m_rID, positionToBin(lRadius, m_gridSizeR, m_offsetR));
+    decoder()->set(cID, m_etaIndex, positionToBin(lEta, gridSizeEta(), offsetEta()));
+    decoder()->set(cID, m_phiIndex, positionToBin(lPhi, 2 * M_PI / (double)phiBins(), offsetPhi()));
+    decoder()->set(cID, m_rIndex, positionToBin(lRadius, m_gridSizeR, m_offsetR));
     return cID;
   }
 
-  /// determine the radial distance R based on the current cell ID
-  // double GridRPhiEta_k4geo::r() const {
-  //   CellID rValue = (*_decoder)[m_rID].value();
-  //   return binToPosition(rValue, m_gridSizeR, m_offsetR);
-  // }
-
   /// determine the radial distance R based on the cell ID
-  double GridRPhiEta_k4geo::r(const CellID& cID) const {
-    CellID rValue = _decoder->get(cID, m_rID);
+  double GridRPhiEta_k4geo::r(const CellID cID) const {
+    CellID rValue = decoder()->get(cID, m_rIndex);
     return binToPosition(rValue, m_gridSizeR, m_offsetR);
   }
 } // namespace DDSegmentation

--- a/detectorSegmentations/src/GridTheta_k4geo.cpp
+++ b/detectorSegmentations/src/GridTheta_k4geo.cpp
@@ -12,7 +12,7 @@ namespace DDSegmentation {
   void GridTheta_k4geo::commonSetup() {
     // define type and description
     _type = "GridTheta_k4geo";
-    _description = "Etheta segmentation in the global coordinates";
+    _description = "Theta segmentation in the global coordinates";
 
     // register all necessary parameters
     registerParameter("grid_size_theta", "Cell size in Theta", m_gridSizeTheta, 1., SegmentationParameter::LengthUnit);

--- a/detectorSegmentations/src/GridTheta_k4geo.cpp
+++ b/detectorSegmentations/src/GridTheta_k4geo.cpp
@@ -4,19 +4,12 @@ namespace dd4hep {
 namespace DDSegmentation {
 
   /// default constructor using an encoding string
-  GridTheta_k4geo::GridTheta_k4geo(const std::string& cellEncoding) : Segmentation(cellEncoding) {
-    // define type and description
-    _type = "GridTheta_k4geo";
-    _description = "Theta segmentation in the global coordinates";
+  GridTheta_k4geo::GridTheta_k4geo(const std::string& cellEncoding) : Segmentation(cellEncoding) { commonSetup(); }
 
-    // register all necessary parameters
-    registerParameter("grid_size_theta", "Cell size in Theta", m_gridSizeTheta, 1., SegmentationParameter::LengthUnit);
-    registerParameter("offset_theta", "Angular offset in theta", m_offsetTheta, 0., SegmentationParameter::AngleUnit,
-                      true);
-    registerIdentifier("identifier_theta", "Cell ID identifier for theta", m_thetaID, "theta");
-  }
+  GridTheta_k4geo::GridTheta_k4geo(const BitFieldCoder* decoder) : Segmentation(decoder) { commonSetup(); }
 
-  GridTheta_k4geo::GridTheta_k4geo(const BitFieldCoder* decoder) : Segmentation(decoder) {
+  /// Initialization common to all ctors.
+  void GridTheta_k4geo::commonSetup() {
     // define type and description
     _type = "GridTheta_k4geo";
     _description = "Etheta segmentation in the global coordinates";
@@ -26,6 +19,8 @@ namespace DDSegmentation {
     registerParameter("offset_theta", "Angular offset in theta", m_offsetTheta, 0., SegmentationParameter::AngleUnit,
                       true);
     registerIdentifier("identifier_theta", "Cell ID identifier for theta", m_thetaID, "theta");
+
+    m_thetaIndex = decoder()->index(m_thetaID);
   }
 
   /// determine the local based on the cell ID
@@ -36,19 +31,13 @@ namespace DDSegmentation {
                                  const VolumeID& vID) const {
     CellID cID = vID;
     double lTheta = thetaFromXYZ(globalPosition);
-    _decoder->set(cID, m_thetaID, positionToBin(lTheta, m_gridSizeTheta, m_offsetTheta));
+    decoder()->set(cID, m_thetaIndex, positionToBin(lTheta, m_gridSizeTheta, m_offsetTheta));
     return cID;
   }
 
-  /// determine the pseudorapidity based on the current cell ID
-  // double GridTheta_k4geo::theta() const {
-  //   CellID thetaValue = (*_decoder)[m_thetaID].value();
-  //   return binToPosition(thetaValue, m_gridSizeTheta, m_offsetTheta);
-  // }
-
   /// determine the polar angle theta based on the cell ID
-  double GridTheta_k4geo::theta(const CellID& cID) const {
-    CellID thetaValue = _decoder->get(cID, m_thetaID);
+  double GridTheta_k4geo::theta(const CellID cID) const {
+    CellID thetaValue = decoder()->get(cID, m_thetaIndex);
     return binToPosition(thetaValue, m_gridSizeTheta, m_offsetTheta);
   }
 

--- a/detectorSegmentations/src/SCEPCal_MainSegmentation_k4geo.cpp
+++ b/detectorSegmentations/src/SCEPCal_MainSegmentation_k4geo.cpp
@@ -13,32 +13,36 @@ namespace DDSegmentation {
 
   SCEPCal_MainSegmentation_k4geo::SCEPCal_MainSegmentation_k4geo(const std::string& cellEncoding)
       : Segmentation(cellEncoding) {
-    _type = "SCEPCal_MainSegmentation_k4geo";
-    _description = "SCEPCal main layer segmentation";
-    registerIdentifier("identifier_system", "Cell ID identifier for System", fSystemId, "system");
-    registerIdentifier("identifier_phi", "Cell ID identifier for Phi", fPhiId, "phi");
-    registerIdentifier("identifier_theta", "Cell ID identifier for Theta", fThetaId, "theta");
-    registerIdentifier("identifier_gamma", "Cell ID identifier for Gamma", fGammaId, "gamma");
-    registerIdentifier("identifier_epsilon", "Cell ID identifier for Epsilon", fEpsilonId, "epsilon");
-    registerIdentifier("identifier_depth", "Cell ID identifier for Depth", fDepthId, "depth");
+    commonSetup();
   }
 
   SCEPCal_MainSegmentation_k4geo::SCEPCal_MainSegmentation_k4geo(const BitFieldCoder* decoder) : Segmentation(decoder) {
-    _type = "SCEPCal_MainSegmentation_k4geo";
-    _description = "SCEPCal main layer segmentation";
-    registerIdentifier("identifier_system", "Cell ID identifier for System", fSystemId, "system");
-    registerIdentifier("identifier_phi", "Cell ID identifier for Phi", fPhiId, "phi");
-    registerIdentifier("identifier_theta", "Cell ID identifier for Theta", fThetaId, "theta");
-    registerIdentifier("identifier_gamma", "Cell ID identifier for Gamma", fGammaId, "gamma");
-    registerIdentifier("identifier_epsilon", "Cell ID identifier for Epsilon", fEpsilonId, "epsilon");
-    registerIdentifier("identifier_depth", "Cell ID identifier for Depth", fDepthId, "depth");
+    commonSetup();
   }
 
-  SCEPCal_MainSegmentation_k4geo::~SCEPCal_MainSegmentation_k4geo() {}
+  /// Initialization common to all ctors.
+  void SCEPCal_MainSegmentation_k4geo::commonSetup() {
+    _type = "SCEPCal_MainSegmentation_k4geo";
+    _description = "SCEPCal main layer segmentation";
+    registerIdentifier("identifier_system", "Cell ID identifier for System", m_systemId, "system");
+    registerIdentifier("identifier_phi", "Cell ID identifier for Phi", m_phiId, "phi");
+    registerIdentifier("identifier_theta", "Cell ID identifier for Theta", m_thetaId, "theta");
+    registerIdentifier("identifier_gamma", "Cell ID identifier for Gamma", m_gammaId, "gamma");
+    registerIdentifier("identifier_epsilon", "Cell ID identifier for Epsilon", m_epsilonId, "epsilon");
+    registerIdentifier("identifier_depth", "Cell ID identifier for Depth", m_depthId, "depth");
+
+    m_systemIndex = decoder()->index(m_systemId);
+    m_phiIndex = decoder()->index(m_phiId);
+    m_thetaIndex = decoder()->index(m_thetaId);
+    m_gammaIndex = decoder()->index(m_gammaId);
+    m_epsilonIndex = decoder()->index(m_epsilonId);
+    m_depthIndex = decoder()->index(m_depthId);
+  }
 
   Vector3D SCEPCal_MainSegmentation_k4geo::position(const CellID& cellId) const {
-    if (fPositionOf.find(cellId) != fPositionOf.end()) {
-      return fPositionOf.find(cellId)->second;
+    auto it = m_positionOf.find(cellId);
+    if (it != m_positionOf.end()) {
+      return it->second;
     }
     dd4hep::printout(dd4hep::WARNING, "SCEPCal_MainSegmentation_k4geo::position",
                      "cellID %lld not found, returning (0,0,0)!", cellId);

--- a/detectorSegmentations/src/SCEPCal_TimingSegmentation_k4geo.cpp
+++ b/detectorSegmentations/src/SCEPCal_TimingSegmentation_k4geo.cpp
@@ -13,29 +13,33 @@ namespace DDSegmentation {
 
   SCEPCal_TimingSegmentation_k4geo::SCEPCal_TimingSegmentation_k4geo(const std::string& cellEncoding)
       : Segmentation(cellEncoding) {
-    _type = "SCEPCal_TimingSegmentation_k4geo";
-    _description = "SCEPCal timing layer segmentation";
-    registerIdentifier("identifier_system", "Cell ID identifier for System", fSystemId, "system");
-    registerIdentifier("identifier_phi", "Cell ID identifier for Phi", fPhiId, "phi");
-    registerIdentifier("identifier_theta", "Cell ID identifier for Theta", fThetaId, "theta");
-    registerIdentifier("identifier_gamma", "Cell ID identifier for Gamma", fGammaId, "gamma");
+    commonSetup();
   }
 
   SCEPCal_TimingSegmentation_k4geo::SCEPCal_TimingSegmentation_k4geo(const BitFieldCoder* decoder)
       : Segmentation(decoder) {
-    _type = "SCEPCal_TimingSegmentation_k4geo";
-    _description = "SCEPCal timing layer segmentation";
-    registerIdentifier("identifier_system", "Cell ID identifier for System", fSystemId, "system");
-    registerIdentifier("identifier_phi", "Cell ID identifier for Phi", fPhiId, "phi");
-    registerIdentifier("identifier_theta", "Cell ID identifier for Theta", fThetaId, "theta");
-    registerIdentifier("identifier_gamma", "Cell ID identifier for Gamma", fGammaId, "gamma");
+    commonSetup();
   }
 
-  SCEPCal_TimingSegmentation_k4geo::~SCEPCal_TimingSegmentation_k4geo() {}
+  /// Initialization common to all ctors.
+  void SCEPCal_TimingSegmentation_k4geo::commonSetup() {
+    _type = "SCEPCal_TimingSegmentation_k4geo";
+    _description = "SCEPCal timing layer segmentation";
+    registerIdentifier("identifier_system", "Cell ID identifier for System", m_systemId, "system");
+    registerIdentifier("identifier_phi", "Cell ID identifier for Phi", m_phiId, "phi");
+    registerIdentifier("identifier_theta", "Cell ID identifier for Theta", m_thetaId, "theta");
+    registerIdentifier("identifier_gamma", "Cell ID identifier for Gamma", m_gammaId, "gamma");
+
+    m_systemIndex = decoder()->index(m_systemId);
+    m_phiIndex = decoder()->index(m_phiId);
+    m_thetaIndex = decoder()->index(m_thetaId);
+    m_gammaIndex = decoder()->index(m_gammaId);
+  }
 
   Vector3D SCEPCal_TimingSegmentation_k4geo::position(const CellID& cellId) const {
-    if (fPositionOf.find(cellId) != fPositionOf.end()) {
-      return fPositionOf.find(cellId)->second;
+    auto it = m_positionOf.find(cellId);
+    if (it != m_positionOf.end()) {
+      return it->second;
     }
 
     dd4hep::printout(dd4hep::WARNING, "SCEPCal_TimingSegmentation_k4geo::position",


### PR DESCRIPTION
 - Avoid directly using protected members from base classes when there is a public accessor.  Change protected members to private.
 - Remember field indices, to avoid having to always do string lookups.
 - Factor out duplicated code between constructors.
 - Naming convention consistency (use m_ for class data members).
 - Prefer to pass simple types by value, and to return vector members as const references.
 - Use override keywords.


BEGINRELEASENOTES
- Code cleanups in the segmentation classes.
ENDRELEASENOTES

