### PR TITLE
Use generic sensitive-detector types in compact geometries

### DIFF
--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/FCCee_ECalBarrel.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/FCCee_ECalBarrel.xml
@@ -92,7 +92,7 @@
   <detectors>
     <detector id="BarECal_id" name="ECalBarrel" type="ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01" readout="ECalBarrelEta">
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
-      <sensitive type="SimpleCalorimeterSD"/>
+      <sensitive type="calorimeter"/>
       <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">
         <material name="Aluminum"/>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/FCCee_EcalEndcaps_coneCryo.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/FCCee_EcalEndcaps_coneCryo.xml
@@ -98,7 +98,7 @@
     </detector>
     <!-- electromagnetic calorimeter -->
     <detector name="EMEC" type="CaloDiscs_o1_v01" id="DetID_ECAL_Endcap" readout="ECalEndcapPhiEta" vis="emec_envelope_vis">
-      <sensitive type="SimpleCalorimeterSD"/>
+      <sensitive type="calorimeter"/>
       <dimensions rmin1="EMEC_rmin1"  rmin2="EMEC_rmin2" rmax="EMEC_rmax" dz="(EMEC_z2-EMEC_z1)/2." z_offset="EMEC_z1+(EMEC_z2-EMEC_z1)/2."/>
       <layers> 
         <!-- thickness of a readout layer (how many 'unit layers' are merged together creating one readout) -->

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/FCCee_HCalBarrel_TileCal.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/FCCee_HCalBarrel_TileCal.xml
@@ -58,7 +58,6 @@
   <detectors>
     <detector id="BarHCal_id" name="HCalBarrel" type="HCalTileBarrel_o1_v01" readout="HCalBarrelReadout" >
       <dimensions rmin="BarHCal_rmin" rmax="BarHCal_rmax" dz="BarHCal_dz" vis="hcal_envelope" />
-      <sensitive type="BirksLawCalorimeterSD"/>
       <end_plate name="end_plate" thickness="BarHCal_end_plate_thickness" material="Fe" sensitive="false" vis="hcal_end_plate_vis" />
       <face_plate name="face_plate" thickness="BarHCal_face_plate_thickness" material="Fe" sensitive="false" vis="hcal_face_plate_vis" />
       <plate_space name="plate_space" thickness="BarHCal_plate_space" material="Air" sensitive="false" vis="hcal_air_vis" />

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/FCCee_HCalEndcaps_ThreeParts_TileCal.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/FCCee_HCalEndcaps_ThreeParts_TileCal.xml
@@ -58,7 +58,6 @@
   <detectors>
     <detector id="DetID_HCAL_Endcap" name="HCalThreePartsEndcap" type="CaloThreePartsEndcap_o1_v01" readout="HCalEndcapReadout" >
       <!-- vis="endcapHcal_envelope"> -->
-      <sensitive type="BirksLawCalorimeterSD"/>
       <dimensions rmin1="HCalEndcap_inner_radius1" rmin2="HCalEndcap_inner_radius2" rmin="HCalEndcap_inner_radius3"
 		  rmax1="HCalEndcap_outer_radius1" rmax2="HCalEndcap_outer_radius2" rmax="HCalEndcap_outer_radius3"
 		  width="(HCalEndcap_max_z1 - HCalEndcap_min_z1)*0.5"  dz="(HCalEndcap_max_z2 - HCalEndcap_min_z2)*0.5" z_length="(HCalEndcap_max_z3 - HCalEndcap_min_z3)*0.5"

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/MuonTagger.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/MuonTagger.xml
@@ -23,19 +23,19 @@
   <detectors>
     <!-- positive side: cryostat -->
     <detector id="DetID_Muon_Barrel" name="MuonTaggerBarrel" type="SimpleCylinder_o1_v01" sensitive="true" vis="muon_vis" readout="MuonTaggerPhiEta">
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
       <dimensions rmin="MuonTagger_inner_radius" rmax="MuonTagger_outer_radius"
                   dz="MuonTagger_half_length" z_offset = "0" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
     </detector>
 
     <detector id="DetID_Muon_Endcap_1" name="MuonTaggerEndcap_positive" type="SimpleCylinder_o1_v01" sensitive="true" vis="muon_vis" readout="MuonTaggerPhiEta">
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
       <dimensions rmin="MuonTaggerEndcap_inner_radius" rmax="MuonTaggerEndcap_outer_radius"
                   dz="(MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" z_offset = "MuonTaggerEndcap_min_z + (MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
     </detector>
     
     <detector id="DetID_Muon_Endcap_2" name="MuonTaggerEndcap_negative" type="SimpleCylinder_o1_v01" sensitive="true" vis="muon_vis" readout="MuonTaggerPhiEta">
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
       <dimensions rmin="MuonTaggerEndcap_inner_radius" rmax="MuonTaggerEndcap_outer_radius"
                   dz="(MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" z_offset = "-MuonTaggerEndcap_max_z + (MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
     </detector>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/SimplifiedDriftChamber.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/SimplifiedDriftChamber.xml
