### PR TITLE
FCChh TrackerOnly layout

### DIFF
--- a/FCChh/compact/FCChhBaseline/FCChh_DectDimensions-v02.xml
+++ b/FCChh/compact/FCChhBaseline/FCChh_DectDimensions-v02.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="FCCDectDimensions"
+    title="master file with includes and world dimension"
+    author="C. Helsens, J. Lingemann"
+    url="no"
+    status="development"
+    version="1.0">
+    <comment>
+        Dimensions for FCChhBaseline1: Design with Twin Solenoid, 6 T, 12 m bore, 10 Tm dipole
+        Sources: FCC hadron detector meeting 31 Aug 2016 (excel table): https://indico.cern.ch/event/557687/
+                 FCC hadron detector meeting 28 Sep 2016 (slides): https://indico.cern.ch/event/557688/
+                 Reference Geometry v7, can be found: /eos/experiment/fcc/hh/simulation/reference_geometry_5m_4T_v7.pdf
+    </comment>
+  </info>
+
+
+  <define>
+    <!-- BEAM PIPE -->
+    <constant name="CentralBeamTube_dz" value="800.0*cm"/>
+    <constant name="CentralBeamTube_rmax" value="2.08*cm"/>
+    <constant name="CentralBeamTube_rmin" value="2.*cm"/>
+
+    <constant name="ForwardBeamTube_rmin1" value="2.*cm"/>
+    <constant name="ForwardBeamTube_rmax1" value="2.08*cm"/>
+    <constant name="ForwardBeamTube_rmin2" value="6.15*cm"/>
+    <constant name="ForwardBeamTube_rmax2" value="6.23*cm"/>
+    <constant name="ForwardBeamTube_dz" value="850*cm"/>
+    <constant name="ForwardBeamTube_zOffset" value="CentralBeamTube_dz + ForwardBeamTube_dz"/>
+
+    <!-- MAGNET SYSTEM -->
+    <!-- Central Solenoid -->
+    <constant name="BarSolenoid_dz" value="950*cm"/>
+    <constant name="BarSolenoid_rmin" value="5450*mm"/>
+    <constant name="BarSolenoid_rmax" value="6000*mm"/>
+    <constant name="BarSolenoidCryo1_rmin" value="5000*mm"/>
+    <constant name="BarSolenoidCryo1_rmax" value="5090*mm"/>
+    <constant name="BarSolenoidCryo_dz" value="10000*mm"/>
+    <constant name="BarSolenoidCryo2_rmin" value="6250*mm"/>
+    <constant name="BarSolenoidCryo2_rmax" value="6305*mm"/>
+    <constant name="BarSolenoidCryoFlange_dz" value="53.5*mm"/>
+    <constant name="BarSolenoidCryoFlange_offset" value="BarSolenoidCryo_dz-BarSolenoidCryoFlange_dz"/>
+
+    <!-- Forward Solenoids -->
+    <constant name="FwdSolenoid_dz" value="1700*mm"/>
+    <constant name="FwdSolenoid_rmin" value="280*cm"/>
+    <constant name="FwdSolenoid_rmax" value="307*cm"/>
+    <constant name="FwdSolenoid_zOffset" value="1230*cm+FwdSolenoid_dz"/>
+    <constant name="FwdSolenoidCryo1_rmin" value="2650*mm"/>
+    <constant name="FwdSolenoidCryo1_rmax" value="2670*mm"/>
+    <constant name="FwdSolenoidCryo_dz" value="2135*mm"/>
+    <constant name="FwdSolenoidCryo2_rmin" value="3500*mm"/>
+    <constant name="FwdSolenoidCryo2_rmax" value="3560*mm"/>
+    <constant name="FwdSolenoidCryoFlange1_dz" value="35*mm"/>
+    <constant name="FwdSolenoidCryoFlange2_dz" value="100*mm"/>
+    <constant name="FwdSolenoidCryoFlange1_offset" value="FwdSolenoid_zOffset-FwdSolenoidCryo_dz+FwdSolenoidCryoFlange1_dz"/>
+    <constant name="FwdSolenoidCryoFlange2_offset" value="FwdSolenoid_zOffset+FwdSolenoidCryo_dz-FwdSolenoidCryoFlange2_dz"/>
+
+    <!-- TRACKER DIMENSIONS -->
+    <constant name="Tracker_rmin" value="23.28*mm"/>
+    <constant name="Tracker_rmax" value="1700*mm"/>
+    <constant name="Tracker_dz" value="5009.7*mm"/>
+    <!-- Tracker Barrel -->
+    <constant name="BarTrackerInner_id" value="4"/>
+    <constant name="BarTrackerOuter_id" value="5"/>
+    <!-- not explicitly defined, up to tracker design -->
+
+    <!-- Tracker End-caps -->
+    <constant name="EndCapTrackerInner_id" value="6"/>
+    <constant name="EndCapTrackerOuter_id" value="7"/>
+
+    <!-- Tracker Forward Inner -->
+    <constant name="FwdTracker_id" value="8"/>
+
+    <!-- single layer close to ExCal -->
+    <constant name="FwdTracker_rmin1" value="40*mm"/>
+    <constant name="FwdTracker_rmax1" value="1076.8*mm"/>
+    <constant name="FwdTracker_zOffset1" value="7500*mm"/>
+    <!-- the rest of the tracking layers inside the forward solenoid / shielding -->
+    <constant name="FwdTracker_rmin2" value="60*mm"/>
+    <constant name="FwdTracker_rmax2" value="1549.8*mm"/>
+    <constant name="FwdTracker_z2" value="3009.65*mm"/>
+    <constant name="FwdTracker_zOffset2" value="10*m + FwdTracker_z2"/>
+
+    <!-- CALORIMETER DIMENSIONS -->
+    <!-- ECal Barrel (EM B) -->
+    <constant name="BarECal_id" value="10"/>
+    <constant name="BarECal_rmin" value="1750*mm"/>
+    <constant name="BarECal_rmax" value="2750*mm"/>
+    <constant name="BarECal_dz" value="5000*mm"/>
+    <!-- HCal Barrel (HCAL B) -->
+    <constant name="BarHCal_id" value="13"/>
+    <constant name="BarHCal_rmin" value="2850*mm"/>
+    <constant name="BarHCal_rmax" value="4890*mm"/>
+    <constant name="BarHCal_dz" value="4600*mm"/>
+    <!-- Calorimeter endcaps (EMEC + HEC)-->
+    <constant name="ExtBarECal_id" value="11"/>
+    <constant name="HadronicEndCap_id" value="12"/>
+    <constant name="ExtBarCal_dz" value="1500*mm"/>
+    <constant name="ExtBarCal_zOffset" value="5300*mm + ExtBarCal_dz"/>
+    <constant name="ExtBarCal_rmin1" value="(ExtBarCal_zOffset - ExtBarCal_dz)* tan (2*atan(exp(-2.5))) - 0.1*m"/>
+    <constant name="ExtBarCal_rmin2" value="(ExtBarCal_zOffset + ExtBarCal_dz)* tan (2*atan(exp(-2.5))) - 0.1*m"/>
+    <constant name="ExtBarCal_rmax" value="2700*mm"/>
+    <!-- HCal extended barrel (HCAL EB) -->
+    <constant name="ExtBarHCal_id" value="14"/>
+    <constant name="ExtBarHCal1_rmin" value="3500*mm"/>
+    <constant name="ExtBarHCal1_rmax" value="4590*mm"/>
+    <constant name="ExtBarHCal2_rmin" value="2850*mm"/>
+    <constant name="ExtBarHCal2_rmax" value="4590*mm"/>
+    <constant name="ExtBarHCal1_dz" value="150*mm"/>
+    <constant name="ExtBarHCal1_zOffset" value="5000*mm + ExtBarHCal1_dz"/>
+    <constant name="ExtBarHCal2_dz" value="1600*mm"/>
+    <constant name="ExtBarHCal2_zOffset" value="ExtBarHCal1_zOffset + ExtBarHCal1_dz + ExtBarHCal2_dz"/>
+    <!-- Forward calorimeters (EMFWD + HFWD) -->
+    <constant name="FwdECal_id" value="15"/>
+    <constant name="FwdHCal_id" value="16"/>
+    <constant name="FwdCal_dz" value="1500*mm"/>
+    <constant name="FwdCal_zOffset" value="16500*mm + FwdCal_dz"/>
+    <constant name="FwdCal_rmin1" value="(FwdCal_zOffset - FwdCal_dz) * tan (2*atan(exp(-6.5)))"/>
+    <constant name="FwdCal_rmin2" value="(FwdCal_zOffset + FwdCal_dz) * tan (2*atan(exp(-6.5)))"/>
+    <constant name="FwdCal_active_rmin1" value="(FwdCal_zOffset - FwdCal_dz) * tan (2*atan(exp(-6)))"/>
+    <constant name="FwdCal_active_rmin2" value="(FwdCal_zOffset + FwdCal_dz) * tan (2*atan(exp(-6)))"/>
+    <constant name="FwdCal_rmax" value="3600*mm"/>
+
+    <!-- MUON SYSTEM DIMENSIONS -->
+    <!-- Muon system barrel -->
+    <constant name="BarMuon_id" value="17"/>
+    <constant name="BarMuon_rmin1" value="5250*mm"/>
+    <constant name="BarMuon_rmax1" value="9000*mm"/>
+    <constant name="BarMuon_z1" value="13000*mm"/>
+    <constant name="BarMuon_rmin2" value="5245*mm"/>
+    <constant name="BarMuon_rmax2" value="6500*mm"/>
+    <constant name="BarMuon_z2" value="10500*mm"/>
+    <!-- Muon system end-caps -->
+    <constant name="EndCapMuon_id" value="18"/>
+    <constant name="EndCapMuon_rmin1" value="2458.67*mm"/>
+    <constant name="EndCapMuon_rmax1" value="4750*mm"/>
+    <constant name="EndCapMuon_rmin2" value="2724.47*mm"/>
+    <constant name="EndCapMuon_rmax2" value="4750*mm"/>
+    <constant name="EndCapMuon_dz" value="500*mm"/>
+    <constant name="EndCapMuon_zOffset" value="9500*mm"/>
+
+    <!-- Muon system forward -->
+    <constant name="FwdBarMuon_id" value="19"/>
+    <constant name="FwdBarMuon_rmin" value="5250*mm"/>
+    <constant name="FwdBarMuon_rmax" value="7000*mm"/>
+    <constant name="FwdBarMuon_dz" value="1750*mm"/>
+    <constant name="FwdBarMuon_zOffset" value="14000*mm + FwdBarMuon_dz"/>
+
+    <constant name="FwdMuon_id" value="20"/>
+    <constant name="FwdMuon_rmin" value="62.3*mm"/>
+    <constant name="FwdMuon_rmax" value="7000*mm"/>
+    <constant name="FwdMuon_dz" value="1500*mm"/>
+    <constant name="FwdMuon_zOffset" value="19700*mm + FwdMuon_dz"/> 
+
+    <include ref="FCChh_DetectorTypes.xml" />
+
+  </define>
+
+</lccdd>

--- a/FCChh/compact/FCChhBaseline/FCChh_DetectorTypes.xml
+++ b/FCChh/compact/FCChhBaseline/FCChh_DetectorTypes.xml
@@ -1,0 +1,30 @@
+<!--
+    define global constants with enums defined in 
+    $DD4hepINSTALL/DDCore/include/DD4hep/DetType.h
+    NB: if that file is changed this file needs to
+        be manually updated correspondingly !!
+
+   author: F.Gaede, DESY 02/2016
+
+   **copied over from OpenDataDetector 
+-->
+<define>
+  <constant name="DetType_TRACKER"         value =  " 0x1 "/>
+  <constant name="DetType_CALORIMETER"     value =  " 0x2 "/>
+  <constant name="DetType_CHERENKOV"       value =  " 0x4 "/>
+  <constant name="DetType_ENDCAP"          value =  " 0x8 "/>
+  <constant name="DetType_BARREL"          value =  " 0x10 "/>
+  <constant name="DetType_FORWARD"         value =  " 0x20 "/>
+  <constant name="DetType_VERTEX"          value =  " 0x40 "/>
+  <constant name="DetType_STRIP"           value =  " 0x80 "/>
+  <constant name="DetType_PIXEL"           value =  " 0x100 "/>
+  <constant name="DetType_GASEOUS"         value =  " 0x200 "/>
+  <constant name="DetType_WIRE"            value =  " 0x400 "/>
+  <constant name="DetType_ELECTROMAGNETIC" value =  " 0x800 "/>
+  <constant name="DetType_HADRONIC"        value =  " 0x1000 "/>
+  <constant name="DetType_MUON"            value =  " 0x2000 "/>
+  <constant name="DetType_SUPPORT"         value =  " 0x4000 "/>
+  <constant name="DetType_BEAMPIPE"        value =  " 0x8000 "/>
+  <constant name="DetType_COIL"            value =  " 0x10000 "/>
+  <constant name="DetType_AUXILIARY"       value =  " 0x20000 "/>
+</define>

