### PR TITLE
Refactor of ARC test: correct cellID assignment

### DIFF
--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -105,58 +105,32 @@ if __name__ == "__main__":
         ROOT.gROOT.SetBatch(1)
         rootfile = ROOT.TFile(SIM.outputFile)
         number_of_events = []
-        if "edm4hep" not in SIM.outputFile:
-            EVENT = rootfile.Get("EVENT")
-            n1 = EVENT.Draw(
-                "ArcCollection.position.Z():ArcCollection.position.phi()",
-                "((ArcCollection.cellID>>5)&0x7)==0",
-            )
-            number_of_events.append(n1)
-            ROOT.gPad.SaveAs(outImagePrefix + "barrel_" + SIM.gun.particle + ".png")
-            n2 = EVENT.Draw(
-                "ArcCollection.position.Y():ArcCollection.position.X()",
-                "((ArcCollection.cellID>>5)&0x7)==1",
-            )
-            number_of_events.append(n2)
-            ROOT.gPad.SaveAs(outImagePrefix + "endcapZpos_" + SIM.gun.particle + ".png")
-            n3 = EVENT.Draw(
-                "ArcCollection.position.Y():ArcCollection.position.X()",
-                "((ArcCollection.cellID>>5)&0x7)==2",
-            )
-            number_of_events.append(n3)
-            ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + ".png")
-            EVENT.Draw(
-                "ArcCollection.position.Y():ArcCollection.position.X()",
-                "((ArcCollection.cellID>>5)&0x7)==2&&ArcCollection.position.Y()>0&&ArcCollection.position.X()>0",
-            )
-            ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + "zoom.png")
-        else:
-            EVENT = rootfile.Get("events")
-            n1 = EVENT.Draw(
-                "ArcCollection.position.z:atan(ArcCollection.position.y/ArcCollection.position.x)",
-                "((ArcCollection.cellID>>5)&0x7)==0&& ArcCollection.position.x>0",
-            )
-            number_of_events.append(n1)
-            ROOT.gPad.SaveAs(outImagePrefix + "barrel_" + SIM.gun.particle + ".png")
-            n2 = EVENT.Draw(
-                "ArcCollection.position.y:ArcCollection.position.x",
-                "((ArcCollection.cellID>>5)&0x7)==1",
-            )
-            number_of_events.append(n2)
-            ROOT.gPad.SaveAs(outImagePrefix + "endcapZpos_" + SIM.gun.particle + ".png")
-            n3 = EVENT.Draw(
-                "ArcCollection.position.y:ArcCollection.position.x",
-                "((ArcCollection.cellID>>5)&0x7)==2",
-            )
-            number_of_events.append(n3)
-            ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + ".png")
-            EVENT.Draw(
-                "ArcCollection.position.y:ArcCollection.position.x",
-                "((ArcCollection.cellID>>5)&0x7)==2&& ArcCollection.position.x>0&& ArcCollection.position.y>0",
-            )
-            ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + "zoom.png")
-
+        EVENT = rootfile.Get("EVENT")
+        n1 = EVENT.Draw(
+            "ArcCollection.position.Z():ArcCollection.position.phi()",
+            "((ArcCollection.cellID>>5)&0x7)==0",
+        )
+        number_of_events.append(n1)
+        ROOT.gPad.SaveAs(outImagePrefix + "barrel_" + SIM.gun.particle + ".png")
+        n2 = EVENT.Draw(
+            "ArcCollection.position.Y():ArcCollection.position.X()",
+            "((ArcCollection.cellID>>5)&0x7)==1",
+        )
+        number_of_events.append(n2)
+        ROOT.gPad.SaveAs(outImagePrefix + "endcapZpos_" + SIM.gun.particle + ".png")
+        n3 = EVENT.Draw(
+            "ArcCollection.position.Y():ArcCollection.position.X()",
+            "((ArcCollection.cellID>>5)&0x7)==2",
+        )
+        number_of_events.append(n3)
+        ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + ".png")
+        EVENT.Draw(
+            "ArcCollection.position.Y():ArcCollection.position.X()",
+            "((ArcCollection.cellID>>5)&0x7)==2&&ArcCollection.position.Y()>0&&ArcCollection.position.X()>0",
+        )
+        ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + "zoom.png")
         rootfile.Close()
+
         if any(0 == val for val in number_of_events):
             logger.fatal("TEST: failed. At least 1 ARC subsystem did not record any hit")
             raise RuntimeError("TEST: failed. At least 1 ARC subsystem did not record any hit")

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     SIM.filter.mapDetFilter["ARCBARREL"] = None
     SIM.filter.mapDetFilter["ARCENDCAP"] = None
 