@@ -42,7 +42,6 @@
 
   <detectors>
     <detector id="DetID_DCH" name="CDCH" type="parametrised_SimplifiedDriftChamber_o1_v01" vis="GasVis" readout="SimplifiedDriftChamberCollection" sensitive="true" limits="SimplifiedDriftChamber_limits" region="SimplifiedDriftChamberRegion">
-      <sensitive type="SimpleDriftChamber"/>
 
       <comment> Dimensions for the drift chamber </comment>
 

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/Vertex.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/Vertex.xml
@@ -135,7 +135,7 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Vertex Detector Endcaps</comment>
-	    <sensitive type="SimpleTrackerSD"/>
+	    <sensitive type="tracker"/>
 
 	    <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_ENDCAP"/>
 

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/Vertex.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v01/Vertex.xml
@@ -135,7 +135,6 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Vertex Detector Endcaps</comment>
-	    <sensitive type="tracker"/>
 
 	    <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_ENDCAP"/>
 

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/ECalBarrel_thetamodulemerged.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/ECalBarrel_thetamodulemerged.xml
@@ -96,7 +96,7 @@
   <detectors>
     <detector id="BarECal_id" name="ECalBarrel" type="ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v02" readout="ECalBarrelModuleThetaMerged">
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
-      <sensitive type="SimpleCalorimeterSD"/>
+      <sensitive type="calorimeter"/>
       <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">
         <material name="Aluminum"/>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/ECalBarrel_thetamodulemerged_calibration.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/ECalBarrel_thetamodulemerged_calibration.xml
@@ -93,7 +93,7 @@
   <detectors>
     <detector id="BarECal_id" name="ECalBarrel" type="ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v02" readout="ECalBarrelModuleThetaMerged">
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
-      <sensitive type="SimpleCalorimeterSD"/>
+      <sensitive type="calorimeter"/>
       <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">
         <material name="Aluminum"/>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/ECalBarrel_thetamodulemerged_upstream.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/ECalBarrel_thetamodulemerged_upstream.xml
@@ -93,7 +93,7 @@
   <detectors>
     <detector id="BarECal_id" name="ECalBarrel" type="ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v02" readout="ECalBarrelModuleThetaMerged">
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
-      <sensitive type="SimpleCalorimeterSD"/>
+      <sensitive type="calorimeter"/>
       <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">
         <material name="Aluminum"/>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/ECalEndcaps_coneCryo.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/ECalEndcaps_coneCryo.xml
@@ -98,7 +98,7 @@
     </detector>
     <!-- electromagnetic calorimeter -->
     <detector name="EMEC" type="CaloDiscs_o1_v01" id="DetID_ECAL_Endcap" readout="ECalEndcapPhiEta" vis="emec_envelope_vis">
-      <sensitive type="SimpleCalorimeterSD"/>
+      <sensitive type="calorimeter"/>
       <dimensions rmin1="EMEC_rmin1"  rmin2="EMEC_rmin2" rmax="EMEC_rmax" dz="(EMEC_z2-EMEC_z1)/2." z_offset="EMEC_z1+(EMEC_z2-EMEC_z1)/2."/>
       <layers> 
         <!-- thickness of a readout layer (how many 'unit layers' are merged together creating one readout) -->

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/HCalBarrel_TileCal.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/HCalBarrel_TileCal.xml
@@ -58,7 +58,6 @@
   <detectors>
     <detector id="BarHCal_id" name="HCalBarrel" type="HCalTileBarrel_o1_v01" readout="HCalBarrelReadout">
       <dimensions rmin="BarHCal_rmin" rmax="BarHCal_rmax" dz="BarHCal_dz" vis="hcal_envelope" />