--- a/FCChh/compact/FCChhBaseline/FCChh_MaterialBinning.xml
+++ b/FCChh/compact/FCChhBaseline/FCChh_MaterialBinning.xml
@@ -1,0 +1,30 @@
+<!-- made phi symmetric for now -->
+<lccdd>
+    <define>
+        <!-- Material binning section -->
+        <!-- beam pipe section -->
+        <constant name="mat_bp_bPhi" value="1"/>  <!-- change phi bins to 1 everywhere -->
+        <constant name="mat_bp_bZ" value="10"/>
+        <!-- pixel section -->
+        <constant name="mat_pix_barrel_bPhi" value="144"/>  <!-- change phi bins to 1 everywhere -->
+        <constant name="mat_pix_barrel_bZ" value="200"/>
+        <constant name="mat_pix_endcap_bPhi" value="1"/>    <!-- change phi bins to 1 everywhere -->
+        <constant name="mat_pix_endcap_bR" value="150"/>
+        <!-- PST section -->
+        <constant name="mat_pst_bPhi" value="1"/>          <!-- change phi bins to 1 everywhere -->
+        <constant name="mat_pst_bZ" value="100"/>
+        <!-- short strip section -->
+        <constant name="mat_sst_barrel_bPhi" value="144"/>    <!-- change phi bins to 1 everywhere -->
+        <constant name="mat_sst_barrel_bZ" value="150"/>
+        <constant name="mat_sst_endcap_bPhi" value="1"/>    <!-- change phi bins to 1 everywhere -->
+        <constant name="mat_sst_endcap_bR" value="150"/>
+        <!-- long strip section -->
+        <constant name="mat_lst_barrel_bPhi" value="144"/>   <!-- change phi bins to 1 everywhere -->
+        <constant name="mat_lst_barrel_bZ" value="250"/>
+        <constant name="mat_lst_endcap_bPhi" value="1"/>    <!-- change phi bins to 1 everywhere -->
+        <constant name="mat_lst_endcap_bR" value="100"/>
+        <!-- Solenoid section -->
+        <constant name="mat_sol_bPhi" value="1"/>     <!-- change phi bins to 1 everywhere -->
+        <constant name="mat_sol_bZ" value="100"/>
+    </define>
+</lccdd>

--- a/FCChh/compact/FCChhBaseline/FCChh_TrackerOnly.xml
+++ b/FCChh/compact/FCChhBaseline/FCChh_TrackerOnly.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <includes>
+    <gdmlFile  ref="Common/elements.xml"/>
+    <gdmlFile  ref="Common/materials.xml"/>
+  </includes>  
+
+  <info name="FCCDectMaster"
+    title="master file with includes and world dimension"
+    author="C. Helsens"
+    url="no"
+    status="development"
+    version="1.0">
+    <comment>master file with includes and world dimension</comment>
+  </info>
+  <define>
+    <constant name="world_size" value="25*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+  </define>
+  <include ref="./FCChh_DectDimensions-v02.xml" />
+  <include ref="./FCChh_Visualisation.xml" />  
+  <include ref="./FCChh_MaterialBinning.xml"/>
+
+  <!-- Including the sub-detectors / volume definitions -->
+
+  <!-- ***** Version3 ***** -->
+  <include ref="./TrackerTkLayout-v02/Tracker.xml" />
+
+</lccdd>

