### PR TITLE
LCIO dependency removal (step #2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,15 +88,11 @@ if(NOT K4GEO_USE_LCIO)
     TrackerBarrel_o1_v03_geo.cpp
     TrackerBarrel_o1_v04_geo.cpp
     TrackerBarrel_o1_v05_geo.cpp
-    TrackerBarrel_o1_v06_geo.cpp
     TrackerEndcap_o1_v05_geo.cpp
     TrackerEndcap_o2_v06_geo.cpp
     TrackerEndcap_o2_v07_geo.cpp
-    StrawTubeTracker_o1_v01_geo.cpp
-    VertexBarrel_detailed_o1_v01_geo.cpp
     VertexEndcap_o1_v05_geo.cpp
     ZPlanarTracker_geo.cpp
-    ZSegmentedPlanarTracker_geo.cpp
     )
   foreach(lcio_source ${lcio_sources})
     list(FILTER sources EXCLUDE REGEX "${lcio_source}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,20 +52,7 @@ find_package(DD4hep 1.31 REQUIRED COMPONENTS DDRec DDG4 DDParsers)
 find_package ( ROOT REQUIRED COMPONENTS Geom GenVector)
 message ( STATUS "ROOT_VERSION: ${ROOT_VERSION}" )
 
-find_package( Geant4 REQUIRED ) 
-OPTION(K4GEO_USE_LCIO "Enable or disable the use of LCIO, which is needed for some detector constructors and plugins" ON)
-if(K4GEO_USE_LCIO)
-  find_package(LCIO REQUIRED)
-  # Shim for older LCIO versions
-  if(NOT TARGET LCIO::lcio)
-    add_library(LCIO::lcio INTERFACE IMPORTED GLOBAL)
-    set_target_properties(LCIO::lcio
-      PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${LCIO_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "${LCIO_LIBRARIES}"
-    )
-  endif()
-endif()
+find_package( Geant4 REQUIRED )
 
 file(GLOB sources
   ./detector/tracker/*.cpp
@@ -80,25 +67,6 @@ file(GLOB sources
   ./plugins/LinearSortingPolicy.cpp
   ./detector/PID/ARC_geo_o1_v01.cpp
   )
-
-if(NOT K4GEO_USE_LCIO)
-  set(lcio_sources # in ./detector/tracker
-    TrackerEndcap_o2_v05_geo.cpp
-    SiTrackerEndcap_o2_v02ext_geo.cpp
-    TrackerBarrel_o1_v03_geo.cpp
-    TrackerBarrel_o1_v04_geo.cpp
-    TrackerBarrel_o1_v05_geo.cpp
-    TrackerEndcap_o1_v05_geo.cpp
-    TrackerEndcap_o2_v06_geo.cpp
-    TrackerEndcap_o2_v07_geo.cpp
-    VertexEndcap_o1_v05_geo.cpp
-    ZPlanarTracker_geo.cpp
-    )
-  foreach(lcio_source ${lcio_sources})
-    list(FILTER sources EXCLUDE REGEX "${lcio_source}")
-  endforeach()
-  message(STATUS "Use of LCIO is DISABLED, some detectors that depend on LCIO will not be built: ${lcio_sources}")
-endif()
 
 if(${DD4hep_VERSION} VERSION_LESS 1.29)
   set(FILES_DEPENDINGON_DCH_INFO_H "DriftChamber_o1_v02.cpp" )
@@ -145,11 +113,6 @@ target_include_directories(${PackageName}G4 PRIVATE ${PROJECT_SOURCE_DIR}/detect
 
 target_link_libraries(${PackageName}   DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers ROOT::Core detectorSegmentations detectorCommon)
 target_link_libraries(${PackageName}G4 DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers DD4hep::DDG4 ROOT::Core detectorSegmentations detectorCommon podio::podioRootIO EDM4HEP::edm4hep ${Geant4_LIBRARIES})
-
-if(K4GEO_USE_LCIO)
-  target_link_libraries(${PackageName}   LCIO::lcio)
-  target_link_libraries(${PackageName}G4 LCIO::lcio)
-endif()
 
 #Create this_package.sh file, and install
 dd4hep_instantiate_package(${PackageName})

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ k4geo is distributed under the [GPLv3 License](http://www.gnu.org/licenses/gpl-3
 To build `k4geo` the following packages are required:
 - DD4hep
 - Geant4
-- LCIO
 - ROOT
 
 They are available for instance via the [Key4hep software stack](https://key4hep.github.io/key4hep-doc/), available on machines which have CVMFS mounted (e.g. lxplus).

--- a/cmake/k4geoConfig.cmake.in
+++ b/cmake/k4geoConfig.cmake.in
@@ -1,10 +1,5 @@
 set(k4geo_VERSION @k4geo_VERSION@)
 
-# Whether this k4geo was built against LCIO (K4GEO_USE_LCIO at build time).
-# Consumers can query it to know if the LCIO-dependent detector constructors
-# and plugins are present in this installation.
-set(k4geo_USE_LCIO @K4GEO_USE_LCIO@)
-
 @PACKAGE_INIT@
 
 set_and_check(k4geo_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@")
@@ -14,9 +9,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(DD4hep REQUIRED)
 find_dependency(Geant4 REQUIRED)
 find_dependency(ROOT REQUIRED COMPONENTS Geom GenVector)
-if(k4geo_USE_LCIO)
-  find_dependency(LCIO REQUIRED)
-endif()
 
 include(${k4geo_CMAKE_DIR}/k4geoConfig-targets.cmake)
 

--- a/detector/include/DetSide_k4geo.h
+++ b/detector/include/DetSide_k4geo.h
@@ -1,0 +1,20 @@
+#ifndef K4GEO_DETSIDE_K4GEO_H
+#define K4GEO_DETSIDE_K4GEO_H
+
+namespace k4geo {
+
+/** Values of the "side" field of the tracker cellID encoding
+ *  "system:5,side:-2,layer:9,module:8,sensor:8".
+ *
+ *  Replaces lcio::ILDDetID::{bwd,barrel,fwd} (UTIL/ILDConf.h), which was one of
+ *  the last two reasons k4geo linked against LCIO. DD4hep ships no equivalent.
+ */
+namespace DetSide {
+  inline constexpr int bwd = -1;
+  inline constexpr int barrel = 0;
+  inline constexpr int fwd = 1;
+} // namespace DetSide
+
+} // namespace k4geo
+
+#endif // K4GEO_DETSIDE_K4GEO_H

--- a/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
@@ -20,7 +20,7 @@
 #include "DD4hep/DetFactoryHelper.h"
 #include "DDRec/DetectorData.h"
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 #include "XML/Utilities.h"
 #include <map>
 
@@ -59,7 +59,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
+  encoder.set(encoderValue, "system", det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -193,18 +193,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
         // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+          encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+          encoder.set(encoderValue, "layer", l_id);
+          encoder.set(encoderValue, "module", mod_num);
+          encoder.set(encoderValue, "sensor", k);
 
           cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
-        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+        encoder.set(encoderValue, "side", k4geo::DetSide::fwd);
+        encoder.set(encoderValue, "layer", l_id);
+        encoder.set(encoderValue, "module", mod_num);
+        encoder.set(encoderValue, "sensor", k);
 
         const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
@@ -232,16 +232,16 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+            encoder.set(encoderValue, "module", newmodule);
+            encoder.set(encoderValue, "sensor", newsensor);
 
             neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+              encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+              encoder.set(encoderValue, "layer", l_id);
+              encoder.set(encoderValue, "module", newmodule);
+              encoder.set(encoderValue, "sensor", newsensor);
               neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }
           }

--- a/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
@@ -19,10 +19,9 @@
 //==========================================================================
 #include "DD4hep/DetFactoryHelper.h"
 #include "DDRec/DetectorData.h"
-#include "UTIL/LCTrackerConf.h"
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 #include "XML/Utilities.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
 #include <map>
 
 using namespace std;
@@ -41,6 +40,7 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
   typedef vector<PlacedVolume> Placements;
@@ -57,10 +57,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
   // encoding that was missing
 
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -194,20 +193,20 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
         // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
+          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-          cellID_reflect = encoder.lowWord(); // 32 bits
+          cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
+        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
+        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+        const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
         // compute neighbours
 
@@ -233,17 +232,17 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+            neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
+              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }
           }
         }