-      <sensitive type="BirksLawCalorimeterSD"/>
       <end_plate name="end_plate" thickness="BarHCal_end_plate_thickness" material="Fe" sensitive="false" vis="hcal_end_plate_vis" />
       <face_plate name="face_plate" thickness="BarHCal_face_plate_thickness" material="Fe" sensitive="false" vis="hcal_face_plate_vis" />
       <plate_space name="plate_space" thickness="BarHCal_plate_space" material="Air" sensitive="false" vis="hcal_air_vis" />

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/HCalEndcaps_ThreeParts_TileCal.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/HCalEndcaps_ThreeParts_TileCal.xml
@@ -58,7 +58,6 @@
   <detectors>
     <detector id="DetID_HCAL_Endcap" name="HCalThreePartsEndcap" type="CaloThreePartsEndcap_o1_v01" readout="HCalEndcapReadout" >
       <!-- vis="endcapHcal_envelope"> -->
-      <sensitive type="BirksLawCalorimeterSD"/>
       <dimensions rmin1="HCalEndcap_inner_radius1" rmin2="HCalEndcap_inner_radius2" rmin="HCalEndcap_inner_radius3"
 		  rmax1="HCalEndcap_outer_radius1" rmax2="HCalEndcap_outer_radius2" rmax="HCalEndcap_outer_radius3"
 		  width="(HCalEndcap_max_z1 - HCalEndcap_min_z1)*0.5"  dz="(HCalEndcap_max_z2 - HCalEndcap_min_z2)*0.5" z_length="(HCalEndcap_max_z3 - HCalEndcap_min_z3)*0.5"

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/MuonTagger.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/MuonTagger.xml
@@ -23,19 +23,19 @@
   <detectors>
     <!-- positive side: cryostat -->
     <detector id="DetID_Muon_Barrel" name="MuonTaggerBarrel" type="SimpleCylinder_o1_v01" sensitive="true" vis="muon_vis" readout="MuonTaggerPhiEta">
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
       <dimensions rmin="MuonTagger_inner_radius" rmax="MuonTagger_outer_radius"
                   dz="MuonTagger_half_length" z_offset = "0" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
     </detector>
 
     <detector id="DetID_Muon_Endcap_1" name="MuonTaggerEndcap_positive" type="SimpleCylinder_o1_v01" sensitive="true" vis="muon_vis" readout="MuonTaggerPhiEta">
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
       <dimensions rmin="MuonTaggerEndcap_inner_radius" rmax="MuonTaggerEndcap_outer_radius"
                   dz="(MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" z_offset = "MuonTaggerEndcap_min_z + (MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
     </detector>
     
     <detector id="DetID_Muon_Endcap_2" name="MuonTaggerEndcap_negative" type="SimpleCylinder_o1_v01" sensitive="true" vis="muon_vis" readout="MuonTaggerPhiEta">
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
       <dimensions rmin="MuonTaggerEndcap_inner_radius" rmax="MuonTaggerEndcap_outer_radius"
                   dz="(MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" z_offset = "-MuonTaggerEndcap_max_z + (MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
     </detector>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/Vertex.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/Vertex.xml
@@ -135,7 +135,7 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Vertex Detector Endcaps</comment>
-	    <sensitive type="SimpleTrackerSD"/>
+	    <sensitive type="tracker"/>
 
 	    <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_ENDCAP"/>
 

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/Vertex.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v02/Vertex.xml
@@ -135,7 +135,6 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Vertex Detector Endcaps</comment>
-	    <sensitive type="tracker"/>
 
 	    <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_ENDCAP"/>
 

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ECalEndcaps_Turbine_o1_v03.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ECalEndcaps_Turbine_o1_v03.xml
@@ -122,7 +122,7 @@
      <!-- electromagnetic calorimeter -->
     <detector id="EMEC_id" name="EMEC_turbine" type="ECalEndcap_Turbine_o1_v03" readout="ECalEndcapTurbine" vis="emec_envelope_vis" sensitive="true">
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP"/>
-      <sensitive type="SimpleCalorimeterSD"/>
+      <sensitive type="calorimeter"/>
        <dimensions rmin1="CryoEndcap_front_rmin" rmin2="CryoEndcap_front_rmin" rmax1="CryoEndcap_rmax" rmax2="CryoEndcap_rmax" dz="(CryoEndcap_z2-CryoEndcap_z1)/2."  z_offset="CryoEndcap_z1+(CryoEndcap_z2-CryoEndcap_z1)/2."/>
       <calorimeter name="EM_endcap">
 	<dimensions rmin="EMEC_rmin1" rmax="EMEC_rmax" dz="(EMEC_z2-EMEC_z1)/2." z_offset="EMEC_z1+(EMEC_z2-EMEC_z1)/2."/>

