### PR TITLE
fix: side leak in reflect loop

### DIFF
--- a/detector/tracker/TrackerEndcap_o2_v07_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v07_geo.cpp
@@ -279,6 +279,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
+            // NB: side has to be set explicitly here, the reflect block below leaves it at bwd
+            encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
             encoder[lcio::LCTrackerCellID::module()] = newmodule;
             encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
 


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Fixed a leak of `encoder[lcio::LCTrackerCellID::side()]` in the computation of neighbourSurfacesData for TrackerEndcap_o2_v07

ENDRELEASENOTES

When studying how to remove the LCIO dependencies from k4geo (more on that later), I noticed what looks like a bug in the computation of neighbourSurfacesData.
The `encoder[lcio::LCTrackerCellID::side()]` would leak out of module/sensor loop when reflect was used.

I am not sure what's the impact of this bug on physics, but it looks like it's been there for a while.

This PR fixes the bug for TrackerEndcap_o2_v07_geo.cpp (used by the MuColl detector concepts), but also TrackerEndcap_o2_v06, TrackerEndcap_o2_v05 and VertexEndcap_o1_v05 used by CLIC and CLD have the same issue.
I'm happy to change those too, but maybe there's a preference to keep the older detector models as they were for reproducibility of results?