--- a/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
@@ -13,9 +13,8 @@
 #include "DDRec/DetectorData.h"
 #include "XML/Utilities.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 
 using namespace std;
 
@@ -35,6 +34,7 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Tube;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZPlanarData;
 
@@ -51,11 +51,10 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   PlacedVolume pv;
 
   // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
+  encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -171,11 +170,11 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         // encoding
 
-        encoder[lcio::LCTrackerCellID::layer()] = lay_id;
-        encoder[lcio::LCTrackerCellID::module()] = module_idx;
-        encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
+        encoder.set(encoderValue, k4geo::TrackerCellID::layer, lay_id);
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, module_idx);
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, sensor_idx);
 
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+        const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
         // compute neighbours
 
@@ -204,10 +203,10 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of the stave
 
             // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+            neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
           }
         }
 

--- a/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
@@ -14,7 +14,7 @@
 #include "XML/Utilities.h"
 
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 
 using namespace std;
 
@@ -53,8 +53,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   // for encoding
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
-  encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
+  encoder.set(encoderValue, "system", det_id);
+  encoder.set(encoderValue, "side", k4geo::DetSide::barrel);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -170,9 +170,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         // encoding
 
-        encoder.set(encoderValue, k4geo::TrackerCellID::layer, lay_id);
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, module_idx);
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, sensor_idx);
+        encoder.set(encoderValue, "layer", lay_id);
+        encoder.set(encoderValue, "module", module_idx);
+        encoder.set(encoderValue, "sensor", sensor_idx);
 
         const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