--- a/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/MuonTagger.xml
+++ b/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/MuonTagger.xml
@@ -23,19 +23,19 @@
   <detectors>
     <!-- positive side: cryostat -->
     <detector id="DetID_Muon_Barrel" name="MuonTaggerBarrel" type="SimpleCylinder_o1_v01" sensitive="true" vis="muon_vis" readout="MuonTaggerPhiEta">
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
       <dimensions rmin="MuonTagger_inner_radius" rmax="MuonTagger_outer_radius"
                   dz="MuonTagger_half_length" z_offset = "0" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
     </detector>
 
     <detector id="DetID_Muon_Endcap_1" name="MuonTaggerEndcap_positive" type="SimpleCylinder_o1_v01" sensitive="true" vis="muon_vis" readout="MuonTaggerPhiEta">
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
       <dimensions rmin="MuonTaggerEndcap_inner_radius" rmax="MuonTaggerEndcap_outer_radius"
                   dz="(MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" z_offset = "MuonTaggerEndcap_min_z + (MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
     </detector>
     
     <detector id="DetID_Muon_Endcap_2" name="MuonTaggerEndcap_negative" type="SimpleCylinder_o1_v01" sensitive="true" vis="muon_vis" readout="MuonTaggerPhiEta">
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
       <dimensions rmin="MuonTaggerEndcap_inner_radius" rmax="MuonTaggerEndcap_outer_radius"
                   dz="(MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" z_offset = "-MuonTaggerEndcap_max_z + (MuonTaggerEndcap_max_z - MuonTaggerEndcap_min_z)*0.5" material="Polystyrene" phi0="0" deltaphi="360*deg" vis="muon_vis"/>
     </detector>

--- a/FCCee/CLD/compact/CLD_o4_v05/LAr_ECalBarrel.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/LAr_ECalBarrel.xml
@@ -93,7 +93,7 @@
   <detectors>
     <detector id="DetID_ECal_Barrel" name="ECalBarrel" type="ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01" readout="ECalBarrelEta">
       <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
-      <sensitive type="SimpleCalorimeterSD"/>
+      <sensitive type="calorimeter"/>
       <dimensions rmin="BarCryoECal_rmin" rmax="BarCryoECal_rmax" dz="BarCryoECal_dz" vis="ecal_envelope"/>
       <cryostat name="ECAL_Cryo">
         <material name="Aluminum"/>

--- a/FCCee/CLD/compact/FCCee_o2_v03/ECalBarrel.xml
+++ b/FCCee/CLD/compact/FCCee_o2_v03/ECalBarrel.xml
@@ -36,7 +36,7 @@
             
             <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_BARREL"/>
 
-            <sensitive type="SimpleCalorimeterSD"/>
+            <sensitive type="calorimeter"/>
 
             <envelope vis="ECALVis">
                 <shape type="PolyhedraRegular" numsides="ECalBarrel_symmetry"  rmin="ECalBarrel_inner_radius" rmax="ECalBarrel_outer_radius" dz="2.*ECalBarrel_half_length"  material="Air"/>
@@ -72,7 +72,6 @@
     
     
 </lccdd>
-
 
 
 

--- a/FCCee/CLD/compact/FCCee_o2_v03/ECalEndcap.xml
+++ b/FCCee/CLD/compact/FCCee_o2_v03/ECalEndcap.xml
@@ -25,7 +25,7 @@
             
             <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP"/>
 
-            <sensitive type="SimpleCalorimeterSD"/>
+            <sensitive type="calorimeter"/>
 
             <envelope vis="ECALVis">
                 <shape type="BooleanShape" operation="Subtraction" material="Air">
@@ -63,5 +63,4 @@
 	  </plugin>
     </plugins>
 </lccdd>