-    # Use the optical tracker for the PFRICH
+    # Use DD4hep optical tracker
     SIM.action.mapActions["ARCBARREL"] = "Geant4OpticalTrackerAction"
     SIM.action.mapActions["ARCENDCAP"] = "Geant4OpticalTrackerAction"
 

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -104,22 +104,26 @@ if __name__ == "__main__":
         outImagePrefix = "arcsim_"
         ROOT.gROOT.SetBatch(1)
         rootfile = ROOT.TFile(SIM.outputFile)
+        number_of_events = []
         if not "edm4hep" in SIM.outputFile:
             EVENT = rootfile.Get("EVENT")
-            EVENT.Draw(
+            n1 = EVENT.Draw(
                 "ArcCollection.position.Z():ArcCollection.position.phi()",
                 "((ArcCollection.cellID>>5)&0x7)==0",
             )
+            number_of_events.append(n1)
             ROOT.gPad.SaveAs(outImagePrefix + "barrel_" + SIM.gun.particle + ".png")
-            EVENT.Draw(
+            n2 = EVENT.Draw(
                 "ArcCollection.position.Y():ArcCollection.position.X()",
                 "((ArcCollection.cellID>>5)&0x7)==1",
             )
+            number_of_events.append(n2)
             ROOT.gPad.SaveAs(outImagePrefix + "endcapZpos_" + SIM.gun.particle + ".png")
-            EVENT.Draw(
+            n3 = EVENT.Draw(
                 "ArcCollection.position.Y():ArcCollection.position.X()",
                 "((ArcCollection.cellID>>5)&0x7)==2",
             )
+            number_of_events.append(n3)
             ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + ".png")
             EVENT.Draw(
                 "ArcCollection.position.Y():ArcCollection.position.X()",
@@ -150,8 +154,11 @@ if __name__ == "__main__":
             ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + "zoom.png")
 
         rootfile.Close()
-
-        logger.info("TEST: passed")
+        if any(0 == val for val in number_of_events):
+        	logger.fatal("TEST: failed. At least 1 ARC subsystem did not record any hit")
+        	raise RuntimeError("TEST: failed. At least 1 ARC subsystem did not record any hit")
+        else:
+                logger.info("TEST: passed")
 
     except NameError as e:
         logger.fatal("TEST: failed")

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -132,20 +132,23 @@ if __name__ == "__main__":
             ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + "zoom.png")
         else:
             EVENT = rootfile.Get("events")
-            EVENT.Draw(
+            n1 = EVENT.Draw(
                 "ArcCollection.position.z:atan(ArcCollection.position.y/ArcCollection.position.x)",
                 "((ArcCollection.cellID>>5)&0x7)==0&& ArcCollection.position.x>0",
             )
+            number_of_events.append(n1)
             ROOT.gPad.SaveAs(outImagePrefix + "barrel_" + SIM.gun.particle + ".png")
-            EVENT.Draw(
+            n2 = EVENT.Draw(
                 "ArcCollection.position.y:ArcCollection.position.x",
                 "((ArcCollection.cellID>>5)&0x7)==1",
             )
+            number_of_events.append(n2)
             ROOT.gPad.SaveAs(outImagePrefix + "endcapZpos_" + SIM.gun.particle + ".png")
-            EVENT.Draw(
+            n3 = EVENT.Draw(
                 "ArcCollection.position.y:ArcCollection.position.x",
                 "((ArcCollection.cellID>>5)&0x7)==2",
             )
+            number_of_events.append(n3)
             ROOT.gPad.SaveAs(outImagePrefix + "endcapZneg_" + SIM.gun.particle + ".png")
             EVENT.Draw(
                 "ArcCollection.position.y:ArcCollection.position.x",

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         ph = PhysicsList(kernel, "Geant4OpticalPhotonPhysics/OpticalGammaPhys")
         ph.addParticleConstructor("G4OpticalPhoton")
         ph.VerboseLevel = 0
-        ph.BoundaryInvokeSD = True
+        ph.BoundaryInvokeSD = False
         ph.enableUI()
         seq.adopt(ph)
         return None

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -91,7 +91,6 @@ if __name__ == "__main__":
     SIM.outputFile = "arcsim.root"
     if hasattr(SIM, "outputConfig") and hasattr(SIM.outputConfig, "forceDD4HEP"):
         SIM.outputConfig.forceDD4HEP = True  # use DD4hep root format, not EDM4HEP
-    # SIM.outputFile = "arcsim_edm4hep.root"
 
     # Override with user options
     SIM.parseOptions()

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -45,14 +45,14 @@ if __name__ == "__main__":
         ph = PhysicsList(kernel, "Geant4OpticalPhotonPhysics/OpticalGammaPhys")
         ph.addParticleConstructor("G4OpticalPhoton")
         ph.VerboseLevel = 0
-	# BoundaryInvokeSD is disabled:
-	# if the SD action is triggered at a boundary, the default cellID calculation fails
-	# because DD4hep uses the step midpoint, which lies outside the active volume,
-	# making a valid cellID assignment impossible.
-	# Temporary workaround: ARC light sensors are given a fake refractive index so
-	# photons enter the active volume and the default DD4hep SD action for
-	# opticalTracker can be used.
-	# A custom SD action would be required to safely enable this option.
+        # BoundaryInvokeSD is disabled:
+        # if the SD action is triggered at a boundary, the default cellID calculation fails
+        # because DD4hep uses the step midpoint, which lies outside the active volume,
+        # making a valid cellID assignment impossible.
+        # Temporary workaround: ARC light sensors are given a fake refractive index so
+        # photons enter the active volume and the default DD4hep SD action for
+        # opticalTracker can be used.
+        # A custom SD action would be required to safely enable this option.
         ph.BoundaryInvokeSD = False
         ph.enableUI()
         seq.adopt(ph)
@@ -158,10 +158,10 @@ if __name__ == "__main__":
 
         rootfile.Close()
         if any(0 == val for val in number_of_events):
-        	logger.fatal("TEST: failed. At least 1 ARC subsystem did not record any hit")
-        	raise RuntimeError("TEST: failed. At least 1 ARC subsystem did not record any hit")
+            logger.fatal("TEST: failed. At least 1 ARC subsystem did not record any hit")
+            raise RuntimeError("TEST: failed. At least 1 ARC subsystem did not record any hit")
         else:
-                logger.info("TEST: passed")
+            logger.info("TEST: passed")
 
     except NameError as e:
         logger.fatal("TEST: failed")

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -60,16 +60,9 @@ if __name__ == "__main__":
 
     SIM.physics.setupUserPhysics(setupCerenkov)
 
-    # Allow energy depositions to 0 energy in trackers (which include optical detectors)
-    SIM.filter.tracker = "edep0"
-
-    # Some detectors are only sensitive to optical photons
-    SIM.filter.filters["opticalphotons"] = dict(
-        name="ParticleSelectFilter/OpticalPhotonSelector",
-        parameter={"particle": "opticalphoton"},
-    )
-    SIM.filter.mapDetFilter["ARCBARREL"] = "opticalphotons"
-    SIM.filter.mapDetFilter["ARCENDCAP"] = "opticalphotons"
+    # Disable filtering for ARC detectors (no hits are filtered out)
+    SIM.filter.mapDetFilter["ARCBARREL"] = None
+    SIM.filter.mapDetFilter["ARCENDCAP"] = None
 
     # Use the optical tracker for the PFRICH
     SIM.action.mapActions["ARCBARREL"] = "Geant4OpticalTrackerAction"

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         ROOT.gROOT.SetBatch(1)
         rootfile = ROOT.TFile(SIM.outputFile)
         number_of_events = []
-        if not "edm4hep" in SIM.outputFile:
+        if "edm4hep" not in SIM.outputFile:
             EVENT = rootfile.Get("EVENT")
             n1 = EVENT.Draw(
                 "ArcCollection.position.Z():ArcCollection.position.phi()",

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -45,6 +45,14 @@ if __name__ == "__main__":
         ph = PhysicsList(kernel, "Geant4OpticalPhotonPhysics/OpticalGammaPhys")
         ph.addParticleConstructor("G4OpticalPhoton")
         ph.VerboseLevel = 0
+	# BoundaryInvokeSD is disabled:
+	# if the SD action is triggered at a boundary, the default cellID calculation fails
+	# because DD4hep uses the step midpoint, which lies outside the active volume,
+	# making a valid cellID assignment impossible.
+	# Temporary workaround: ARC light sensors are given a fake refractive index so
+	# photons enter the active volume and the default DD4hep SD action for
+	# opticalTracker can be used.
+	# A custom SD action would be required to safely enable this option.
         ph.BoundaryInvokeSD = False
         ph.enableUI()
         seq.adopt(ph)

--- a/example/arcfullsim.py
+++ b/example/arcfullsim.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     SIM.action.mapActions["ARCBARREL"] = "Geant4OpticalTrackerAction"
     SIM.action.mapActions["ARCENDCAP"] = "Geant4OpticalTrackerAction"
 
-    # Disable user tracker particle handler, so hits can be associated to photons
+    # Disable user tracker particle handler because no tracking region is defined in arc_full_v0.xml
     SIM.part.userParticleHandler = ""
 
     # Particle gun settings: pions with fixed energy and theta, varying phi


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [not applicable] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [not applicable] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [not applicable] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Refactor of the ARC DDSim configuration example, used in CI. The main change is that hit cellID assignment now works correctly, thanks to consistent handling between the optical physics configuration (SD not triggered at boundaries) and the DD4hep SD action for the optical tracker.

ENDRELEASENOTES