@@ -203,8 +203,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of the stave
 
             // encoding
-            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+            encoder.set(encoderValue, "module", newmodule);
+            encoder.set(encoderValue, "sensor", newsensor);
 
             neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
           }

--- a/detector/tracker/TrackerBarrel_o1_v04_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v04_geo.cpp
@@ -14,7 +14,7 @@
 #include "XML/Utilities.h"
 
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 
 using namespace std;
 
@@ -53,8 +53,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   // for encoding
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
-  encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
+  encoder.set(encoderValue, "system", det_id);
+  encoder.set(encoderValue, "side", k4geo::DetSide::barrel);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -171,9 +171,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         // encoding
 
-        encoder.set(encoderValue, k4geo::TrackerCellID::layer, lay_id);
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, module_idx);
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, sensor_idx);
+        encoder.set(encoderValue, "layer", lay_id);
+        encoder.set(encoderValue, "module", module_idx);
+        encoder.set(encoderValue, "sensor", sensor_idx);
 
         const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
@@ -204,8 +204,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of the stave
 
             // encoding
-            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+            encoder.set(encoderValue, "module", newmodule);
+            encoder.set(encoderValue, "sensor", newsensor);
 
             neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
           }

--- a/detector/tracker/TrackerBarrel_o1_v04_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v04_geo.cpp
@@ -13,9 +13,8 @@
 #include "DDRec/DetectorData.h"
 #include "XML/Utilities.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 
 using namespace std;
 
@@ -35,6 +34,7 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Tube;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZPlanarData;
 
@@ -51,11 +51,10 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   PlacedVolume pv;
 
   // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
+  encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -172,11 +171,11 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         // encoding
 
-        encoder[lcio::LCTrackerCellID::layer()] = lay_id;
-        encoder[lcio::LCTrackerCellID::module()] = module_idx;
-        encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
+        encoder.set(encoderValue, k4geo::TrackerCellID::layer, lay_id);
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, module_idx);
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, sensor_idx);
 
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+        const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
         // compute neighbours
 
@@ -205,10 +204,10 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of the stave
 
             // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+            neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
           }
         }
 

--- a/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
@@ -17,7 +17,7 @@
 #include "XML/Utilities.h"
 
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 
 using namespace std;
 