--- a/FCChh/compact/FCChhBaseline/TrackerTkLayout-v02/FCChh_v3.03_Definitions.xml
+++ b/FCChh/compact/FCChhBaseline/TrackerTkLayout-v02/FCChh_v3.03_Definitions.xml
@@ -1,0 +1,2624 @@
+<detectors>
+    <detector name="InnerBRL" id="BarTrackerInner_id" type="TkLayoutTrackerBarrel_o1_v02" readout="TrackerBarrelReadout">
+        <type_flags type="DetType_TRACKER + DetType_BARREL"/> <!--I added-->
+        <dimensions rmin="23.283*mm" rmax="409.734*mm" zmin="-820.000*mm" zmax="820.000*mm"/>
+        <boundary_material surface="negative" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
+        <boundary_material surface="outer" binning="binPhi,binZ" bins0="mat_pix_barrel_bPhi" bins1="mat_pix_barrel_bZ"/>
+        <boundary_material surface="positive" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <layers repeat="4">
+            <layer id="0" name ="layer0" radius="25.000*mm" rmin="25.000*mm" rmax="27.473*mm" bigDelta="1.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_pix_barrel_bPhi" bins1="mat_pix_barrel_bZ"/>
+                <rods repeat="14" smallDelta="0.000*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="20">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="26.000*mm" Z="-650.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="26.000*mm" Z="-582.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="26.000*mm" Z="-513.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="26.000*mm" Z="-445.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="26.000*mm" Z="-376.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="26.000*mm" Z="-308.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="26.000*mm" Z="-239.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="26.000*mm" Z="-171.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="26.000*mm" Z="-102.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="26.000*mm" Z="-34.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="26.000*mm" Z="34.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="26.000*mm" Z="102.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="26.000*mm" Z="171.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="26.000*mm" Z="239.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="26.000*mm" Z="308.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="26.000*mm" Z="376.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="26.000*mm" Z="445.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="26.000*mm" Z="513.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="26.000*mm" Z="582.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="26.000*mm" Z="650.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="68.500*mm" modWidth="12.800*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="68.500*mm" sensorWidth="12.800*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-10.413*mm" Y="21.623*mm" Z="-650.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-10.413*mm" Y="21.623*mm" Z="-582.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-10.413*mm" Y="21.623*mm" Z="-513.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-10.413*mm" Y="21.623*mm" Z="-445.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-10.413*mm" Y="21.623*mm" Z="-376.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-10.413*mm" Y="21.623*mm" Z="-308.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-10.413*mm" Y="21.623*mm" Z="-239.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-10.413*mm" Y="21.623*mm" Z="-171.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-10.413*mm" Y="21.623*mm" Z="-102.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-10.413*mm" Y="21.623*mm" Z="-34.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-10.413*mm" Y="21.623*mm" Z="34.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-10.413*mm" Y="21.623*mm" Z="102.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-10.413*mm" Y="21.623*mm" Z="171.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-10.413*mm" Y="21.623*mm" Z="239.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-10.413*mm" Y="21.623*mm" Z="308.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-10.413*mm" Y="21.623*mm" Z="376.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-10.413*mm" Y="21.623*mm" Z="445.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-10.413*mm" Y="21.623*mm" Z="513.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-10.413*mm" Y="21.623*mm" Z="582.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-10.413*mm" Y="21.623*mm" Z="650.750*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="68.500*mm" modWidth="12.800*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="68.500*mm" sensorWidth="12.800*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="1" name ="layer1" radius="60.000*mm" rmin="58.283*mm" rmax="63.030*mm" bigDelta="1.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_pix_barrel_bPhi" bins1="mat_pix_barrel_bZ"/>
+                <rods repeat="16" smallDelta="0.000*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="40">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="61.000*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="61.000*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="61.000*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="61.000*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="61.000*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="61.000*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="61.000*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="61.000*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="61.000*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="61.000*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="61.000*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="61.000*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="61.000*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="61.000*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="61.000*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="61.000*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="61.000*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="61.000*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="61.000*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="61.000*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="61.000*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="61.000*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="61.000*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="61.000*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="61.000*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="61.000*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="61.000*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="61.000*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="61.000*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="61.000*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="61.000*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="61.000*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="61.000*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="61.000*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="61.000*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="61.000*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="61.000*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="61.000*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="61.000*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="61.000*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-22.578*mm" Y="54.509*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-22.578*mm" Y="54.509*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-22.578*mm" Y="54.509*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-22.578*mm" Y="54.509*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-22.578*mm" Y="54.509*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-22.578*mm" Y="54.509*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-22.578*mm" Y="54.509*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-22.578*mm" Y="54.509*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-22.578*mm" Y="54.509*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-22.578*mm" Y="54.509*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-22.578*mm" Y="54.509*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-22.578*mm" Y="54.509*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-22.578*mm" Y="54.509*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-22.578*mm" Y="54.509*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-22.578*mm" Y="54.509*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-22.578*mm" Y="54.509*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-22.578*mm" Y="54.509*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-22.578*mm" Y="54.509*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-22.578*mm" Y="54.509*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-22.578*mm" Y="54.509*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-22.578*mm" Y="54.509*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-22.578*mm" Y="54.509*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-22.578*mm" Y="54.509*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-22.578*mm" Y="54.509*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-22.578*mm" Y="54.509*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-22.578*mm" Y="54.509*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-22.578*mm" Y="54.509*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-22.578*mm" Y="54.509*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-22.578*mm" Y="54.509*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-22.578*mm" Y="54.509*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-22.578*mm" Y="54.509*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-22.578*mm" Y="54.509*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-22.578*mm" Y="54.509*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-22.578*mm" Y="54.509*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-22.578*mm" Y="54.509*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-22.578*mm" Y="54.509*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-22.578*mm" Y="54.509*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-22.578*mm" Y="54.509*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-22.578*mm" Y="54.509*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-22.578*mm" Y="54.509*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="2" name ="layer2" radius="100.000*mm" rmin="98.283*mm" rmax="102.519*mm" bigDelta="1.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_pix_barrel_bPhi" bins1="mat_pix_barrel_bZ"/>
+                <rods repeat="26" smallDelta="0.000*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="40">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="101.000*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="101.000*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="101.000*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="101.000*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="101.000*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="101.000*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="101.000*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="101.000*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="101.000*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="101.000*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="101.000*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="101.000*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="101.000*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="101.000*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="101.000*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="101.000*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="101.000*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="101.000*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="101.000*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="101.000*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="101.000*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="101.000*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="101.000*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="101.000*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="101.000*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="101.000*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="101.000*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="101.000*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="101.000*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="101.000*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="101.000*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="101.000*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="101.000*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="101.000*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="101.000*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="101.000*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="101.000*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="101.000*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="101.000*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="101.000*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-23.692*mm" Y="96.123*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-23.692*mm" Y="96.123*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-23.692*mm" Y="96.123*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-23.692*mm" Y="96.123*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-23.692*mm" Y="96.123*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-23.692*mm" Y="96.123*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-23.692*mm" Y="96.123*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-23.692*mm" Y="96.123*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-23.692*mm" Y="96.123*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-23.692*mm" Y="96.123*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-23.692*mm" Y="96.123*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-23.692*mm" Y="96.123*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-23.692*mm" Y="96.123*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-23.692*mm" Y="96.123*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-23.692*mm" Y="96.123*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-23.692*mm" Y="96.123*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-23.692*mm" Y="96.123*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-23.692*mm" Y="96.123*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-23.692*mm" Y="96.123*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-23.692*mm" Y="96.123*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-23.692*mm" Y="96.123*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-23.692*mm" Y="96.123*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-23.692*mm" Y="96.123*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-23.692*mm" Y="96.123*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-23.692*mm" Y="96.123*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-23.692*mm" Y="96.123*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-23.692*mm" Y="96.123*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-23.692*mm" Y="96.123*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-23.692*mm" Y="96.123*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-23.692*mm" Y="96.123*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-23.692*mm" Y="96.123*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-23.692*mm" Y="96.123*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-23.692*mm" Y="96.123*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-23.692*mm" Y="96.123*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-23.692*mm" Y="96.123*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-23.692*mm" Y="96.123*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-23.692*mm" Y="96.123*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-23.692*mm" Y="96.123*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-23.692*mm" Y="96.123*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-23.692*mm" Y="96.123*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="3" name ="layer3" radius="150.000*mm" rmin="148.283*mm" rmax="152.256*mm" bigDelta="1.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_pix_barrel_bPhi" bins1="mat_pix_barrel_bZ"/>
+                <rods repeat="38" smallDelta="0.000*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="40">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="151.000*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="151.000*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="151.000*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="151.000*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="151.000*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="151.000*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="151.000*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="151.000*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="151.000*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="151.000*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="151.000*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="151.000*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="151.000*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="151.000*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="151.000*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="151.000*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="151.000*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="151.000*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="151.000*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="151.000*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="151.000*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="151.000*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="151.000*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="151.000*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="151.000*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="151.000*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="151.000*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="151.000*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="151.000*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="151.000*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="151.000*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="151.000*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="151.000*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="151.000*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="151.000*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="151.000*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="151.000*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="151.000*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="151.000*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="151.000*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-24.525*mm" Y="146.968*mm" Z="-799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-24.525*mm" Y="146.968*mm" Z="-758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-24.525*mm" Y="146.968*mm" Z="-717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-24.525*mm" Y="146.968*mm" Z="-676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-24.525*mm" Y="146.968*mm" Z="-635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-24.525*mm" Y="146.968*mm" Z="-594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-24.525*mm" Y="146.968*mm" Z="-553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-24.525*mm" Y="146.968*mm" Z="-512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-24.525*mm" Y="146.968*mm" Z="-471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-24.525*mm" Y="146.968*mm" Z="-430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-24.525*mm" Y="146.968*mm" Z="-389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-24.525*mm" Y="146.968*mm" Z="-348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-24.525*mm" Y="146.968*mm" Z="-307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-24.525*mm" Y="146.968*mm" Z="-266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-24.525*mm" Y="146.968*mm" Z="-225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-24.525*mm" Y="146.968*mm" Z="-184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-24.525*mm" Y="146.968*mm" Z="-143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-24.525*mm" Y="146.968*mm" Z="-102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-24.525*mm" Y="146.968*mm" Z="-61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-24.525*mm" Y="146.968*mm" Z="-20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-24.525*mm" Y="146.968*mm" Z="20.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-24.525*mm" Y="146.968*mm" Z="61.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-24.525*mm" Y="146.968*mm" Z="102.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-24.525*mm" Y="146.968*mm" Z="143.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-24.525*mm" Y="146.968*mm" Z="184.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-24.525*mm" Y="146.968*mm" Z="225.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-24.525*mm" Y="146.968*mm" Z="266.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-24.525*mm" Y="146.968*mm" Z="307.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-24.525*mm" Y="146.968*mm" Z="348.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-24.525*mm" Y="146.968*mm" Z="389.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-24.525*mm" Y="146.968*mm" Z="430.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-24.525*mm" Y="146.968*mm" Z="471.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-24.525*mm" Y="146.968*mm" Z="512.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-24.525*mm" Y="146.968*mm" Z="553.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-24.525*mm" Y="146.968*mm" Z="594.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-24.525*mm" Y="146.968*mm" Z="635.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-24.525*mm" Y="146.968*mm" Z="676.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-24.525*mm" Y="146.968*mm" Z="717.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-24.525*mm" Y="146.968*mm" Z="758.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-24.525*mm" Y="146.968*mm" Z="799.500*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="41.000*mm" modWidth="25.600*mm" modThickness="1.434*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.187*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.029*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.086*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.602*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.430*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="41.000*mm" sensorWidth="25.600*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="4" name ="layer4" radius="270.000*mm" rmin="261.066*mm" rmax="280.106*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_pix_barrel_bPhi" bins1="mat_pix_barrel_bZ"/>
+                <rods repeat="34" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="17">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="272.500*mm" Z="-768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="277.500*mm" Z="-687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="272.500*mm" Z="-580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="277.500*mm" Z="-494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="272.500*mm" Z="-389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="277.500*mm" Z="-299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="272.500*mm" Z="-196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="277.500*mm" Z="-100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="272.500*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="277.500*mm" Z="100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="272.500*mm" Z="196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="277.500*mm" Z="299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="272.500*mm" Z="389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="277.500*mm" Z="494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="272.500*mm" Z="580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="277.500*mm" Z="687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="272.500*mm" Z="768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="51.200*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="51.200*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-48.234*mm" Y="258.030*mm" Z="-768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-49.153*mm" Y="262.945*mm" Z="-687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-48.234*mm" Y="258.030*mm" Z="-580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-49.153*mm" Y="262.945*mm" Z="-494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-48.234*mm" Y="258.030*mm" Z="-389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-49.153*mm" Y="262.945*mm" Z="-299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-48.234*mm" Y="258.030*mm" Z="-196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-49.153*mm" Y="262.945*mm" Z="-100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-48.234*mm" Y="258.030*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-49.153*mm" Y="262.945*mm" Z="100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-48.234*mm" Y="258.030*mm" Z="196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-49.153*mm" Y="262.945*mm" Z="299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-48.234*mm" Y="258.030*mm" Z="389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-49.153*mm" Y="262.945*mm" Z="494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-48.234*mm" Y="258.030*mm" Z="580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-49.153*mm" Y="262.945*mm" Z="687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-48.234*mm" Y="258.030*mm" Z="768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="51.200*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="51.200*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="5" name ="layer5" radius="400.000*mm" rmin="391.066*mm" rmax="409.734*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_pix_barrel_bPhi" bins1="mat_pix_barrel_bZ"/>
+                <rods repeat="50" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="2" zOverlap="0.000*mm" nModules="17">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="402.500*mm" Z="-768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="407.500*mm" Z="-687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="402.500*mm" Z="-580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="407.500*mm" Z="-494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="402.500*mm" Z="-389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="407.500*mm" Z="-299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="402.500*mm" Z="-196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="407.500*mm" Z="-100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="402.500*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="407.500*mm" Z="100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="402.500*mm" Z="196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="407.500*mm" Z="299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="402.500*mm" Z="389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="407.500*mm" Z="494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="402.500*mm" Z="580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="407.500*mm" Z="687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="402.500*mm" Z="768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="51.200*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="51.200*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-49.193*mm" Y="389.405*mm" Z="-768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-49.820*mm" Y="394.366*mm" Z="-687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-49.193*mm" Y="389.405*mm" Z="-580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-49.820*mm" Y="394.366*mm" Z="-494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-49.193*mm" Y="389.405*mm" Z="-389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-49.820*mm" Y="394.366*mm" Z="-299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-49.193*mm" Y="389.405*mm" Z="-196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-49.820*mm" Y="394.366*mm" Z="-100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-49.193*mm" Y="389.405*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-49.820*mm" Y="394.366*mm" Z="100.802*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-49.193*mm" Y="389.405*mm" Z="196.287*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-49.820*mm" Y="394.366*mm" Z="299.250*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-49.193*mm" Y="389.405*mm" Z="389.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-49.820*mm" Y="394.366*mm" Z="494.917*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-49.193*mm" Y="389.405*mm" Z="580.649*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-49.820*mm" Y="394.366*mm" Z="687.843*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-49.193*mm" Y="389.405*mm" Z="768.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="51.200*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="51.200*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+        </layers>
+    </detector>
+    <detector name="InnerECAP" id="EndCapTrackerInner_id" type="TkLayoutTrackerEndcap_o1_v02" readout="TrackerEndcapReadout">
+        <type_flags type="DetType_TRACKER + DetType_ENDCAP"/> <!--I added-->
+        <dimensions rmin="25.000*mm" rmax="403.728*mm" zmin="941.066*mm" zmax="2258.934*mm" reflect="false"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="10">
+            <discZPls id="0" z="950.000*mm" zmin="941.066*mm" zmax="958.934*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="63.049*mm" Y="0.000*mm" Z="942.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="54.602*mm" Y="31.525*mm" Z="947.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="76.099*mm" modWidthMin="13.397*mm" modWidthMax="54.179*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="76.099*mm" sensorWidthMin="13.397*mm" sensorWidthMax="54.179*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="151.685*mm" Y="0.000*mm" Z="952.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="144.261*mm" Y="46.873*mm" Z="957.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.736*mm" modWidthMin="32.094*mm" modWidthMax="64.004*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.736*mm" sensorWidthMin="32.094*mm" sensorWidthMax="64.004*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="250.156*mm" Y="0.000*mm" Z="942.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="245.349*mm" Y="48.803*mm" Z="947.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="103.074*mm" modWidthMin="39.124*mm" modWidthMax="59.428*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="103.074*mm" sensorWidthMin="39.124*mm" sensorWidthMax="59.428*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="352.521*mm" Y="0.000*mm" Z="952.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="348.933*mm" Y="50.169*mm" Z="957.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.357*mm" modWidthMin="43.248*mm" modWidthMax="57.603*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.357*mm" sensorWidthMin="43.248*mm" sensorWidthMax="57.603*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="1" z="1178.524*mm" zmin="1169.590*mm" zmax="1187.457*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+            <discZPls id="2" z="1462.019*mm" zmin="1453.085*mm" zmax="1470.953*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+            <discZPls id="3" z="1813.710*mm" zmin="1804.776*mm" zmax="1822.643*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+            <discZPls id="4" z="2250.000*mm" zmin="2241.066*mm" zmax="2258.934*mm" rmin="25.000*mm" rmax="403.728*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
+                <rings repeat="4" smallDelta="2.500*mm" rPhiOverlap="0.000*mm" nRPhiSegments="4" rOverlap="0.000*mm"/>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="OuterBRL" id="BarTrackerOuter_id" type="TkLayoutTrackerBarrel_o1_v02" readout="TrackerBarrelReadout">
+        <type_flags type="DetType_TRACKER + DetType_BARREL"/> <!--I added-->
+        <dimensions rmin="521.016*mm" rmax="1526.688*mm" zmin="-2250.000*mm" zmax="2250.000*mm"/>
+        <boundary_material surface="negative" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
+        <boundary_material surface="outer" binning="binPhi,binZ" bins0="mat_pix_barrel_bPhi" bins1="mat_pix_barrel_bZ"/>
+        <boundary_material surface="positive" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <layers repeat="6">
+            <layer id="0" radius="529.950*mm" rmin="521.016*mm" rmax="541.311*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_sst_barrel_bPhi" bins1="mat_sst_barrel_bZ"/>
+                <rods repeat="34" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="532.450*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="537.450*mm" Z="-2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="532.450*mm" Z="-2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="537.450*mm" Z="-1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="532.450*mm" Z="-1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="537.450*mm" Z="-1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="532.450*mm" Z="-1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="537.450*mm" Z="-1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="532.450*mm" Z="-1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="537.450*mm" Z="-1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="532.450*mm" Z="-1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="537.450*mm" Z="-1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="532.450*mm" Z="-1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="537.450*mm" Z="-981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="532.450*mm" Z="-879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="537.450*mm" Z="-787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="532.450*mm" Z="-685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="537.450*mm" Z="-592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="532.450*mm" Z="-491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="537.450*mm" Z="-396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="532.450*mm" Z="-295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="537.450*mm" Z="-198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="532.450*mm" Z="-98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="537.450*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="532.450*mm" Z="98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="537.450*mm" Z="198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="532.450*mm" Z="295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="537.450*mm" Z="396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="532.450*mm" Z="491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="537.450*mm" Z="592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="532.450*mm" Z="685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="537.450*mm" Z="787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="532.450*mm" Z="879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="537.450*mm" Z="981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="532.450*mm" Z="1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="537.450*mm" Z="1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="532.450*mm" Z="1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="537.450*mm" Z="1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="532.450*mm" Z="1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="537.450*mm" Z="1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="532.450*mm" Z="1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="537.450*mm" Z="1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="532.450*mm" Z="1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="537.450*mm" Z="1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="532.450*mm" Z="2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="537.450*mm" Z="2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="532.450*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-96.000*mm" Y="513.554*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-96.919*mm" Y="518.469*mm" Z="-2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-96.000*mm" Y="513.554*mm" Z="-2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-96.919*mm" Y="518.469*mm" Z="-1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-96.000*mm" Y="513.554*mm" Z="-1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-96.919*mm" Y="518.469*mm" Z="-1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-96.000*mm" Y="513.554*mm" Z="-1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-96.919*mm" Y="518.469*mm" Z="-1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-96.000*mm" Y="513.554*mm" Z="-1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-96.919*mm" Y="518.469*mm" Z="-1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-96.000*mm" Y="513.554*mm" Z="-1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-96.919*mm" Y="518.469*mm" Z="-1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-96.000*mm" Y="513.554*mm" Z="-1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-96.919*mm" Y="518.469*mm" Z="-981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-96.000*mm" Y="513.554*mm" Z="-879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-96.919*mm" Y="518.469*mm" Z="-787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-96.000*mm" Y="513.554*mm" Z="-685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-96.919*mm" Y="518.469*mm" Z="-592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-96.000*mm" Y="513.554*mm" Z="-491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-96.919*mm" Y="518.469*mm" Z="-396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-96.000*mm" Y="513.554*mm" Z="-295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-96.919*mm" Y="518.469*mm" Z="-198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-96.000*mm" Y="513.554*mm" Z="-98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-96.919*mm" Y="518.469*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-96.000*mm" Y="513.554*mm" Z="98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-96.919*mm" Y="518.469*mm" Z="198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-96.000*mm" Y="513.554*mm" Z="295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-96.919*mm" Y="518.469*mm" Z="396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-96.000*mm" Y="513.554*mm" Z="491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-96.919*mm" Y="518.469*mm" Z="592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-96.000*mm" Y="513.554*mm" Z="685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-96.919*mm" Y="518.469*mm" Z="787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-96.000*mm" Y="513.554*mm" Z="879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-96.919*mm" Y="518.469*mm" Z="981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-96.000*mm" Y="513.554*mm" Z="1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-96.919*mm" Y="518.469*mm" Z="1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-96.000*mm" Y="513.554*mm" Z="1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-96.919*mm" Y="518.469*mm" Z="1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-96.000*mm" Y="513.554*mm" Z="1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-96.919*mm" Y="518.469*mm" Z="1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-96.000*mm" Y="513.554*mm" Z="1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-96.919*mm" Y="518.469*mm" Z="1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-96.000*mm" Y="513.554*mm" Z="1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-96.919*mm" Y="518.469*mm" Z="1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-96.000*mm" Y="513.554*mm" Z="2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-96.919*mm" Y="518.469*mm" Z="2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-96.000*mm" Y="513.554*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="1" radius="742.396*mm" rmin="733.462*mm" rmax="753.072*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_sst_barrel_bPhi" bins1="mat_sst_barrel_bZ"/>
+                <rods repeat="46" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="744.896*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="749.896*mm" Z="-2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="744.896*mm" Z="-2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="749.896*mm" Z="-1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="744.896*mm" Z="-1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="749.896*mm" Z="-1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="744.896*mm" Z="-1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="749.896*mm" Z="-1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="744.896*mm" Z="-1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="749.896*mm" Z="-1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="744.896*mm" Z="-1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="749.896*mm" Z="-1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="744.896*mm" Z="-1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="749.896*mm" Z="-981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="744.896*mm" Z="-879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="749.896*mm" Z="-787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="744.896*mm" Z="-685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="749.896*mm" Z="-592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="744.896*mm" Z="-491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="749.896*mm" Z="-396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="744.896*mm" Z="-295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="749.896*mm" Z="-198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="744.896*mm" Z="-98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="749.896*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="744.896*mm" Z="98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="749.896*mm" Z="198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="744.896*mm" Z="295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="749.896*mm" Z="396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="744.896*mm" Z="491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="749.896*mm" Z="592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="744.896*mm" Z="685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="749.896*mm" Z="787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="744.896*mm" Z="879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="749.896*mm" Z="981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="744.896*mm" Z="1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="749.896*mm" Z="1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="744.896*mm" Z="1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="749.896*mm" Z="1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="744.896*mm" Z="1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="749.896*mm" Z="1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="744.896*mm" Z="1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="749.896*mm" Z="1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="744.896*mm" Z="1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="749.896*mm" Z="1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="744.896*mm" Z="2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="749.896*mm" Z="2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="744.896*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.068*mm" Y="728.051*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-100.749*mm" Y="733.005*mm" Z="-2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.068*mm" Y="728.051*mm" Z="-2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-100.749*mm" Y="733.005*mm" Z="-1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.068*mm" Y="728.051*mm" Z="-1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-100.749*mm" Y="733.005*mm" Z="-1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.068*mm" Y="728.051*mm" Z="-1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-100.749*mm" Y="733.005*mm" Z="-1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.068*mm" Y="728.051*mm" Z="-1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-100.749*mm" Y="733.005*mm" Z="-1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.068*mm" Y="728.051*mm" Z="-1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-100.749*mm" Y="733.005*mm" Z="-1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.068*mm" Y="728.051*mm" Z="-1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-100.749*mm" Y="733.005*mm" Z="-981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.068*mm" Y="728.051*mm" Z="-879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-100.749*mm" Y="733.005*mm" Z="-787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.068*mm" Y="728.051*mm" Z="-685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-100.749*mm" Y="733.005*mm" Z="-592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.068*mm" Y="728.051*mm" Z="-491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-100.749*mm" Y="733.005*mm" Z="-396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.068*mm" Y="728.051*mm" Z="-295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-100.749*mm" Y="733.005*mm" Z="-198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.068*mm" Y="728.051*mm" Z="-98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-100.749*mm" Y="733.005*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.068*mm" Y="728.051*mm" Z="98.919*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-100.749*mm" Y="733.005*mm" Z="198.793*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.068*mm" Y="728.051*mm" Z="295.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-100.749*mm" Y="733.005*mm" Z="396.350*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.068*mm" Y="728.051*mm" Z="491.511*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-100.749*mm" Y="733.005*mm" Z="592.678*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.068*mm" Y="728.051*mm" Z="685.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-100.749*mm" Y="733.005*mm" Z="787.785*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.068*mm" Y="728.051*mm" Z="879.236*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-100.749*mm" Y="733.005*mm" Z="981.679*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.068*mm" Y="728.051*mm" Z="1071.292*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-100.749*mm" Y="733.005*mm" Z="1174.366*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.068*mm" Y="728.051*mm" Z="1262.153*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-100.749*mm" Y="733.005*mm" Z="1365.856*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.068*mm" Y="728.051*mm" Z="1451.827*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-100.749*mm" Y="733.005*mm" Z="1556.154*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.068*mm" Y="728.051*mm" Z="1640.321*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-100.749*mm" Y="733.005*mm" Z="1745.269*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.068*mm" Y="728.051*mm" Z="1827.643*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-100.749*mm" Y="733.005*mm" Z="1933.208*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.068*mm" Y="728.051*mm" Z="2013.801*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-100.749*mm" Y="733.005*mm" Z="2119.978*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.068*mm" Y="728.051*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="2" radius="937.244*mm" rmin="927.950*mm" rmax="947.921*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_sst_barrel_bPhi" bins1="mat_sst_barrel_bZ"/>
+                <rods repeat="58" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="939.744*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="944.744*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="939.744*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="944.744*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="939.744*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="944.744*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="939.744*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="944.744*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="939.744*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="944.744*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="939.744*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="944.744*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="939.744*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="944.744*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="939.744*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="944.744*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="939.744*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="944.744*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="939.744*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="944.744*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="939.744*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="944.744*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="939.744*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="944.744*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="939.744*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="944.744*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="939.744*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="944.744*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="939.744*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="944.744*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="939.744*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="944.744*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="939.744*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="944.744*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="939.744*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="944.744*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="939.744*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="944.744*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="939.744*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="944.744*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="939.744*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="944.744*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="939.744*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="944.744*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="939.744*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="944.744*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="939.744*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.523*mm" Y="924.294*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-101.064*mm" Y="929.264*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.523*mm" Y="924.294*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-101.064*mm" Y="929.264*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.523*mm" Y="924.294*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-101.064*mm" Y="929.264*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.523*mm" Y="924.294*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-101.064*mm" Y="929.264*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.523*mm" Y="924.294*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-101.064*mm" Y="929.264*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.523*mm" Y="924.294*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-101.064*mm" Y="929.264*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.523*mm" Y="924.294*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-101.064*mm" Y="929.264*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.523*mm" Y="924.294*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-101.064*mm" Y="929.264*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.523*mm" Y="924.294*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-101.064*mm" Y="929.264*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.523*mm" Y="924.294*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-101.064*mm" Y="929.264*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.523*mm" Y="924.294*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-101.064*mm" Y="929.264*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.523*mm" Y="924.294*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-101.064*mm" Y="929.264*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.523*mm" Y="924.294*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-101.064*mm" Y="929.264*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.523*mm" Y="924.294*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-101.064*mm" Y="929.264*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.523*mm" Y="924.294*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-101.064*mm" Y="929.264*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.523*mm" Y="924.294*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-101.064*mm" Y="929.264*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.523*mm" Y="924.294*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-101.064*mm" Y="929.264*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.523*mm" Y="924.294*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-101.064*mm" Y="929.264*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.523*mm" Y="924.294*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-101.064*mm" Y="929.264*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.523*mm" Y="924.294*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-101.064*mm" Y="929.264*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.523*mm" Y="924.294*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-101.064*mm" Y="929.264*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.523*mm" Y="924.294*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-101.064*mm" Y="929.264*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.523*mm" Y="924.294*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-101.064*mm" Y="929.264*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.523*mm" Y="924.294*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="3" radius="1132.012*mm" rmin="1122.718*mm" rmax="1142.453*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_sst_barrel_bPhi" bins1="mat_sst_barrel_bZ"/>
+                <rods repeat="70" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="1134.512*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="1139.512*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="1134.512*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="1139.512*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="1134.512*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="1139.512*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="1134.512*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="1139.512*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="1134.512*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="1139.512*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="1134.512*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="1139.512*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="1134.512*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="1139.512*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="1134.512*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="1139.512*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="1134.512*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="1139.512*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="1134.512*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="1139.512*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="1134.512*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="1139.512*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="1134.512*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="1139.512*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="1134.512*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="1139.512*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="1134.512*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="1139.512*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="1134.512*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="1139.512*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="1134.512*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="1139.512*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="1134.512*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="1139.512*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="1134.512*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="1139.512*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="1134.512*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="1139.512*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="1134.512*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="1139.512*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="1134.512*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="1139.512*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="1134.512*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="1139.512*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="1134.512*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="1139.512*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="1134.512*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.800*mm" Y="1119.985*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-101.249*mm" Y="1124.965*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.800*mm" Y="1119.985*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-101.249*mm" Y="1124.965*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.800*mm" Y="1119.985*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-101.249*mm" Y="1124.965*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.800*mm" Y="1119.985*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-101.249*mm" Y="1124.965*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.800*mm" Y="1119.985*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-101.249*mm" Y="1124.965*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.800*mm" Y="1119.985*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-101.249*mm" Y="1124.965*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.800*mm" Y="1119.985*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-101.249*mm" Y="1124.965*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.800*mm" Y="1119.985*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-101.249*mm" Y="1124.965*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.800*mm" Y="1119.985*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-101.249*mm" Y="1124.965*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.800*mm" Y="1119.985*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-101.249*mm" Y="1124.965*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.800*mm" Y="1119.985*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-101.249*mm" Y="1124.965*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.800*mm" Y="1119.985*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-101.249*mm" Y="1124.965*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.800*mm" Y="1119.985*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-101.249*mm" Y="1124.965*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.800*mm" Y="1119.985*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-101.249*mm" Y="1124.965*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.800*mm" Y="1119.985*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-101.249*mm" Y="1124.965*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.800*mm" Y="1119.985*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-101.249*mm" Y="1124.965*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.800*mm" Y="1119.985*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-101.249*mm" Y="1124.965*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.800*mm" Y="1119.985*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-101.249*mm" Y="1124.965*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.800*mm" Y="1119.985*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-101.249*mm" Y="1124.965*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.800*mm" Y="1119.985*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-101.249*mm" Y="1124.965*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.800*mm" Y="1119.985*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-101.249*mm" Y="1124.965*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.800*mm" Y="1119.985*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-101.249*mm" Y="1124.965*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.800*mm" Y="1119.985*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-101.249*mm" Y="1124.965*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.800*mm" Y="1119.985*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="4" radius="1326.735*mm" rmin="1317.441*mm" rmax="1337.009*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_sst_barrel_bPhi" bins1="mat_sst_barrel_bZ"/>
+                <rods repeat="82" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="1329.235*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="1334.235*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="1329.235*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="1334.235*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="1329.235*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="1334.235*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="1329.235*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="1334.235*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="1329.235*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="1334.235*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="1329.235*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="1334.235*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="1329.235*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="1334.235*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="1329.235*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="1334.235*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="1329.235*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="1334.235*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="1329.235*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="1334.235*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="1329.235*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="1334.235*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="1329.235*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="1334.235*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="1329.235*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="1334.235*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="1329.235*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="1334.235*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="1329.235*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="1334.235*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="1329.235*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="1334.235*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="1329.235*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="1334.235*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="1329.235*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="1334.235*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="1329.235*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="1334.235*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="1329.235*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="1334.235*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="1329.235*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="1334.235*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="1329.235*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="1334.235*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="1329.235*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="1334.235*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="1329.235*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.986*mm" Y="1315.364*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-101.369*mm" Y="1320.349*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.986*mm" Y="1315.364*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-101.369*mm" Y="1320.349*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.986*mm" Y="1315.364*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-101.369*mm" Y="1320.349*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.986*mm" Y="1315.364*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-101.369*mm" Y="1320.349*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.986*mm" Y="1315.364*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-101.369*mm" Y="1320.349*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.986*mm" Y="1315.364*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-101.369*mm" Y="1320.349*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.986*mm" Y="1315.364*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-101.369*mm" Y="1320.349*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.986*mm" Y="1315.364*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-101.369*mm" Y="1320.349*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.986*mm" Y="1315.364*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-101.369*mm" Y="1320.349*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.986*mm" Y="1315.364*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-101.369*mm" Y="1320.349*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.986*mm" Y="1315.364*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-101.369*mm" Y="1320.349*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.986*mm" Y="1315.364*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-101.369*mm" Y="1320.349*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.986*mm" Y="1315.364*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-101.369*mm" Y="1320.349*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.986*mm" Y="1315.364*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-101.369*mm" Y="1320.349*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.986*mm" Y="1315.364*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-101.369*mm" Y="1320.349*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.986*mm" Y="1315.364*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-101.369*mm" Y="1320.349*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.986*mm" Y="1315.364*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-101.369*mm" Y="1320.349*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.986*mm" Y="1315.364*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-101.369*mm" Y="1320.349*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.986*mm" Y="1315.364*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-101.369*mm" Y="1320.349*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.986*mm" Y="1315.364*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-101.369*mm" Y="1320.349*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.986*mm" Y="1315.364*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-101.369*mm" Y="1320.349*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.986*mm" Y="1315.364*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-101.369*mm" Y="1320.349*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.986*mm" Y="1315.364*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-101.369*mm" Y="1320.349*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.986*mm" Y="1315.364*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+            <layer id="5" radius="1516.536*mm" rmin="1507.243*mm" rmax="1526.688*mm" bigDelta="5.000*mm" phi0="1.570796*rad">
+                <layer_material surface="outer" binning="binPhi,binZ" bins0="mat_sst_barrel_bPhi" bins1="mat_sst_barrel_bZ"/>
+                <rods repeat="96" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="2" zOverlap="0.750*mm" nModules="47">
+                    <rodOdd id="1">
+                        <modules>
+                            <module id="1" X="0.000*mm" Y="1519.036*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="0.000*mm" Y="1524.036*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="0.000*mm" Y="1519.036*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="0.000*mm" Y="1524.036*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="0.000*mm" Y="1519.036*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="0.000*mm" Y="1524.036*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="0.000*mm" Y="1519.036*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="0.000*mm" Y="1524.036*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="0.000*mm" Y="1519.036*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="0.000*mm" Y="1524.036*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="0.000*mm" Y="1519.036*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="0.000*mm" Y="1524.036*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="0.000*mm" Y="1519.036*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="0.000*mm" Y="1524.036*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="0.000*mm" Y="1519.036*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="0.000*mm" Y="1524.036*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="0.000*mm" Y="1519.036*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="0.000*mm" Y="1524.036*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="0.000*mm" Y="1519.036*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="0.000*mm" Y="1524.036*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="0.000*mm" Y="1519.036*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="0.000*mm" Y="1524.036*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="0.000*mm" Y="1519.036*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="0.000*mm" Y="1524.036*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="0.000*mm" Y="1519.036*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="0.000*mm" Y="1524.036*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="0.000*mm" Y="1519.036*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="0.000*mm" Y="1524.036*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="0.000*mm" Y="1519.036*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="0.000*mm" Y="1524.036*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="0.000*mm" Y="1519.036*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="0.000*mm" Y="1524.036*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="0.000*mm" Y="1519.036*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="0.000*mm" Y="1524.036*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="0.000*mm" Y="1519.036*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="0.000*mm" Y="1524.036*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="0.000*mm" Y="1519.036*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="0.000*mm" Y="1524.036*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="0.000*mm" Y="1519.036*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="0.000*mm" Y="1524.036*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="0.000*mm" Y="1519.036*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="0.000*mm" Y="1524.036*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="0.000*mm" Y="1519.036*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="0.000*mm" Y="1524.036*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="0.000*mm" Y="1519.036*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="0.000*mm" Y="1524.036*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="0.000*mm" Y="1519.036*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodOdd>
+                    <rodEven id="2">
+                        <modules>
+                            <module id="1" X="-100.792*mm" Y="1505.666*mm" Z="-2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="2" X="-101.126*mm" Y="1510.655*mm" Z="-2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="3" X="-100.792*mm" Y="1505.666*mm" Z="-2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="4" X="-101.126*mm" Y="1510.655*mm" Z="-1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="5" X="-100.792*mm" Y="1505.666*mm" Z="-1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="6" X="-101.126*mm" Y="1510.655*mm" Z="-1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="7" X="-100.792*mm" Y="1505.666*mm" Z="-1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="8" X="-101.126*mm" Y="1510.655*mm" Z="-1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="9" X="-100.792*mm" Y="1505.666*mm" Z="-1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="10" X="-101.126*mm" Y="1510.655*mm" Z="-1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="11" X="-100.792*mm" Y="1505.666*mm" Z="-1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="12" X="-101.126*mm" Y="1510.655*mm" Z="-1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="13" X="-100.792*mm" Y="1505.666*mm" Z="-1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="14" X="-101.126*mm" Y="1510.655*mm" Z="-981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="15" X="-100.792*mm" Y="1505.666*mm" Z="-879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="16" X="-101.126*mm" Y="1510.655*mm" Z="-787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="17" X="-100.792*mm" Y="1505.666*mm" Z="-685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="18" X="-101.126*mm" Y="1510.655*mm" Z="-592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="19" X="-100.792*mm" Y="1505.666*mm" Z="-491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="20" X="-101.126*mm" Y="1510.655*mm" Z="-396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="21" X="-100.792*mm" Y="1505.666*mm" Z="-295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="22" X="-101.126*mm" Y="1510.655*mm" Z="-198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="23" X="-100.792*mm" Y="1505.666*mm" Z="-98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="24" X="-101.126*mm" Y="1510.655*mm" Z="0.000*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="25" X="-100.792*mm" Y="1505.666*mm" Z="98.918*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="26" X="-101.126*mm" Y="1510.655*mm" Z="198.792*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="27" X="-100.792*mm" Y="1505.666*mm" Z="295.826*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="28" X="-101.126*mm" Y="1510.655*mm" Z="396.348*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="29" X="-100.792*mm" Y="1505.666*mm" Z="491.509*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="30" X="-101.126*mm" Y="1510.655*mm" Z="592.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="31" X="-100.792*mm" Y="1505.666*mm" Z="685.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="32" X="-101.126*mm" Y="1510.655*mm" Z="787.782*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="33" X="-100.792*mm" Y="1505.666*mm" Z="879.233*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="34" X="-101.126*mm" Y="1510.655*mm" Z="981.675*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="35" X="-100.792*mm" Y="1505.666*mm" Z="1071.288*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="36" X="-101.126*mm" Y="1510.655*mm" Z="1174.363*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="37" X="-100.792*mm" Y="1505.666*mm" Z="1262.150*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="38" X="-101.126*mm" Y="1510.655*mm" Z="1365.852*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="39" X="-100.792*mm" Y="1505.666*mm" Z="1451.824*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="40" X="-101.126*mm" Y="1510.655*mm" Z="1556.151*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="41" X="-100.792*mm" Y="1505.666*mm" Z="1640.319*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="42" X="-101.126*mm" Y="1510.655*mm" Z="1745.266*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="43" X="-100.792*mm" Y="1505.666*mm" Z="1827.642*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="44" X="-101.126*mm" Y="1510.655*mm" Z="1933.206*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="45" X="-100.792*mm" Y="1505.666*mm" Z="2013.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="46" X="-101.126*mm" Y="1510.655*mm" Z="2119.976*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                            <module id="47" X="-100.792*mm" Y="1505.666*mm" Z="2198.800*mm" phiTilt="0.000000*rad" thetaTilt="0.000000*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidth="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidth="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="14434.0*um"/>
+                    </rodEven>
+                </rods>
+            </layer>
+        </layers>
+    </detector>
+    <detector name="OuterECAP" id="EndCapTrackerOuter_id" type="TkLayoutTrackerEndcap_o1_v02" readout="TrackerEndcapReadout">
+        <type_flags type="DetType_TRACKER + DetType_ENDCAP"/> <!--I added-->
+        <dimensions rmin="25.000*mm" rmax="1549.268*mm" zmin="2615.706*mm" zmax="5009.294*mm" reflect="false"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="12">
+            <discZPls id="1" z="2625.000*mm" zmin="2615.706*mm" zmax="2634.294*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="62.666*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="54.270*mm" Y="31.333*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="75.332*mm" modWidthMin="13.935*mm" modWidthMax="55.924*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="75.332*mm" sensorWidthMin="13.935*mm" sensorWidthMax="55.924*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="150.203*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="142.851*mm" Y="46.415*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.543*mm" modWidthMin="32.168*mm" modWidthMax="64.533*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.543*mm" sensorWidthMin="32.168*mm" sensorWidthMax="64.533*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="250.208*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="245.400*mm" Y="48.813*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.747*mm" modWidthMin="39.672*mm" modWidthMax="60.172*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.747*mm" sensorWidthMin="39.672*mm" sensorWidthMax="60.172*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="351.448*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="347.871*mm" Y="50.016*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.131*mm" modWidthMin="43.613*mm" modWidthMax="58.103*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.131*mm" sensorWidthMin="43.613*mm" sensorWidthMax="58.103*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="451.105*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="447.816*mm" Y="54.375*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="104.752*mm" modWidthMin="48.739*mm" modWidthMax="61.544*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="104.752*mm" sensorWidthMin="48.739*mm" sensorWidthMax="61.544*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="553.187*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="550.523*mm" Y="54.222*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="99.406*mm" modWidthMin="49.970*mm" modWidthMax="59.836*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="99.406*mm" sensorWidthMin="49.970*mm" sensorWidthMax="59.836*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="650.158*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="643.540*mm" Y="92.527*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="752.759*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="747.270*mm" Y="90.735*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="850.081*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="844.736*mm" Y="95.179*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="952.882*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="948.294*mm" Y="93.399*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="68">
+                        <modules>
+                            <moduleOdd id="1" X="1049.064*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1044.589*mm" Y="96.795*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="12" phi0="0.000000*rad" nModules="76">
+                        <modules>
+                            <moduleOdd id="1" X="1152.064*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1148.129*mm" Y="95.137*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="13" phi0="0.000000*rad" nModules="84">
+                        <modules>
+                            <moduleOdd id="1" X="1247.111*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1243.623*mm" Y="93.197*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="14" phi0="0.000000*rad" nModules="88">
+                        <modules>
+                            <moduleOdd id="1" X="1350.309*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1346.869*mm" Y="96.330*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="15" phi0="0.000000*rad" nModules="96">
+                        <modules>
+                            <moduleOdd id="1" X="1444.226*mm" Y="0.000*mm" Z="2622.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1441.134*mm" Y="94.457*mm" Z="2617.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="16" phi0="0.000000*rad" nModules="96">
+                        <modules>
+                            <moduleOdd id="1" X="1522.422*mm" Y="0.000*mm" Z="2632.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1519.162*mm" Y="99.571*mm" Z="2627.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="52.000*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="52.000*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="2986.053*mm" zmin="2976.759*mm" zmax="2995.346*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="3" z="3396.766*mm" zmin="3387.472*mm" zmax="3406.059*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="4" z="3863.970*mm" zmin="3854.676*mm" zmax="3873.263*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="5" z="4395.435*mm" zmin="4386.142*mm" zmax="4404.729*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="6" z="5000.000*mm" zmin="4990.707*mm" zmax="5009.294*mm" rmin="25.000*mm" rmax="1549.268*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
+                <rings repeat="16" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="FwdIECAP" id="27" type="TkLayoutTrackerEndcap_o1_v02" readout="TrackerEndcapReadout">
+        <type_flags type="DetType_TRACKER + DetType_ENDCAP"/> 
+        <dimensions rmin="25.000*mm" rmax="1321.527*mm" zmin="6241.066*mm" zmax="8759.293*mm" reflect="false"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="6">
+            <discZPls id="1" z="6250.000*mm" zmin="6241.066*mm" zmax="6258.934*mm" rmin="25.000*mm" rmax="918.570*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+                <rings repeat="9" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="70.594*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="61.136*mm" Y="35.297*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="91.188*mm" modWidthMin="13.935*mm" modWidthMax="64.762*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="91.188*mm" sensorWidthMin="13.935*mm" sensorWidthMax="64.762*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="166.145*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="158.013*mm" Y="51.342*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.782*mm" modWidthMin="37.180*mm" modWidthMax="69.551*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.782*mm" sensorWidthMin="37.180*mm" sensorWidthMax="69.551*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="265.730*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="260.625*mm" Y="51.841*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.425*mm" modWidthMin="42.958*mm" modWidthMax="62.976*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.425*mm" sensorWidthMin="42.958*mm" sensorWidthMax="62.976*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="365.777*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="362.054*mm" Y="52.056*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.307*mm" modWidthMin="45.650*mm" modWidthMax="60.158*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.307*mm" sensorWidthMin="45.650*mm" sensorWidthMax="60.158*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="464.528*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="461.607*mm" Y="52.011*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.185*mm" modWidthMin="47.050*mm" modWidthMax="58.424*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.185*mm" sensorWidthMin="47.050*mm" sensorWidthMax="58.424*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="564.439*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="561.721*mm" Y="55.325*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.049*mm" modWidthMin="51.044*mm" modWidthMax="60.972*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.049*mm" sensorWidthMin="51.044*mm" sensorWidthMax="60.972*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="663.691*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="658.013*mm" Y="86.629*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="766.000*mm" Y="0.000*mm" Z="6257.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="760.415*mm" Y="92.331*mm" Z="6252.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="865.942*mm" Y="0.000*mm" Z="6247.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="861.198*mm" Y="90.516*mm" Z="6242.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="7395.100*mm" zmin="7385.806*mm" zmax="7404.393*mm" rmin="25.000*mm" rmax="1120.194*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+                <rings repeat="11" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="70.594*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="61.136*mm" Y="35.297*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="91.188*mm" modWidthMin="13.935*mm" modWidthMax="64.762*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="91.188*mm" sensorWidthMin="13.935*mm" sensorWidthMax="64.762*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="166.145*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="158.013*mm" Y="51.342*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.782*mm" modWidthMin="37.180*mm" modWidthMax="69.551*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.782*mm" sensorWidthMin="37.180*mm" sensorWidthMax="69.551*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="265.730*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="260.625*mm" Y="51.841*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.425*mm" modWidthMin="42.958*mm" modWidthMax="62.976*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.425*mm" sensorWidthMin="42.958*mm" sensorWidthMax="62.976*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="365.777*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="362.054*mm" Y="52.056*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.307*mm" modWidthMin="45.650*mm" modWidthMax="60.158*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.307*mm" sensorWidthMin="45.650*mm" sensorWidthMax="60.158*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="464.528*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="461.607*mm" Y="52.011*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.185*mm" modWidthMin="47.050*mm" modWidthMax="58.424*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.185*mm" sensorWidthMin="47.050*mm" sensorWidthMax="58.424*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="564.439*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="561.721*mm" Y="55.325*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.049*mm" modWidthMin="51.044*mm" modWidthMax="60.972*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.049*mm" sensorWidthMin="51.044*mm" sensorWidthMax="60.972*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="663.691*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="658.013*mm" Y="86.629*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="766.000*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="760.415*mm" Y="92.331*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="865.942*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="861.198*mm" Y="90.516*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="968.366*mm" Y="0.000*mm" Z="7402.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="963.703*mm" Y="94.916*mm" Z="7397.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="500.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="72">
+                        <modules>
+                            <moduleOdd id="1" X="1067.823*mm" Y="0.000*mm" Z="7392.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1063.760*mm" Y="93.067*mm" Z="7387.600*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="500.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="3" z="8750.000*mm" zmin="8740.707*mm" zmax="8759.293*mm" rmin="25.000*mm" rmax="1321.527*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+                <rings repeat="13" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="70.594*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="61.136*mm" Y="35.297*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="91.188*mm" modWidthMin="13.935*mm" modWidthMax="64.762*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="91.188*mm" sensorWidthMin="13.935*mm" sensorWidthMax="64.762*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="20">
+                        <modules>
+                            <moduleOdd id="1" X="166.145*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="158.013*mm" Y="51.342*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.782*mm" modWidthMin="37.180*mm" modWidthMax="69.551*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.782*mm" sensorWidthMin="37.180*mm" sensorWidthMax="69.551*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="32">
+                        <modules>
+                            <moduleOdd id="1" X="265.730*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="260.625*mm" Y="51.841*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.425*mm" modWidthMin="42.958*mm" modWidthMax="62.976*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.425*mm" sensorWidthMin="42.958*mm" sensorWidthMax="62.976*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="44">
+                        <modules>
+                            <moduleOdd id="1" X="365.777*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="362.054*mm" Y="52.056*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.307*mm" modWidthMin="45.650*mm" modWidthMax="60.158*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.307*mm" sensorWidthMin="45.650*mm" sensorWidthMax="60.158*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="464.528*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="461.607*mm" Y="52.011*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.185*mm" modWidthMin="47.050*mm" modWidthMax="58.424*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.185*mm" sensorWidthMin="47.050*mm" sensorWidthMax="58.424*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="564.439*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="561.721*mm" Y="55.325*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.049*mm" modWidthMin="51.044*mm" modWidthMax="60.972*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.049*mm" sensorWidthMin="51.044*mm" sensorWidthMax="60.972*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="663.691*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="658.013*mm" Y="86.629*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="766.000*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="760.415*mm" Y="92.331*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="865.942*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="861.198*mm" Y="90.516*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="64">
+                        <modules>
+                            <moduleOdd id="1" X="968.366*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="963.703*mm" Y="94.916*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="72">
+                        <modules>
+                            <moduleOdd id="1" X="1067.823*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1063.760*mm" Y="93.067*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="12" phi0="0.000000*rad" nModules="76">
+                        <modules>
+                            <moduleOdd id="1" X="1170.362*mm" Y="0.000*mm" Z="8757.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1166.365*mm" Y="96.648*mm" Z="8752.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="13" phi0="0.000000*rad" nModules="84">
+                        <modules>
+                            <moduleOdd id="1" X="1269.335*mm" Y="0.000*mm" Z="8747.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1265.786*mm" Y="94.858*mm" Z="8742.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+        </discs>
+    </detector>
+    <detector name="FwdECAP" id="29" type="TkLayoutTrackerEndcap_o1_v02" readout="TrackerEndcapReadout">
+        <type_flags type="DetType_TRACKER + DetType_ENDCAP"/> 
+        <dimensions rmin="49.500*mm" rmax="1550.163*mm" zmin="9990.707*mm" zmax="16009.294*mm" reflect="false"/>
+        <sensitive type="SimpleTrackerSD"/>
+        <discs repeat="12">
+            <discZPls id="1" z="10000.000*mm" zmin="9990.707*mm" zmax="10009.293*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm">
+                    <ring id="1" phi0="0.000000*rad" nModules="12">
+                        <modules>
+                            <moduleOdd id="1" X="94.508*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="81.846*mm" Y="47.254*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="90.016*mm" modWidthMin="27.064*mm" modWidthMax="76.279*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="90.016*mm" sensorWidthMin="27.064*mm" sensorWidthMax="76.279*mm" sensorThickness="0.100*mm" resRPhi="7.5*um" resZ="15.0*um"/>
+                    </ring>
+                    <ring id="2" phi0="0.000000*rad" nModules="24">
+                        <modules>
+                            <moduleOdd id="1" X="189.080*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="182.638*mm" Y="48.938*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.043*mm" modWidthMin="37.124*mm" modWidthMax="63.832*mm" modThickness="2.150*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.330*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.043*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.129*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="0.903*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.645*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.043*mm" sensorWidthMin="37.124*mm" sensorWidthMax="63.832*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="30.0*um"/>
+                    </ring>
+                    <ring id="3" phi0="0.000000*rad" nModules="36">
+                        <modules>
+                            <moduleOdd id="1" X="288.237*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="283.858*mm" Y="50.052*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="99.985*mm" modWidthMin="42.191*mm" modWidthMax="59.898*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="99.985*mm" sensorWidthMin="42.191*mm" sensorWidthMax="59.898*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="4" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="387.840*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="384.522*mm" Y="50.623*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="100.010*mm" modWidthMin="44.788*mm" modWidthMax="58.047*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="100.010*mm" sensorWidthMin="44.788*mm" sensorWidthMax="58.047*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="5" phi0="0.000000*rad" nModules="56">
+                        <modules>
+                            <moduleOdd id="1" X="486.679*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="483.619*mm" Y="54.491*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="99.980*mm" modWidthMin="49.549*mm" modWidthMax="60.894*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="99.980*mm" sensorWidthMin="49.549*mm" sensorWidthMax="60.894*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="6" phi0="0.000000*rad" nModules="40">
+                        <modules>
+                            <moduleOdd id="1" X="587.536*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="580.303*mm" Y="91.911*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="7" phi0="0.000000*rad" nModules="48">
+                        <modules>
+                            <moduleOdd id="1" X="688.480*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="682.590*mm" Y="89.865*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="8" phi0="0.000000*rad" nModules="52">
+                        <modules>
+                            <moduleOdd id="1" X="790.611*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="784.846*mm" Y="95.298*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="9" phi0="0.000000*rad" nModules="60">
+                        <modules>
+                            <moduleOdd id="1" X="891.250*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="886.367*mm" Y="93.161*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="2.867*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.100*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.474*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.057*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.172*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.204*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="0.860*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.100*mm" resRPhi="9.5*um" resZ="115.0*um"/>
+                    </ring>
+                    <ring id="10" phi0="0.000000*rad" nModules="68">
+                        <modules>
+                            <moduleOdd id="1" X="993.444*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="989.206*mm" Y="91.663*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="11" phi0="0.000000*rad" nModules="72">
+                        <modules>
+                            <moduleOdd id="1" X="1093.779*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1089.617*mm" Y="95.329*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="12" phi0="0.000000*rad" nModules="80">
+                        <modules>
+                            <moduleOdd id="1" X="1196.037*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1192.350*mm" Y="93.840*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="13" phi0="0.000000*rad" nModules="84">
+                        <modules>
+                            <moduleOdd id="1" X="1296.068*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1292.444*mm" Y="96.855*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="14" phi0="0.000000*rad" nModules="92">
+                        <modules>
+                            <moduleOdd id="1" X="1398.389*mm" Y="0.000*mm" Z="10007.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1395.129*mm" Y="95.429*mm" Z="10002.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                    <ring id="15" phi0="0.000000*rad" nModules="96">
+                        <modules>
+                            <moduleOdd id="1" X="1498.117*mm" Y="0.000*mm" Z="9997.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                            <moduleEven id="2" X="1494.909*mm" Y="97.982*mm" Z="9992.500*mm" phiTilt="0.000000*rad" thetaTilt="1.570796*rad"/>
+                        </modules>
+                        <moduleProperties modLength="102.400*mm" modWidthMin="102.400*mm" modWidthMax="102.400*mm" modThickness="3.587*mm">
+                            <components>
+                                <component name="Sensor-Si" thickness="0.200*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="true"/>
+                                <component name="Module-Si" thickness="0.520*mm" material="Silicon" density="2.330*g/cm3" radLength="21.820*g/cm2" intLength="108.400*g/cm2" sensitive="false"/>
+                                <component name="Module-Cu" thickness="0.072*mm" material="Cu" density="8.960*g/cm3" radLength="12.860*g/cm2" intLength="137.300*g/cm2" sensitive="false"/>
+                                <component name="Module-Al" thickness="0.215*mm" material="Al" density="2.700*g/cm3" radLength="24.010*g/cm2" intLength="107.200*g/cm2" sensitive="false"/>
+                                <component name="Module-C" thickness="1.505*mm" material="C" density="2.000*g/cm3" radLength="42.700*g/cm2" intLength="85.800*g/cm2" sensitive="false"/>
+                                <component name="Module-PE" thickness="1.075*mm" material="PE" density="0.950*g/cm3" radLength="44.770*g/cm2" intLength="67.700*g/cm2" sensitive="false"/>
+                            </components>
+                        </moduleProperties>
+                        <sensorProperties sensorLength="102.400*mm" sensorWidthMin="102.400*mm" sensorWidthMax="102.400*mm" sensorThickness="0.200*mm" resRPhi="9.5*um" resZ="2887.0*um"/>
+                    </ring>
+                </rings>
+            </discZPls>
+            <discZPls id="2" z="10985.605*mm" zmin="10976.312*mm" zmax="10994.899*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="3" z="12068.353*mm" zmin="12059.059*mm" zmax="12077.646*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="4" z="13257.816*mm" zmin="13248.523*mm" zmax="13267.110*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="5" z="14564.514*mm" zmin="14555.220*mm" zmax="14573.807*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+            <discZPls id="6" z="16000.000*mm" zmin="15990.707*mm" zmax="16009.294*mm" rmin="49.500*mm" rmax="1550.163*mm" bigDelta="5.000*mm">
+                <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+                <rings repeat="15" smallDelta="2.500*mm" rPhiOverlap="0.500*mm" nRPhiSegments="4" rOverlap="0.500*mm"/>
+            </discZPls>
+        </discs>
+    </detector>
+</detectors>