-
 

--- a/FCCee/CLD/compact/FCCee_o2_v03/HCalEndcap.xml
+++ b/FCCee/CLD/compact/FCCee_o2_v03/HCalEndcap.xml
@@ -64,7 +64,7 @@
 
 	    <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_ENDCAP"/>
 
-            <sensitive type="SimpleCalorimeterSD"/>
+            <sensitive type="calorimeter"/>
 
             <envelope vis="HCALVis">
                 <shape type="Assembly"/>
@@ -108,7 +108,7 @@
 
 	    <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_ENDCAP + DetType_AUXILIARY"/>
 
-            <sensitive type="SimpleCalorimeterSD"/>
+            <sensitive type="calorimeter"/>
 
             <envelope vis="HCALVis">
                 <shape type="Assembly"/>
@@ -140,5 +140,4 @@
     
     
 </lccdd>
-
 

--- a/FCCee/CLD/compact/FCCee_o2_v03/InnerTracker.xml
+++ b/FCCee/CLD/compact/FCCee_o2_v03/InnerTracker.xml
@@ -106,7 +106,7 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Silicon Inner Tracker Barrel</comment>
-            <!-- <sensitive type="SimpleTrackerSD"/>   -->   <!-- hardcoded in the driver -->
+            <!-- <sensitive type="tracker"/>   -->   <!-- hardcoded in the driver -->
 
             <type_flags type=" DetType_TRACKER + DetType_BARREL"/>
 
@@ -136,7 +136,7 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Silicon Inner Tracker Endcaps</comment>
-            <sensitive type="SimpleTrackerSD"/>
+            <sensitive type="tracker"/>
 
             <type_flags type=" DetType_TRACKER + DetType_ENDCAP"/>
 

--- a/FCCee/CLD/compact/FCCee_o2_v03/InnerTracker.xml
+++ b/FCCee/CLD/compact/FCCee_o2_v03/InnerTracker.xml
@@ -106,7 +106,6 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Silicon Inner Tracker Barrel</comment>
-            <!-- <sensitive type="tracker"/>   -->   <!-- hardcoded in the driver -->
 
             <type_flags type=" DetType_TRACKER + DetType_BARREL"/>
 
@@ -136,7 +135,6 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Silicon Inner Tracker Endcaps</comment>
-            <sensitive type="tracker"/>
 
             <type_flags type=" DetType_TRACKER + DetType_ENDCAP"/>
 

--- a/FCCee/CLD/compact/FCCee_o2_v03/YokeBarrel.xml
+++ b/FCCee/CLD/compact/FCCee_o2_v03/YokeBarrel.xml
@@ -39,7 +39,7 @@
             
             <type_flags type=" DetType_CALORIMETER + DetType_MUON + DetType_BARREL"/>
 
-            <sensitive type="SimpleCalorimeterSD"/>
+            <sensitive type="calorimeter"/>
             
             <envelope vis="YOKEVis">
                 <shape type="PolyhedraRegular" numsides="YokeBarrel_symmetry"  rmin="YokeBarrel_inner_radius-10*env_safety" rmax="YokeBarrel_outer_radius+10*env_safety" dz="2*YokeBarrel_half_length"  material = "Air" />

--- a/FCCee/CLD/compact/FCCee_o2_v03/YokeEndcap.xml
+++ b/FCCee/CLD/compact/FCCee_o2_v03/YokeEndcap.xml
@@ -28,7 +28,7 @@
             
             <type_flags type=" DetType_CALORIMETER + DetType_MUON + DetType_ENDCAP"/>
 
-            <sensitive type="SimpleCalorimeterSD"/>
+            <sensitive type="calorimeter"/>
 
             <envelope vis="YOKEVis">
                 <shape type="BooleanShape" operation="Subtraction" material="Air">
@@ -73,5 +73,4 @@
     
     
 </lccdd>
-
 

--- a/FCCee/IDEA/compact/IDEA_o1_v01/SimplifiedDriftChamber.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v01/SimplifiedDriftChamber.xml
@@ -42,7 +42,6 @@
 
   <detectors>
     <detector id="DetID_DCH" name="CDCH" type="parametrised_SimplifiedDriftChamber_o1_v01" vis="GasVis" readout="SimplifiedDriftChamberCollection" sensitive="true" limits="SimplifiedDriftChamber_limits" region="SimplifiedDriftChamberRegion">