@@ -56,8 +56,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   // for encoding
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
-  encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
+  encoder.set(encoderValue, "system", det_id);
+  encoder.set(encoderValue, "side", k4geo::DetSide::barrel);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -184,9 +184,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         // encoding
 
-        encoder.set(encoderValue, k4geo::TrackerCellID::layer, lay_id);
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, module_idx);
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, sensor_idx);
+        encoder.set(encoderValue, "layer", lay_id);
+        encoder.set(encoderValue, "module", module_idx);
+        encoder.set(encoderValue, "sensor", sensor_idx);
 
         const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
@@ -217,8 +217,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of the stave
 
             // encoding
-            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+            encoder.set(encoderValue, "module", newmodule);
+            encoder.set(encoderValue, "sensor", newsensor);
 
             neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
           }

--- a/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
@@ -16,9 +16,8 @@
 #include "XML/DocumentHandler.h"
 #include "XML/Utilities.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 
 using namespace std;
 
@@ -38,6 +37,7 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Tube;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZPlanarData;
 
@@ -54,11 +54,10 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   PlacedVolume pv;
 
   // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
+  encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -185,11 +184,11 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         // encoding
 
-        encoder[lcio::LCTrackerCellID::layer()] = lay_id;
-        encoder[lcio::LCTrackerCellID::module()] = module_idx;
-        encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
+        encoder.set(encoderValue, k4geo::TrackerCellID::layer, lay_id);
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, module_idx);
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, sensor_idx);
 
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+        const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
         // compute neighbours
 
@@ -218,10 +217,10 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of the stave
 
             // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+            neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
           }
         }
 

--- a/detector/tracker/TrackerBarrel_o1_v06_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v06_geo.cpp
@@ -16,11 +16,6 @@
 #include "XML/DocumentHandler.h"
 #include "XML/Utilities.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/BitSet32.h>
-#include <UTIL/ILDConf.h>
-
 using dd4hep::_toString;
 using dd4hep::Assembly;
 using dd4hep::Box;
@@ -88,13 +83,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   std::map<std::string, Volume> volumes;
   std::map<std::string, Placements> sensitives;
   PlacedVolume pv;
-
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
 
   // --- create an envelope volume and position it into the world ---------------------
 

--- a/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
@@ -25,9 +25,8 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 
 using namespace std;
 
@@ -47,6 +46,7 @@ using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
@@ -64,10 +64,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   PlacedVolume pv;
 
   // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -217,20 +216,20 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
+          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-          cellID_reflect = encoder.lowWord(); // 32 bits
+          cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
+        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
+        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+        const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
         // compute neighbours
 
@@ -258,18 +257,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+            neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
+              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }
           }
         }

--- a/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
@@ -26,7 +26,7 @@
 #include <map>
 
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 
 using namespace std;
 
@@ -66,7 +66,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   // for encoding
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
+  encoder.set(encoderValue, "system", det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -216,18 +216,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+          encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+          encoder.set(encoderValue, "layer", l_id);
+          encoder.set(encoderValue, "module", mod_num);
+          encoder.set(encoderValue, "sensor", k);
 
           cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
-        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+        encoder.set(encoderValue, "side", k4geo::DetSide::fwd);
+        encoder.set(encoderValue, "layer", l_id);
+        encoder.set(encoderValue, "module", mod_num);
+        encoder.set(encoderValue, "sensor", k);
 
         const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
@@ -257,16 +257,16 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+            encoder.set(encoderValue, "module", newmodule);
+            encoder.set(encoderValue, "sensor", newsensor);
 
             neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+              encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+              encoder.set(encoderValue, "layer", l_id);
+              encoder.set(encoderValue, "module", newmodule);
+              encoder.set(encoderValue, "sensor", newsensor);
 
               neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }

--- a/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
@@ -26,7 +26,7 @@
 #include <map>
 
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 
 using namespace std;
 