--- a/FCChh/compact/FCChhBaseline/TrackerTkLayout-v02/Tracker.xml
+++ b/FCChh/compact/FCChhBaseline/TrackerTkLayout-v02/Tracker.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+    <info name="TkLayoutTracker" title="TkLayoutTracker" author="Z.Drasal" url="http://fcc-tklayout.web.cern.ch/fcc-tklayout" status="optimization" version="FCChh_v3.03">
+        <comment>The tracker geometry as designed and optimized by tkLayout software - design version: FCChh_v3.03</comment>
+    </info>
+    <readouts>
+        <readout name="TrackerBarrelReadout">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:4,layer:5,module:18,x:-15,z:-15</id>
+        </readout>
+        <readout name="TrackerEndcapReadout">
+            <segmentation type="CartesianGridXZ" grid_size_x="0.005*mm" grid_size_z="0.010*mm"/>
+            <id>system:4,posneg:1,disc:5,ring:4,component:17,x:-15,z:-15</id>
+        </readout>
+    </readouts>
+    <include ref="FCChh_v3.03_Definitions.xml"/>
+
+    <!--Material Binning-->
+    <include ref="../FCChh_MaterialBinning.xml"/>
+
+    <detectors>
+        <detector id="0" name="beampipe" type="BeamTube">
+            <dimensions rmin="CentralBeamTube_rmin" rmax="CentralBeamTube_rmax" z="CentralBeamTube_dz" material="Beryllium" vis="violet"/>
+            <type_flags type="DetType_TRACKER + DetType_BEAMPIPE" />
+        </detector>
+        <detector id="1" name="FCChhInner" type="DD4hep_SubdetectorAssembly" vis="BlueVisTrans">
+            <composite name="InnerBRL"/>
+            <composite name="InnerECAP"/>
+        </detector>
+        <detector id="2" name="FCChhOuter" type="DD4hep_SubdetectorAssembly" vis="BlueVisTrans">
+            <composite name="OuterBRL"/>
+            <composite name="OuterECAP"/>
+        </detector>
+        <detector id="3" name="FCChhFwdEcap_Inner" type="DD4hep_SubdetectorAssembly" vis="BlueVisTrans">
+            <composite name="FwdIECAP"/>
+        </detector>
+         <detector id="4" name="FCChhFwdEcap_Outer" type="DD4hep_SubdetectorAssembly" vis="BlueVisTrans">
+            <composite name="FwdECAP"/>
+        </detector>
+    </detectors>
+
+
+<!--*************************************Plugins*************************************************************-->
+
+<plugins>
+     <plugin name="DD4hep_ParametersPlugin">                              <!--for inner BRL-->
+        <argument value="InnerBRL"/>
+        <argument value="layer_pattern=layer\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">                             <!-- for inner pos ecap-->
+        <argument value="FCChhInner/InnerECAP/InnerECAPposEndcap"/>
+        <argument value="layer_pattern=disc\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">                             <!--for inner neg ecap-->
+        <argument value="FCChhInner/InnerECAP/InnerECAPnegEndcap"/>
+        <argument value="layer_pattern=disc\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">                                   <!--for outer BRL-->
+        <argument value="OuterBRL"/>
+        <argument value="layer_pattern=layer\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">                              <!-- for outer pos ecap-->
+        <argument value="FCChhOuter/OuterECAP/OuterECAPposEndcap"/>
+        <argument value="layer_pattern=disc\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">                               <!-- for outer neg ecap-->
+        <argument value="FCChhOuter/OuterECAP/OuterECAPnegEndcap"/>
+        <argument value="layer_pattern=disc\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">                          <!--for forward inner neg ecap-->
+        <argument value="FCChhFwdEcap_Inner/FwdIECAP/FwdIECAPnegEndcap"/>
+        <argument value="layer_pattern=disc\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">                            <!--for forward innerpos ecap-->
+        <argument value="FCChhFwdEcap_Inner/FwdIECAP/FwdIECAPposEndcap"/>
+        <argument value="layer_pattern=disc\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">                            <!--for forward outer neg ecap-->
+        <argument value="FCChhFwdEcap_Outer/FwdECAP/FwdECAPnegEndcap"/>
+        <argument value="layer_pattern=disc\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">                             <!--for forward outer pos ecap-->
+        <argument value="FCChhFwdEcap_Outer/FwdECAP/FwdECAPposEndcap"/>
+        <argument value="layer_pattern=disc\d"/>
+    </plugin>
+    <plugin name="DD4hep_ParametersPlugin">     
+        <argument value="beampipe"/>
+        <argument value="passive_layer: bool = true"/>
+        <argument value="acts_volume: bool = true"/>
+        <argument value="acts_volume_type: int = 3"/>
+        <!-- <argument value="acts_volume_bvalues_n: int = 3"/>
+        <argument value="acts_volume_bvalues_0: double = 0"/>
+        <argument value="acts_volume_bvalues_1: double = CentralBeamTube_rmax"/>
+        <argument value="acts_volume_bvalues_2: double = Tracker_dz"/>
+        <argument value="acts_volume_internals: bool = true"/>
+        <argument value="acts_volume_internals_type: str = layer"/>
+        <argument value="acts_portal_proto_material_2: bool = true"/>
+        <argument value="acts_portal_proto_material_2_binning_dim: int = 1"/>
+        <argument value="acts_portal_proto_material_2_binning_z_type: str = equidistant"/>
+        <argument value="acts_portal_proto_material_2_binning_z_n: int = 1"/>
+        <argument value="acts_portal_proto_material_2_binning_z_autorange: bool = true"/>
+        <argument value="acts_portal_proto_material_2_binning_phi_type: str = equidistant"/>
+        <argument value="acts_portal_proto_material_2_binning_phi_n: int = 1"/> -->
+    </plugin>
+</plugins>
+
+</lccdd>