-      <sensitive type="SimpleDriftChamber"/>
 
       <comment> Dimensions for the drift chamber </comment>
 

--- a/FCCee/IDEA/compact/IDEA_o1_v01/Vertex.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v01/Vertex.xml
@@ -135,7 +135,7 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Vertex Detector Endcaps</comment>
-	    <sensitive type="SimpleTrackerSD"/>
+	    <sensitive type="tracker"/>
 
 	    <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_ENDCAP"/>
 

--- a/FCCee/IDEA/compact/IDEA_o1_v01/Vertex.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v01/Vertex.xml
@@ -135,7 +135,6 @@
                 <shape type="Assembly"/>
             </envelope>
             <comment>Vertex Detector Endcaps</comment>
-	    <sensitive type="tracker"/>
 
 	    <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX + DetType_ENDCAP"/>
 

--- a/FCCee/IDEA/compact/IDEA_o1_v02/DriftChamber_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v02/DriftChamber_o1_v01.xml
@@ -77,7 +77,7 @@
 
   <detectors>
     <detector id="DetID_DCH" name="CDCH" type="DriftChamber_o1_v01" readout="CDCHHits" vis="CDCH"> <!-- region="CDCH_region">-->
-      <sensitive type="SimpleTrackerSD"/>
+      <sensitive type="tracker"/>
     </detector>
   </detectors>
 

--- a/FCCee/IDEA/compact/IDEA_o1_v03/FiberDualReadoutCalo_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o1_v03/FiberDualReadoutCalo_o1_v01.xml
@@ -582,7 +582,6 @@
   <detectors>
     <detector id="DetID_FiberDRCalo" name="DRcalo" type="FiberDualReadoutCalo_o1_v01" readout="DRcaloSiPMreadout" region="FastSimOpFiberRegion" reflect="true" vis="DRCInvisible">
       <type_flags type="DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_HADRONIC + DetType_BARREL + DetType_ENDCAP"/>
-      <sensitive type="DRcaloSiPMSD"/>
       <sipmDim height="0.3*mm" material="PolyvinylChloride" vis="DRCGenericVis">
         <sipmGlass material="DR_PyrexGlass" vis="DRCGlassVis"/>
         <sipmWafer height="0.3*mm" material="Silicon" vis="DRCWaferVis" sensitive="false"/> <!-- Original height : 0.01 mm, change to 0.3 mm, same as sipmDim (to reduce memory)-->