@@ -68,7 +68,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   // for encoding
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
+  encoder.set(encoderValue, "system", det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -218,18 +218,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+          encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+          encoder.set(encoderValue, "layer", l_id);
+          encoder.set(encoderValue, "module", mod_num);
+          encoder.set(encoderValue, "sensor", k);
 
           cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
-        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+        encoder.set(encoderValue, "side", k4geo::DetSide::fwd);
+        encoder.set(encoderValue, "layer", l_id);
+        encoder.set(encoderValue, "module", mod_num);
+        encoder.set(encoderValue, "sensor", k);
 
         const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
@@ -259,16 +259,16 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+            encoder.set(encoderValue, "module", newmodule);
+            encoder.set(encoderValue, "sensor", newsensor);
 
             neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+              encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+              encoder.set(encoderValue, "layer", l_id);
+              encoder.set(encoderValue, "module", newmodule);
+              encoder.set(encoderValue, "sensor", newsensor);
 
               neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }

--- a/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
@@ -25,9 +25,8 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 
 using namespace std;
 
@@ -49,6 +48,7 @@ using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
@@ -66,10 +66,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   PlacedVolume pv;
 
   // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -219,20 +218,20 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
+          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-          cellID_reflect = encoder.lowWord(); // 32 bits
+          cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
+        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
+        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+        const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
         // compute neighbours
 
@@ -260,18 +259,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+            neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
+              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }
           }
         }

--- a/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
@@ -30,7 +30,7 @@
 #include <map>
 
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 
 using namespace std;
 
@@ -72,7 +72,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   // for encoding
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
+  encoder.set(encoderValue, "system", det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -234,18 +234,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+          encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+          encoder.set(encoderValue, "layer", l_id);
+          encoder.set(encoderValue, "module", mod_num);
+          encoder.set(encoderValue, "sensor", k);
 
           cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
-        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+        encoder.set(encoderValue, "side", k4geo::DetSide::fwd);
+        encoder.set(encoderValue, "layer", l_id);
+        encoder.set(encoderValue, "module", mod_num);
+        encoder.set(encoderValue, "sensor", k);
 
         const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
@@ -275,16 +275,16 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+            encoder.set(encoderValue, "module", newmodule);
+            encoder.set(encoderValue, "sensor", newsensor);
 
             neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+              encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+              encoder.set(encoderValue, "layer", l_id);
+              encoder.set(encoderValue, "module", newmodule);
+              encoder.set(encoderValue, "sensor", newsensor);
 
               neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }

--- a/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
@@ -29,9 +29,8 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 
 using namespace std;
 
@@ -53,6 +52,7 @@ using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
@@ -70,10 +70,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   PlacedVolume pv;
 
   // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -235,20 +234,20 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
+          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-          cellID_reflect = encoder.lowWord(); // 32 bits
+          cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
+        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
+        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+        const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
         // compute neighbours
 
@@ -276,18 +275,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+            neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
+              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }
           }
         }

--- a/detector/tracker/TrackerEndcap_o2_v07_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v07_geo.cpp
@@ -32,9 +32,8 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 
 using namespace std;
 
@@ -56,6 +55,7 @@ using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
@@ -73,10 +73,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   PlacedVolume pv;
 
   // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -238,20 +237,20 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
+          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-          cellID_reflect = encoder.lowWord(); // 32 bits
+          cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
+        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
+        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+        const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
         // compute neighbours
 
@@ -279,18 +278,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+            neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
+              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }
           }
         }

--- a/detector/tracker/TrackerEndcap_o2_v07_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v07_geo.cpp
@@ -33,7 +33,7 @@
 #include <map>
 
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 
 using namespace std;
 
@@ -75,7 +75,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   // for encoding
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
+  encoder.set(encoderValue, "system", det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -237,18 +237,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-          encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+          encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+          encoder.set(encoderValue, "layer", l_id);
+          encoder.set(encoderValue, "module", mod_num);
+          encoder.set(encoderValue, "sensor", k);
 
           cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
-        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, mod_num);
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+        encoder.set(encoderValue, "side", k4geo::DetSide::fwd);
+        encoder.set(encoderValue, "layer", l_id);
+        encoder.set(encoderValue, "module", mod_num);
+        encoder.set(encoderValue, "sensor", k);
 
         const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
@@ -278,16 +278,16 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
               continue; // out of disk
 
             // encoding