--- a/detector/tracker/FCCHelper.hpp
+++ b/detector/tracker/FCCHelper.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <DD4hep/DetElement.h>
+#include <DDRec/DetectorData.h>
+#include <boost/foreach.hpp>
+#include <boost/tokenizer.hpp>
+
+#include "DD4hep/DetFactoryHelper.h"
+
+namespace FCCHelper {
+
+template <typename T>
+T& ensureExtension(dd4hep::DetElement& elt) {
+  T* ext = elt.extension<T>(false);
+  if (ext == nullptr) {
+    ext = new T();
+  }
+  elt.addExtension<T>(ext);
+  return *ext;
+}
+
+inline void xmlToProtoSurfaceMaterial(const xml_comp_t& x_material,
+                                      dd4hep::rec::VariantParameters& params,
+                                      const std::string& baseTag,
+                                      int nMaterialSurface = 0) {
+  using namespace std::string_literals;
+  using namespace dd4hep;
+
+  // Add the layer material flag
+  params.set(baseTag, true);
+  // prepare everything here
+  std::string mSurface = x_material.attr<std::string>("surface");
+  std::string mBinning = x_material.attr<std::string>("binning");
+  boost::char_separator<char> sep(",");
+  boost::tokenizer binTokens(mBinning, sep);
+  const auto n = std::distance(binTokens.begin(), binTokens.end());
+  if (n == 2) {
+    // Fill the bins
+    auto bin = binTokens.begin();
+    std::string bin0 = *(bin);
+    std::string bin1 = *(++bin);
+    size_t nBins0 = x_material.attr<int>("bins0");
+    size_t nBins1 = x_material.attr<int>("bins1");
+    // Add the material tags
+    std::string btmSurface = baseTag + "_"s + mSurface;
+    params.set<bool>(btmSurface, true);
+    params.set<int>(btmSurface + "_"s + bin0, nBins0);
+    params.set<int>(btmSurface + "_"s + bin1, nBins1);
+  }
+
+  // New style detector description
+  params.set<std::string>("passive_surface_n"+std::to_string(nMaterialSurface)+"_type", mSurface);
+
+}
+
+}  // namespace FCCHelper