--- a/detector/calorimeter/HCalThreePartsEndcap_o1_v01_geo.cpp
+++ b/detector/calorimeter/HCalThreePartsEndcap_o1_v01_geo.cpp
@@ -19,8 +19,8 @@ void buildEC(dd4hep::Detector& aLcdd, dd4hep::SensitiveDetector& aSensDet, dd4he
              dd4hep::DetElement& aHCal, xml_det_t aXmlElement, int sign) {
 
   dd4hep::SensitiveDetector sensDet = aSensDet;
-  Dimension sensDetType = aXmlElement.child(_Unicode(sensitive));
-  sensDet.setType(sensDetType.typeStr());
+  // sensitive detector type: generic calorimeter (BirksLawCalorimeterSD is obsolete)
+  sensDet.setType("calorimeter");
 
   Dimension dimensions(aXmlElement.child(_Unicode(dimensions)));
   xml_comp_t xEndPlate = aXmlElement.child(_Unicode(end_plate));

--- a/detector/calorimeter/HCalTileBarrel_o1_v01_geo.cpp
+++ b/detector/calorimeter/HCalTileBarrel_o1_v01_geo.cpp
@@ -24,9 +24,8 @@ static dd4hep::Ref_t createHCal(dd4hep::Detector& lcdd, xml_det_t xmlDet, dd4hep
   // Make volume that envelopes the whole barrel; set material to air
   Dimension xDimensions(xmlDet.dimensions());
 
-  // sensitive detector type read from xml (for example "SimpleCalorimeterSD")
-  Dimension xSensitive = xmlDet.child(_U(sensitive));
-  sensDet.setType(xSensitive.typeStr());
+  // sensitive detector type: generic calorimeter (BirksLawCalorimeterSD is obsolete)
+  sensDet.setType("calorimeter");
 
   xml_comp_t xEndPlate = xmlDet.child(_Unicode(end_plate));
   double dZEndPlate = xEndPlate.thickness();

--- a/detector/calorimeter/dual-readout/src/FiberDualReadoutCalo_o1_v01.cpp
+++ b/detector/calorimeter/dual-readout/src/FiberDualReadoutCalo_o1_v01.cpp
@@ -19,9 +19,8 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& description, xml_h xmlEle
   std::string name = x_det.nameStr();
   // Create the detector element
   dd4hep::DetElement drDet(name, x_det.id());
-  // set the sensitive detector type to the DD4hep calorimeter
-  dd4hep::xml::Dimension sensDetType = xmlElement.child(_Unicode(sensitive));
-  sensDet.setType(sensDetType.typeStr());
+  // set the sensitive detector type to the DD4hep calorimeter (DRcaloSiPMSD is obsolete)
+  sensDet.setType("calorimeter");
   // Get the world volume
   dd4hep::Assembly experimentalHall("hall");
   // Get the dimensions defined in the xml-tree

--- a/detector/tracker/parametrised_DriftChamber_o1_v01.cpp
+++ b/detector/tracker/parametrised_DriftChamber_o1_v01.cpp
@@ -20,8 +20,7 @@ static dd4hep::Ref_t createParamSimplifiedDriftChamber(dd4hep::Detector& theDete
   dd4hep::Volume mother = theDetector.pickMotherVolume(sdet);
 
   dd4hep::SensitiveDetector sens = aSensDet;
-  dd4hep::xml::Dimension sdType = x_det.child(_U(sensitive));
-  sens.setType(sdType.typeStr());
+  sens.setType("tracker");
 
   xml_comp_t detectorDim(x_det.child(_U(dimensions)));
   xml_comp_t layerDim(x_det.child(_U(layer)));

--- a/example/SteeringFile_IDEA_o1_v03.py
+++ b/example/SteeringFile_IDEA_o1_v03.py
@@ -101,7 +101,7 @@ SIM.vertexSigma = [0.0, 0.0, 0.0, 0.0]
 SIM.action.calo = "Geant4ScintillatorCalorimeterAction"
 
 ## List of patterns matching sensitive detectors of type Calorimeter.
-SIM.action.calorimeterSDTypes = ["calorimeter", "DRcaloSiPMSD"]
+SIM.action.calorimeterSDTypes = ["calorimeter"]
 
 ##  set the default event action
 SIM.action.event = []


### PR DESCRIPTION
Replace legacy sensitive-detector type labels in compact geometries with the generic `tracker` and `calorimeter` labels. The labels `SimpleTrackerSD`, `SimpleCalorimeterSD`, `SimpleDriftChamber`, `BirksLawCalorimeterSD` and `DRcaloSiPMSD` are (or were) defined in FCCDetectors (https://github.com/HEP-FCC/FCCDetectors), but in practice they are not used because ddsim looks for anything that contains `tracker` or `calorimeter` (https://github.com/AIDASoft/DD4hep/blob/master/DDG4/python/DDSim/DD4hepSimulation.py#L304). Types containing neither string land in the "unknown" list, which aborts the setup — this is what happened with `SimpleDriftChamber` and `DRcaloSiPMSD`.

### Detectors for which the sensitive type changes

| Detector type | Compact file(s) | Old type | New type |
|---|---|---|---|
| `ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v01` | ALLEGRO o1_v01 `FCCee_ECalBarrel.xml`, CLD o4_v05 `LAr_ECalBarrel.xml` | `SimpleCalorimeterSD` | `calorimeter` |
| `ECalBarrel_NobleLiquid_InclinedTrapezoids_o1_v02` | ALLEGRO o1_v02 `ECalBarrel_thetamodulemerged.xml` (+ `_calibration`, `_upstream`) | `SimpleCalorimeterSD` | `calorimeter` |
| `CaloDiscs_o1_v01` | ALLEGRO o1_v01 & o1_v02 `ECalEndcaps_coneCryo.xml` (EMEC) | `SimpleCalorimeterSD` | `calorimeter` |
| `ECalEndcap_Turbine_o1_v03` | ALLEGRO o1_v03 `ECalEndcaps_Turbine_o1_v03.xml` | `SimpleCalorimeterSD` | `calorimeter` |
| `CLD_GenericCalBarrel_o1_v01` | FCCee o2_v03 `ECalBarrel.xml`, `YokeBarrel.xml` | `SimpleCalorimeterSD` | `calorimeter` |
| `CLD_GenericCalEndcap_o1_v01` | FCCee o2_v03 `ECalEndcap.xml`, `HCalEndcap.xml` (x2), `YokeEndcap.xml` | `SimpleCalorimeterSD` | `calorimeter` |
| `SimpleCylinder_o1_v01` | ALLEGRO o1_v01/v02/v03 `MuonTagger.xml` (MuonTaggerBarrel, MuonTaggerEndcap) | `SimpleTrackerSD` | `tracker` |
| `DriftChamber_o1_v01` | IDEA o1_v02 `DriftChamber_o1_v01.xml` (CDCH) | `SimpleTrackerSD` | `tracker` |
| `parametrised_SimplifiedDriftChamber_o1_v01` | ALLEGRO o1_v01 & IDEA o1_v01 `SimplifiedDriftChamber.xml` (CDCH) | `SimpleDriftChamber` | `tracker` |
| `HCalTileBarrel_o1_v01` | ALLEGRO o1_v01 `FCCee_HCalBarrel_TileCal.xml`, o1_v02 `HCalBarrel_TileCal.xml` | `BirksLawCalorimeterSD` | `calorimeter` |
| `CaloThreePartsEndcap_o1_v01` | ALLEGRO o1_v01 `FCCee_HCalEndcaps_ThreeParts_TileCal.xml`, o1_v02 `HCalEndcaps_ThreeParts_TileCal.xml` | `BirksLawCalorimeterSD` | `calorimeter` |
| `FiberDualReadoutCalo_o1_v01` | IDEA o1_v03 `FiberDualReadoutCalo_o1_v01.xml` (DRcalo; also included by IDEA o1_v04 and the test compact) | `DRcaloSiPMSD` | `calorimeter` |

Notes:
- For most of these the Geant4 action selection is unchanged: the old labels already contain `tracker`/`calorimeter` and ddsim matches by substring (`SimpleCalorimeterSD` -> calo, `SimpleTrackerSD` -> tracker, `BirksLawCalorimeterSD` -> calo). The real behavioural change is for `SimpleDriftChamber` and `DRcaloSiPMSD`, which matched neither pattern and landed in the "unknown" list (aborting the ddsim setup).
- For `SimpleDriftChamber`, `BirksLawCalorimeterSD` and `DRcaloSiPMSD` the `<sensitive>` element was removed from the compact files: the drivers (`parametrised_SimplifiedDriftChamber_o1_v01`, `HCalTileBarrel_o1_v01`, `CaloThreePartsEndcap_o1_v01`, `FiberDualReadoutCalo_o1_v01`) now set the type themselves.
- For `CLD_GenericCalBarrel_o1_v01` (FCCee o2_v03 ECalBarrel, YokeBarrel) the FCCDetectors driver still overrides the type with `SimpleCalorimeterSD`; the change there only takes effect once that driver is updated.
- The IDEA o1_v03 steering files in FCC-config and k4geo (example + k4RecTracker test) were updated to drop the obsolete `DRcaloSiPMSD` entry from `calorimeterSDTypes`.

### Detectors for which nothing changes

The `<sensitive>` element was not read by the driver (the driver already sets the sensitive type itself), so removing it does not change the type:

| Detector type | Compact file(s) |
|---|---|
| `VertexEndcap_o1_v06` | ALLEGRO o1_v01 & o1_v02, IDEA o1_v01 `Vertex.xml` — driver already sets `tracker` |
| `TrackerBarrel_o1_v05` | FCCee o2_v03 `InnerTracker.xml` — driver already sets `tracker` |
| `TrackerEndcap_o2_v06` | FCCee o2_v03 `InnerTracker.xml` — driver already sets `tracker` |

BEGINRELEASENOTES
- Replace legacy sensitive-detector type labels (`SimpleTrackerSD`, `SimpleCalorimeterSD`, `SimpleDriftChamber`, `BirksLawCalorimeterSD`, `DRcaloSiPMSD`) with the generic `tracker` and `calorimeter` labels, and drop the `<sensitive>` element where the driver sets the type itself.

ENDRELEASENOTES