-            encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+            encoder.set(encoderValue, "module", newmodule);
+            encoder.set(encoderValue, "sensor", newsensor);
 
             neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
             if (reflect) {
-              encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-              encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-              encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-              encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+              encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+              encoder.set(encoderValue, "layer", l_id);
+              encoder.set(encoderValue, "module", newmodule);
+              encoder.set(encoderValue, "sensor", newsensor);
 
               neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
             }

--- a/detector/tracker/VertexEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v05_geo.cpp
@@ -19,9 +19,8 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 
 using namespace std;
 
@@ -39,6 +38,7 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
@@ -56,10 +56,9 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   PlacedVolume pv;
 
   // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -219,20 +218,20 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = 0; // only 1 ring so always 0
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
+          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+          encoder.set(encoderValue, k4geo::TrackerCellID::module, 0); // only 1 ring so always 0
+          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-          cellID_reflect = encoder.lowWord(); // 32 bits
+          cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = 0; // only 1 ring so always 0
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
+        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
+        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, 0); // only 1 ring so always 0
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
 
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+        const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
         // compute neighbours
 
@@ -254,18 +253,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             newsensor = newsensor - nmodules;
 
           // encoding
-          encoder[lcio::LCTrackerCellID::module()] = 0;
-          encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+          encoder.set(encoderValue, k4geo::TrackerCellID::module, 0);
+          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-          neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+          neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
           if (reflect) {
-            encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-            encoder[lcio::LCTrackerCellID::layer()] = l_id;
-            encoder[lcio::LCTrackerCellID::module()] = 0;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
+            encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
+            encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
+            encoder.set(encoderValue, k4geo::TrackerCellID::module, 0);
+            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
 
-            neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
+            neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
           }
         }
 

--- a/detector/tracker/VertexEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v05_geo.cpp
@@ -20,7 +20,7 @@
 #include <map>
 
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 
 using namespace std;
 
@@ -58,7 +58,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   // for encoding
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, det_id);
+  encoder.set(encoderValue, "system", det_id);
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -218,18 +218,18 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
         dd4hep::CellID cellID_reflect;
         if (reflect) {
-          encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-          encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-          encoder.set(encoderValue, k4geo::TrackerCellID::module, 0); // only 1 ring so always 0
-          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+          encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+          encoder.set(encoderValue, "layer", l_id);
+          encoder.set(encoderValue, "module", 0); // only 1 ring so always 0
+          encoder.set(encoderValue, "sensor", k);
 
           cellID_reflect = BitFieldCoder::lowWord(encoderValue); // 32 bits
         }
 
-        encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::fwd);
-        encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, 0); // only 1 ring so always 0
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, k);
+        encoder.set(encoderValue, "side", k4geo::DetSide::fwd);
+        encoder.set(encoderValue, "layer", l_id);
+        encoder.set(encoderValue, "module", 0); // only 1 ring so always 0
+        encoder.set(encoderValue, "sensor", k);
 
         const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
@@ -253,16 +253,16 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
             newsensor = newsensor - nmodules;
 
           // encoding
-          encoder.set(encoderValue, k4geo::TrackerCellID::module, 0);
-          encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+          encoder.set(encoderValue, "module", 0);
+          encoder.set(encoderValue, "sensor", newsensor);
 
           neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
 
           if (reflect) {
-            encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::bwd);
-            encoder.set(encoderValue, k4geo::TrackerCellID::layer, l_id);
-            encoder.set(encoderValue, k4geo::TrackerCellID::module, 0);
-            encoder.set(encoderValue, k4geo::TrackerCellID::sensor, newsensor);
+            encoder.set(encoderValue, "side", k4geo::DetSide::bwd);
+            encoder.set(encoderValue, "layer", l_id);
+            encoder.set(encoderValue, "module", 0);
+            encoder.set(encoderValue, "sensor", newsensor);
 
             neighbourSurfacesData->sameLayer[cellID_reflect].push_back(BitFieldCoder::lowWord(encoderValue));
           }