--- a/detector/tracker/README.md
+++ b/detector/tracker/README.md
@@ -87,9 +87,14 @@ FCChh barrel tracker as designed by tkLayout.
 ### o1_v01
 Original version taken from [FCCDetectors](https://github.com/HEP-FCC/FCCDetectors/blob/f2268e282c6c77d93e7079d0d235cabd06a03599/Detector/DetFCChhTrackerTkLayout/src/TkLayoutBarrel_Geo.cpp).
 
+### o1_v02
+Version taken from Mehrunnisa's [fork](https://github.com/mehrunnisamirza2/FCCDetectors/tree/feature-acts-gen1) of the `FCCDetectors` repository, branch `feature-acts-gen1`.
 
 ## TkLayoutTrackerEndcap
 FCChh endcap tracker as designed by tkLayout.
 
 ### o1_v01
 Original version taken from [FCCDetectors](https://github.com/HEP-FCC/FCCDetectors/blob/f2268e282c6c77d93e7079d0d235cabd06a03599/Detector/DetFCChhTrackerTkLayout/src/TkLayoutEndcap_Geo.cpp).
+
+### o1_v02
+Version taken from Mehrunnisa's [fork](https://github.com/mehrunnisamirza2/FCCDetectors/tree/feature-acts-gen1) of the `FCCDetectors` repository, branch `feature-acts-gen1`.

--- a/detector/tracker/TkLayoutTrackerBarrel_o1_v02_geo.cpp
+++ b/detector/tracker/TkLayoutTrackerBarrel_o1_v02_geo.cpp
@@ -1,0 +1,163 @@
+
+#include "DD4hep/DetFactoryHelper.h"
+#include "XML/Utilities.h"
+#include "XML/Layering.h"
+
+#include "FCCHelper.hpp"
+
+using dd4hep::Volume;
+using dd4hep::DetElement;
+using dd4hep::xml::Dimension;
+using dd4hep::PlacedVolume;
+
+namespace det {
+
+
+static dd4hep::Ref_t createTkLayoutTrackerBarrel(dd4hep::Detector& lcdd,
+                                                 dd4hep::xml::Handle_t xmlElement,
+                                                 dd4hep::SensitiveDetector sensDet) {
+  // shorthands
+
+  dd4hep::xml::DetElement xmlDet = static_cast<dd4hep::xml::DetElement>(xmlElement);
+  Dimension dimensions(xmlDet.dimensions());
+  // get sensitive detector type from xml
+  dd4hep::xml::Dimension sdTyp = xmlElement.child(_Unicode(sensitive));
+  // sensitive detector used for all sensitive parts of this detector
+  sensDet.setType(sdTyp.typeStr());
+
+  // definition of top volume
+  // has min/max dimensions of tracker for visualization etc.
+  std::string detectorName = xmlDet.nameStr();
+  DetElement topDetElement(detectorName, xmlDet.id());
+
+  dd4hep::xml::setDetectorTypeFlag(xmlElement, topDetElement) ; //set type flags
+  auto &params = FCCHelper::ensureExtension<dd4hep::rec::VariantParameters>(topDetElement);
+
+  
+  ////add valume boundary material
+  for (dd4hep::xml::Collection_t bmat(xmlDet, _Unicode(boundary_material)); bmat; ++bmat) {
+       dd4hep::xml::Component x_boundary_material = bmat;
+       FCCHelper::xmlToProtoSurfaceMaterial(x_boundary_material, params,
+                                             "boundary_material");
+  }
+
+  dd4hep::Tube topVolumeShape(dimensions.rmin(), dimensions.rmax(), (dimensions.zmax() - dimensions.zmin()) * 0.5);
+  Volume topVolume(detectorName, topVolumeShape, lcdd.air());
+  topVolume.setVisAttributes(lcdd.invisible());
+
+  // counts all layers - incremented in the inner loop over repeat - tags
+  unsigned int layerCounter = 0;
+  double integratedModuleComponentThickness = 0;
+  double phi = 0;
+  // loop over 'layer' nodes in xml
+  dd4hep::xml::Component xLayers = xmlElement.child(_Unicode(layers));
+  for (dd4hep::xml::Collection_t xLayerColl(xLayers, _U(layer)); nullptr != xLayerColl; ++xLayerColl) {
+    std::vector<dd4hep::xml::Component> rodLists;
+    dd4hep::xml::Component xLayer = static_cast<dd4hep::xml::Component>(xLayerColl);
+    dd4hep::xml::Component xRods = xLayer.child("rods");
+    rodLists.push_back(xRods.child("rodOdd"));
+    rodLists.push_back(xRods.child("rodEven"));
+    rodLists.push_back(xRods.child("rodOddTilted", false));
+    rodLists.push_back(xRods.child("rodEvenTilted", false));
+    dd4hep::xml::Component xModulePropertiesOdd = rodLists[0].child("moduleProperties");
+    dd4hep::Tube layerShape(xLayer.rmin(), xLayer.rmax(), dimensions.zmax());
+    Volume layerVolume("layer", layerShape, lcdd.material("Air"));
+    // layerVolume.setVisAttributes(lcdd.invisible());
+    PlacedVolume placedLayerVolume = topVolume.placeVolume(layerVolume);
+    placedLayerVolume.addPhysVolID("layer", layerCounter);
+    DetElement lay_det(topDetElement, "layer" + std::to_string(layerCounter), layerCounter);
+
+    // add layer params user extension
+    auto &layerParams =
+    FCCHelper::ensureExtension<dd4hep::rec::VariantParameters>(
+      lay_det);
+
+    //add proto layer material material
+    unsigned int nMaterialSurfaces = 0;
+    for (dd4hep::xml::Collection_t lmat(xLayer, _Unicode(layer_material)); lmat; ++lmat) {
+      dd4hep::xml::Component x_layer_material = lmat;
+      FCCHelper::xmlToProtoSurfaceMaterial(x_layer_material, layerParams,
+                                          "layer_material",  nMaterialSurfaces);
+      ++nMaterialSurfaces;
+    }
+    
+    //set number of pasive surfaces to process
+    if (nMaterialSurfaces >0) {
+      layerParams.set<bool>("passive_surface", true);
+      layerParams.set<int>("passive_surface_count", nMaterialSurfaces);
+    }
+
+    lay_det.setPlacement(placedLayerVolume);
+    dd4hep::xml::Component xModuleComponentsOdd = xModulePropertiesOdd.child("components");
+    integratedModuleComponentThickness = 0;
+    int moduleCounter = 0;
+    Volume moduleVolume;
+
+    for (dd4hep::xml::Collection_t xModuleComponentOddColl(xModuleComponentsOdd, _U(component));
+         nullptr != xModuleComponentOddColl;
+         ++xModuleComponentOddColl) {
+      dd4hep::xml::Component xModuleComponentOdd = static_cast<dd4hep::xml::Component>(xModuleComponentOddColl);
+      double moduleWidth = 0.5 * xModulePropertiesOdd.attr<double>("modWidth");
+      double moduleThickness = 0.5 * xModuleComponentOdd.thickness();
+      double moduleLength = 0.5 * xModulePropertiesOdd.attr<double>("modLength");
+
+      moduleVolume = Volume("module",
+                            dd4hep::Box(moduleWidth, moduleThickness, moduleLength),
+                            lcdd.material(xModuleComponentOdd.materialStr()));
+
+      moduleVolume.setVisAttributes(lcdd.invisible());
+      unsigned int nPhi = xRods.repeat();
+      for (unsigned int phiIndex = 0; phiIndex < nPhi; phiIndex += 2) {
+        double lX = 0;
+        double lY = 0;
+        double lZ = 0;
+        for (auto currentComp : rodLists) {
+          if (currentComp.ptr()) {
+            phi = 2 * M_PI * static_cast<double>(phiIndex) / static_cast<double>(nPhi);
+            for (dd4hep::xml::Collection_t xModuleColl(currentComp.child(_Unicode(modules)), _U(module));
+                 nullptr != xModuleColl;
+                 ++xModuleColl) {
+              dd4hep::xml::Component xModule = static_cast<dd4hep::xml::Component>(xModuleColl);
+              double currentPhi = atan2(xModule.Y(), xModule.X());
+              double componentOffset = integratedModuleComponentThickness -
+                  0.5 * xModulePropertiesOdd.attr<double>("modThickness") + 0.5 * xModuleComponentOdd.thickness();
+              dd4hep::Translation3D offsetOnly(cos(currentPhi) * componentOffset, sin(currentPhi) * componentOffset, 0);
+              lX = xModule.X();
+              lY = xModule.Y();
+              lZ = xModule.Z();
+              dd4hep::Translation3D moduleOffset(lX, lY, lZ);
+              dd4hep::Transform3D lTrafo(dd4hep::RotationZ(atan2(lY, lX) + 0.5 * M_PI), moduleOffset);
+              dd4hep::RotationZ lRotation(phi);
+              double thetaTilt = xModule.attr<double>("thetaTilt");
+              dd4hep::RotationX lRotation_thetaTilt(-1 * thetaTilt);
+              PlacedVolume placedModuleVolume =
+                  layerVolume.placeVolume(moduleVolume, lRotation * lTrafo * lRotation_thetaTilt * offsetOnly);
+              if (xModuleComponentOdd.isSensitive()) {
+                placedModuleVolume.addPhysVolID("module", moduleCounter);
+                moduleVolume.setSensitiveDetector(sensDet);
+                DetElement mod_det(lay_det, "module" + std::to_string(moduleCounter), moduleCounter);
+                mod_det.setPlacement(placedModuleVolume);
+                ++moduleCounter;
+
+		//add the sensor extension
+		auto &par = FCCHelper::ensureExtension<dd4hep::rec::VariantParameters>(mod_det);
+		par.set<std::string>("axis_definitions", "XZy");
+              }
+            }
+          }
+        }
+      }
+      integratedModuleComponentThickness += xModuleComponentOdd.thickness();
+    }
+    ++layerCounter;
+  }
+
+  Volume motherVol = lcdd.pickMotherVolume(topDetElement);
+  PlacedVolume placedGenericTrackerBarrel = motherVol.placeVolume(topVolume);
+  placedGenericTrackerBarrel.addPhysVolID("system", topDetElement.id());
+  topDetElement.setPlacement(placedGenericTrackerBarrel);
+  return topDetElement;
+}
+}  // namespace det
+
+DECLARE_DETELEMENT(TkLayoutTrackerBarrel_o1_v02, det::createTkLayoutTrackerBarrel)

--- a/detector/tracker/TkLayoutTrackerEndcap_o1_v02_geo.cpp
+++ b/detector/tracker/TkLayoutTrackerEndcap_o1_v02_geo.cpp
@@ -1,0 +1,211 @@
+
+#include "XML/Utilities.h"
+#include "DD4hep/DetFactoryHelper.h"
+#include "XML/Layering.h"
+
+#include "FCCHelper.hpp"
+
+using dd4hep::Volume;
+using dd4hep::DetElement;
+using dd4hep::xml::Dimension;
+using dd4hep::xml::Component;
+using dd4hep::PlacedVolume;
+
+namespace det {
+
+static dd4hep::Ref_t createTkLayoutTrackerEndcap(dd4hep::Detector& lcdd,
+                                                 dd4hep::xml::Handle_t xmlElement,
+                                                 dd4hep::SensitiveDetector sensDet) {
+  // shorthands
+  dd4hep::xml::DetElement xmlDet = static_cast<dd4hep::xml::DetElement>(xmlElement);
+  Dimension dimensions(xmlDet.dimensions());
+  double l_overlapMargin = 0.01;
+
+  // get sensitive detector type from xml
+  dd4hep::xml::Dimension sdTyp = xmlElement.child(_Unicode(sensitive));  // retrieve the type
+  sensDet.setType(sdTyp.typeStr());                                      // set for the whole detector
+
+  // definition of top volume
+  std::string detName = xmlDet.nameStr();
+  DetElement worldDetElement(detName, xmlDet.id());
+  DetElement posEcapDetElement(worldDetElement, detName+"posEndcap", 0);
+
+  dd4hep::Assembly envelopeVolume("endcapEnvelope");
+  envelopeVolume.setVisAttributes(lcdd.invisible());
+
+  Component xDiscs = xmlElement.child(_Unicode(discs));
+
+  double envelopeThickness = 0.5 * (dimensions.zmax() - dimensions.zmin());
+
+  l_overlapMargin *= 0.9;
+
+  unsigned int discCounter = 0;
+  unsigned int compCounter = 0;
+  double currentZ;
+  std::vector<Volume> discVolumeVec;
+  std::vector<DetElement> discDetElementVec;
+  /// iterate over discs
+  for (dd4hep::xml::Collection_t xDiscColl(xDiscs, _Unicode(discZPls)); nullptr != xDiscColl; ++xDiscColl) {
+    Component xDisc = static_cast<Component>(xDiscColl);
+    Component xCurrentRings = xDisc.child(_Unicode(rings));
+    // create disc volume
+    double discThickness = 0.5 * (xDisc.zmax() - xDisc.zmin());
+    currentZ = xDisc.z() - dimensions.zmin() - envelopeThickness;
+    if (xCurrentRings.hasChild(_Unicode(ring))) {  // we have information to construct a new volume
+      dd4hep::Tube discShape(
+          xDisc.rmin() - l_overlapMargin, xDisc.rmax() + l_overlapMargin, discThickness + l_overlapMargin);
+
+      discVolumeVec.emplace_back("disc", discShape, lcdd.air());
+      discDetElementVec.emplace_back(posEcapDetElement, "disc" + std::to_string(discCounter), discCounter);
+
+      /////add layer params user extension
+      auto &layerParams =
+           FCCHelper::ensureExtension<dd4hep::rec::VariantParameters>(
+           discDetElementVec.back());
+
+      ///// Add proto layer material
+      unsigned int nMaterialSurfaces = 0;
+      for (dd4hep::xml::Collection_t lmat(xDisc, _Unicode(layer_material)); lmat; ++lmat) {
+        dd4hep::xml::Component x_layer_material = lmat;
+        FCCHelper::xmlToProtoSurfaceMaterial(x_layer_material, layerParams,
+                                             "layer_material", nMaterialSurfaces);    
+        ++nMaterialSurfaces;                                       
+      }
+
+      // iterate over rings
+      unsigned int ringCounter = 0;
+      for (dd4hep::xml::Collection_t xRingColl(xCurrentRings, _U(ring)); (nullptr != xRingColl); ++xRingColl) {
+        Component xRing = static_cast<Component>(xRingColl);
+        Component xRingModules = xRing.child(_Unicode(modules));
+        Component xModuleOdd = xRingModules.child(_Unicode(moduleOdd));
+        Component xModuleEven = xRingModules.child(_Unicode(moduleEven));
+        Component xModuleProperties = xRing.child(_Unicode(moduleProperties));
+        Component xModulePropertiesComp = xModuleProperties.child(_Unicode(components));
+        Component xSensorProperties = xRing.child(_Unicode(sensorProperties));
+
+        //// added to have rings printed in hierarchy
+        std::string ringName = "ring" + std::to_string(ringCounter);
+        dd4hep::Assembly ringAssembly(ringName);
+        
+        DetElement ringElement(discDetElementVec.back(), ringName, ringCounter);
+
+        PlacedVolume placedRing = discVolumeVec.back().placeVolume(ringAssembly);
+        placedRing.addPhysVolID("ring", ringCounter++);
+        ringElement.setPlacement(placedRing);
+        /////////////////////////////////////////////
+
+        // place components in module
+        double integratedCompThickness = 0.;
+        for (dd4hep::xml::Collection_t xCompColl(xModulePropertiesComp, _U(component)); nullptr != xCompColl;
+             ++xCompColl) {
+          Component xComp = static_cast<Component>(xCompColl);
+
+          double compMinWidth = 0.5 * xModuleProperties.attr<double>("modWidthMin");
+          double compMaxWidth = 0.5 * xModuleProperties.attr<double>("modWidthMax");
+          double compThickness = 0.5 * xComp.thickness();
+          double compLength = 0.5 * xSensorProperties.attr<double>("sensorLength");
+          Volume componentVolume(
+              "component",
+              dd4hep::Trapezoid(compMinWidth, compMaxWidth, compThickness, compThickness, compLength),
+              lcdd.material(xComp.materialStr()));
+          componentVolume.setVisAttributes(lcdd.invisible());
+          unsigned int nPhi = xRing.attr<int>("nModules");
+          double phi = 0;
+          for (unsigned int phiIndex = 0; phiIndex < nPhi; ++phiIndex) {
+            double lX = 0;
+            double lY = 0;
+            double lZ = 0;
+            double phiTilt = 0;
+            double thetaTilt = 0;
+            if (0 == phiIndex % 2) {
+              // the rotation for the odd module is already taken care
+              // of by the position in tklayout xml
+              phi = 2 * dd4hep::pi * static_cast<double>(phiIndex) / static_cast<double>(nPhi);
+              lX = xModuleEven.X();
+              lY = xModuleEven.Y();
+              lZ = xModuleEven.Z() - xDisc.zmin() - discThickness;
+              phiTilt = xModuleEven.attr<double>("phiTilt");
+              thetaTilt = xModuleEven.attr<double>("thetaTilt");
+            } else {
+              lX = xModuleOdd.X();
+              lY = xModuleOdd.Y();
+              lZ = xModuleOdd.Z() - xDisc.zmin() - discThickness;
+              phiTilt = xModuleOdd.attr<double>("phiTilt");
+              thetaTilt = xModuleOdd.attr<double>("thetaTilt");
+            }
+            // position module in the x-y plane, smaller end inward
+            // and incorporate phi tilt if any
+            dd4hep::RotationY lRotation1(M_PI * 0.5);
+            dd4hep::RotationX lRotation2(M_PI * 0.5 + phiTilt);
+            // align radially
+            double componentOffset = integratedCompThickness - 0.5 * xModuleProperties.attr<double>("modThickness") +
+                0.5 * xComp.thickness();
+            dd4hep::RotationZ lRotation3(atan2(lY, lX));
+            // theta tilt, if any -- note the different convention between
+            // tklayout and here, thus the subtraction of pi / 2
+            dd4hep::RotationY lRotation4(thetaTilt - M_PI * 0.5);
+            dd4hep::RotationZ lRotation_PhiPos(phi);
+            // position in  disk
+            dd4hep::Translation3D lTranslation(lX, lY, lZ + componentOffset);
+            dd4hep::Transform3D myTrafo(lRotation4 * lRotation3 * lRotation2 * lRotation1, lTranslation);
+            PlacedVolume placedComponentVolume =
+                ringAssembly.placeVolume(componentVolume, lRotation_PhiPos * myTrafo);
+            if (xComp.isSensitive()) {
+              placedComponentVolume.addPhysVolID("component", compCounter);
+              componentVolume.setSensitiveDetector(sensDet);
+              DetElement moduleDetElement(ringElement, "comp" + std::to_string(compCounter), compCounter); //added ringElement in place of discDetElementVec.back()
+              moduleDetElement.setPlacement(placedComponentVolume);
+              ++compCounter;
+
+              // Add the sensor extension
+              auto &params = FCCHelper::ensureExtension<dd4hep::rec::VariantParameters>(
+                moduleDetElement);
+              params.set<std::string>("axis_definitions", "XZY");
+            }
+          }
+          integratedCompThickness += xComp.thickness();
+        }
+      }
+    } else {
+      discDetElementVec.emplace_back(discDetElementVec.back().clone("disc" + std::to_string(discCounter)));
+      posEcapDetElement.add(discDetElementVec.back());
+    }
+    PlacedVolume placedDiscVolume = envelopeVolume.placeVolume(discVolumeVec.back(), dd4hep::Position(0, 0, currentZ));
+    placedDiscVolume.addPhysVolID("disc", discCounter);
+    ++discCounter;
+
+    discDetElementVec.back().setPlacement(placedDiscVolume);
+  }
+
+  dd4hep::Assembly bothEndcaps("bothEndcapsEnvelope");
+
+  dd4hep::Translation3D envelopeTranslation(0, 0, dimensions.zmin() + envelopeThickness);
+
+  dd4hep::RotationX envelopeNegRotation(dd4hep::pi);
+  dd4hep::RotationX envelopePosRotation(0.);
+  PlacedVolume placedEnvelopeVolume =
+      bothEndcaps.placeVolume(envelopeVolume, envelopePosRotation * envelopeTranslation);
+  PlacedVolume placedNegEnvelopeVolume =
+      bothEndcaps.placeVolume(envelopeVolume, envelopeNegRotation * envelopeTranslation);
+  placedEnvelopeVolume.addPhysVolID("posneg", 0);
+  placedNegEnvelopeVolume.addPhysVolID("posneg", 1);
+  auto negEcapDetElement = posEcapDetElement.clone(detName+"negEndcap");
+
+  posEcapDetElement.setPlacement(placedEnvelopeVolume);
+  negEcapDetElement.setPlacement(placedNegEnvelopeVolume);
+  worldDetElement.add(negEcapDetElement);
+  
+  ////set type flags
+  dd4hep::xml::setDetectorTypeFlag(xmlElement, posEcapDetElement); 
+  dd4hep::xml::setDetectorTypeFlag(xmlElement, negEcapDetElement); 
+
+
+  // top of the hierarchy
+  PlacedVolume mplv = lcdd.pickMotherVolume(worldDetElement).placeVolume(bothEndcaps);
+  worldDetElement.setPlacement(mplv);
+  mplv.addPhysVolID("system", xmlDet.id());
+  return worldDetElement;
+}
+}  // namespace det
+
+DECLARE_DETELEMENT(TkLayoutTrackerEndcap_o1_v02, det::createTkLayoutTrackerEndcap)


### PR DESCRIPTION
Introduced the FCChh Tracker Only layout. This is based on the work done by @mehrunnisamirza2, presented at the [ACTS developers meeting](https://indico.cern.ch/event/1572152/) on Oct-14, 2025. The code was taken from Mehrunnisa's [fork](https://github.com/mehrunnisamirza2/FCCDetectors/tree/feature-acts-gen1) of the FCCDetectors repository, and slightly modified.

Tests done so far:

- Overlap detection test with `ddsim`. Many overlaps have been reported. The largest ones are around 1-1.5mm. I'm also getting many overlaps when I run a similar test on `FCChh_DectMaster.xml` from the main branch of this repository, so I assume the existence of the overlaps should not prevent this PR from merging
- Translation from `DD4Hep` to the latest version of the ACTS tracking geometry (Gen3)

BEGINRELEASENOTES
- Introduced the geometry description of the FCChh Tracker Only layout 
ENDRELEASENOTES