--- a/detector/tracker/ZPlanarTracker_geo.cpp
+++ b/detector/tracker/ZPlanarTracker_geo.cpp
@@ -15,7 +15,7 @@
 #include "DDRec/Surface.h"
 
 #include "DDSegmentation/BitFieldCoder.h"
-#include "TrackerCellID_k4geo.h"
+#include "DetSide_k4geo.h"
 
 using dd4hep::_toString;
 using dd4hep::Assembly;
@@ -57,8 +57,8 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
   // for encoding
   const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
   dd4hep::CellID encoderValue = 0;
-  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, x_det.id());
-  encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
+  encoder.set(encoderValue, "system", x_det.id());
+  encoder.set(encoderValue, "side", k4geo::DetSide::barrel);
 
   ZPlanarData* zPlanarData = new ZPlanarData;
   NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
@@ -239,10 +239,10 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 
       // encoding
 
-      encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
-      encoder.set(encoderValue, k4geo::TrackerCellID::layer, layer_id);
-      encoder.set(encoderValue, k4geo::TrackerCellID::module, nLadders);
-      encoder.set(encoderValue, k4geo::TrackerCellID::sensor,
+      encoder.set(encoderValue, "side", k4geo::DetSide::barrel);
+      encoder.set(encoderValue, "layer", layer_id);
+      encoder.set(encoderValue, "module", nLadders);
+      encoder.set(encoderValue, "sensor",
                   0); // there is no sensor defintion in VertexBarrel at the moment
 
       const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
@@ -267,8 +267,8 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
           newmodule = newmodule - nLadders;
 
         // encoding
-        encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
-        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, 0);
+        encoder.set(encoderValue, "module", newmodule);
+        encoder.set(encoderValue, "sensor", 0);
 
         neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
       }

--- a/detector/tracker/ZPlanarTracker_geo.cpp
+++ b/detector/tracker/ZPlanarTracker_geo.cpp
@@ -14,9 +14,8 @@
 #include "DDRec/DetectorData.h"
 #include "DDRec/Surface.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
+#include "DDSegmentation/BitFieldCoder.h"
+#include "TrackerCellID_k4geo.h"
 
 using dd4hep::_toString;
 using dd4hep::Assembly;
@@ -33,6 +32,7 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Volume;
+using dd4hep::DDSegmentation::BitFieldCoder;
 using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::SurfaceType;
 using dd4hep::rec::Vector3D;
@@ -55,11 +55,10 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
   PlacedVolume pv;
 
   // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = x_det.id();
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
+  const BitFieldCoder& encoder = *sens.readout().idSpec().decoder();
+  dd4hep::CellID encoderValue = 0;
+  encoder.set(encoderValue, k4geo::TrackerCellID::subdet, x_det.id());
+  encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
 
   ZPlanarData* zPlanarData = new ZPlanarData;
   NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
@@ -240,12 +239,13 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 
       // encoding
 
-      encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
-      encoder[lcio::LCTrackerCellID::layer()] = layer_id;
-      encoder[lcio::LCTrackerCellID::module()] = nLadders;
-      encoder[lcio::LCTrackerCellID::sensor()] = 0; // there is no sensor defintion in VertexBarrel at the moment
+      encoder.set(encoderValue, k4geo::TrackerCellID::side, k4geo::DetSide::barrel);
+      encoder.set(encoderValue, k4geo::TrackerCellID::layer, layer_id);
+      encoder.set(encoderValue, k4geo::TrackerCellID::module, nLadders);
+      encoder.set(encoderValue, k4geo::TrackerCellID::sensor,
+                  0); // there is no sensor defintion in VertexBarrel at the moment
 
-      const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
+      const dd4hep::CellID cellID = BitFieldCoder::lowWord(encoderValue); // 32 bits
 
       // compute neighbours
 
@@ -267,10 +267,10 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
           newmodule = newmodule - nLadders;
 
         // encoding
-        encoder[lcio::LCTrackerCellID::module()] = newmodule;
-        encoder[lcio::LCTrackerCellID::sensor()] = 0;
+        encoder.set(encoderValue, k4geo::TrackerCellID::module, newmodule);
+        encoder.set(encoderValue, k4geo::TrackerCellID::sensor, 0);
 
-        neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
+        neighbourSurfacesData->sameLayer[cellID].push_back(BitFieldCoder::lowWord(encoderValue));
       }
 
       ///////////////////

--- a/detector/tracker/ZSegmentedPlanarTracker_geo.cpp
+++ b/detector/tracker/ZSegmentedPlanarTracker_geo.cpp
@@ -15,10 +15,6 @@
 #include "DDRec/DetectorData.h"
 #include "DDRec/Surface.h"
 
-#include <UTIL/BitField64.h>
-#include <UTIL/BitSet32.h>
-#include <UTIL/ILDConf.h>
-
 using dd4hep::_toString;
 using dd4hep::Assembly;
 using dd4hep::Box;


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [x] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Removed dependency on LCIO by using dd4hep::DDSegmentation::BitFieldCoder instead of UTIL::BitField64. This allows to build and run the software stack without any of the LCIO-related packages.

ENDRELEASENOTES

This PR removes the LCIO dependency from k4geo entirely.

The whole LCIO dependency is `UTIL::BitField64` plus eight compile-time constants, used by ten tracker drivers to pack a 32-bit cellID for the `dd4hep::rec::NeighbourSurfacesData` extension. 

These have a DD4hep equivalent in `UTIL::BitField64` → `dd4hep::DDSegmentation::BitFieldCoder`, taken straight from `sens.readout().idSpec().decoder()` instead of re-parsing `fieldDescription()`.

DD4hep ships no equivalent (or at least I could not find one) for `lcio::ILDDetID::{bwd,barrel,fwd}` so the cost is a new `detector/include/DetSide_k4geo.h`. **Note that paying this costs enables to build/run a complete software stack based on gaudi/edm4hep without any of the legacy LCIO/Marlin packages**

Since we don't need LCIO anymore, the build system drops `find_package(LCIO)`, the `LCIO::lcio` shim, the `K4GEO_USE_LCIO` option and its
source-exclusion list, and both `target_link_libraries(... LCIO::lcio)` calls.

### Additional Notes

* **The cellID fields are now addressed by name, where LCIO addressed them by position.** `LCTrackerCellID::subdet()` and friends returned `static unsigned` field *indices* (0–4), not strings, so the old code indexed into the readout's field list. Every readout reachable from the ten drivers using this was audited and all are `system, side, layer, module, sensor` in that order, so the two are equivalent for everything k4geo ships — confirmed by the byte-identical geometry check below.
Names are preferable going forward: a compact file with a reordered readout now throws `unknown name` at construction instead of silently encoding into the wrong fields. Note LCIO called field 0 `subdet` while every k4geo readout calls it `system`.
* **`BitFieldCoder` is stateless**, so the mutable `BitField64` value becomes a single `dd4hep::CellID encoderValue` carried through the same code paths. This is deliberate: several endcap drivers depend on fields set before a loop persisting into it.
* **This reverts #631.** That PR made `find_dependency(LCIO)` conditional and exported `k4geo_USE_LCIO` so consumers could tell whether the LCIO-dependent constructors were present.
* Note that `k4geoG4` was linking `LCIO::lcio` despite containing no LCIO user at all.

### Verification

Geometry output is unchanged. A dump of every `NeighbourSurfacesData::sameLayer` entry was compared before/after across MAIA_v0, MuSIC_v2, CLIC_o3_v15, CLIC_o3_v07, CLIC_o2_v04_p1 and CLD_o2_v08:
**0 differing lines out of ~2.6M neighbour entries.** 

Also checked, in `ghcr.io/muoncollidersoft/mucoll-sim-ubuntu24`:
* configure + build + install with LCIO stripped from the environment entirely;
* neither `libk4geo.so` nor `libk4geoG4.so` links `liblcio`;
* all ten previously-excluded detectors are present in the resulting library;
* a downstream `find_package(k4geo)` configures against the install tree with no LCIO available;
* no LCIO mention remains in the installed CMake config;
* `ctest`: 43/45. The two failures (`t_name_check_ILD_FCCee_v01`/`_v02`) are missing beampipe STL files and fail identically on unmodified `main` in the same container (the stl files are not installed in the MuColl image).
