### PR TITLE
Remove the population of the NeighbourSurfacesData from the detector drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,19 +52,13 @@ find_package(DD4hep 1.31 REQUIRED COMPONENTS DDRec DDG4 DDParsers)
 find_package ( ROOT REQUIRED COMPONENTS Geom GenVector)
 message ( STATUS "ROOT_VERSION: ${ROOT_VERSION}" )
 
-find_package( Geant4 REQUIRED ) 
-OPTION(K4GEO_USE_LCIO "Enable or disable the use of LCIO, which is needed for some detector constructors and plugins" ON)
+find_package( Geant4 REQUIRED )
+
+# Deprecated: k4geo no longer uses LCIO. The option is kept temporarily so that
+# existing configurations passing it do not fail outright.
+OPTION(K4GEO_USE_LCIO "Deprecated and without effect: k4geo does not depend on LCIO anymore" OFF)
 if(K4GEO_USE_LCIO)
-  find_package(LCIO REQUIRED)
-  # Shim for older LCIO versions
-  if(NOT TARGET LCIO::lcio)
-    add_library(LCIO::lcio INTERFACE IMPORTED GLOBAL)
-    set_target_properties(LCIO::lcio
-      PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${LCIO_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "${LCIO_LIBRARIES}"
-    )
-  endif()
+  message(DEPRECATION "K4GEO_USE_LCIO is deprecated and has no effect, since k4geo does not depend on LCIO anymore. The option will be removed in a future release, please stop setting it.")
 endif()
 
 file(GLOB sources
@@ -126,11 +120,6 @@ target_include_directories(${PackageName}G4 PRIVATE ${PROJECT_SOURCE_DIR}/detect
 
 target_link_libraries(${PackageName}   DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers ROOT::Core detectorSegmentations detectorCommon)
 target_link_libraries(${PackageName}G4 DD4hep::DDCore DD4hep::DDRec DD4hep::DDParsers DD4hep::DDG4 ROOT::Core detectorSegmentations detectorCommon podio::podioRootIO EDM4HEP::edm4hep ${Geant4_LIBRARIES})
-
-if(K4GEO_USE_LCIO)
-  target_link_libraries(${PackageName}   LCIO::lcio)
-  target_link_libraries(${PackageName}G4 LCIO::lcio)
-endif()
 
 #Create this_package.sh file, and install
 dd4hep_instantiate_package(${PackageName})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,25 +81,6 @@ file(GLOB sources
   ./detector/PID/ARC_geo_o1_v01.cpp
   )
 
-if(NOT K4GEO_USE_LCIO)
-  set(lcio_sources # in ./detector/tracker
-    TrackerEndcap_o2_v05_geo.cpp
-    SiTrackerEndcap_o2_v02ext_geo.cpp
-    TrackerBarrel_o1_v03_geo.cpp
-    TrackerBarrel_o1_v04_geo.cpp
-    TrackerBarrel_o1_v05_geo.cpp
-    TrackerEndcap_o1_v05_geo.cpp
-    TrackerEndcap_o2_v06_geo.cpp
-    TrackerEndcap_o2_v07_geo.cpp
-    VertexEndcap_o1_v05_geo.cpp
-    ZPlanarTracker_geo.cpp
-    )
-  foreach(lcio_source ${lcio_sources})
-    list(FILTER sources EXCLUDE REGEX "${lcio_source}")
-  endforeach()
-  message(STATUS "Use of LCIO is DISABLED, some detectors that depend on LCIO will not be built: ${lcio_sources}")
-endif()
-
 if(${DD4hep_VERSION} VERSION_LESS 1.29)
   set(FILES_DEPENDINGON_DCH_INFO_H "DriftChamber_o1_v02.cpp" )
   list(FILTER sources EXCLUDE REGEX "${FILES_DEPENDINGON_DCH_INFO_H}")

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ k4geo is distributed under the [GPLv3 License](http://www.gnu.org/licenses/gpl-3
 To build `k4geo` the following packages are required:
 - DD4hep
 - Geant4
-- LCIO
 - ROOT
 
 They are available for instance via the [Key4hep software stack](https://key4hep.github.io/key4hep-doc/), available on machines which have CVMFS mounted (e.g. lxplus).

--- a/cmake/k4geoConfig.cmake.in
+++ b/cmake/k4geoConfig.cmake.in
@@ -1,10 +1,5 @@
 set(k4geo_VERSION @k4geo_VERSION@)
 
-# Whether this k4geo was built against LCIO (K4GEO_USE_LCIO at build time).
-# Consumers can query it to know if the LCIO-dependent detector constructors
-# and plugins are present in this installation.
-set(k4geo_USE_LCIO @K4GEO_USE_LCIO@)
-
 @PACKAGE_INIT@
 
 set_and_check(k4geo_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@")
@@ -14,9 +9,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(DD4hep REQUIRED)
 find_dependency(Geant4 REQUIRED)
 find_dependency(ROOT REQUIRED COMPONENTS Geom GenVector)
-if(k4geo_USE_LCIO)
-  find_dependency(LCIO REQUIRED)
-endif()
 
 include(${k4geo_CMAKE_DIR}/k4geoConfig-targets.cmake)
 

--- a/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
+++ b/detector/tracker/SiTrackerEndcap_o2_v02ext_geo.cpp
@@ -19,10 +19,7 @@
 //==========================================================================
 #include "DD4hep/DetFactoryHelper.h"
 #include "DDRec/DetectorData.h"
-#include "UTIL/LCTrackerConf.h"
 #include "XML/Utilities.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
 #include <map>
 
 using namespace std;
@@ -55,13 +52,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   map<string, Placements> sensitives;
   PlacedVolume pv;
 
-  // encoding that was missing
-
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-
   // --- create an envelope volume and position it into the world ---------------------
 
   Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
@@ -72,9 +62,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
   //-----------------------------------------------------------------------------------
   dd4hep::rec::ZDiskPetalsData* zDiskPetalsData = new dd4hep::rec::ZDiskPetalsData;
-  // neighbour surfaces added
-  dd4hep::rec::NeighbourSurfacesData* neighbourSurfacesData = new dd4hep::rec::NeighbourSurfacesData();
-  //
   std::map<std::string, double> moduleSensThickness;
 
   envelope.setVisAttributes(theDetector.invisible());
@@ -123,13 +110,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
     int ring_num = 0;
     int petal_num = 0;
     double sumZ(0.), innerR(1e100), outerR(0.);
-    // loop only to count the number of rings in a disk - it is then needed for looking for neighborous when you are in
-    // a "border" cell
-    int nrings = 0;
-
-    for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
-      nrings++;
-    }
     dd4hep::rec::ZDiskPetalsData::LayerLayout thisLayer;
 
     for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
@@ -190,63 +170,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
           }
         }
 
-        // modified on  comparison with  TrackerEndcap_o2_v06_geo.cpp
-        // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-        dd4hep::CellID cellID_reflect;
-        if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-          cellID_reflect = encoder.lowWord(); // 32 bits
-        }
-
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-        // compute neighbours
-
-        int n_neighbours_module = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-        int n_neighbours_sensor = 1;
-        int newmodule = 0, newsensor = 0;
-
-        for (int imodule = -n_neighbours_module; imodule <= n_neighbours_module; imodule++) {   // neighbouring modules
-          for (int isensor = -n_neighbours_sensor; isensor <= n_neighbours_sensor; isensor++) { // neighbouring sensors
-
-            if (imodule == 0 && isensor == 0)
-              continue; // cellID we started with
-            newmodule = mod_num + imodule;
-            newsensor = k + isensor;
-
-            // compute special case at the boundary
-            // general computation to allow (if necessary) more then adiacent neighbours (ie: +-2)
-            if (newsensor < 0)
-              newsensor = nmodules + newsensor;
-            if (newsensor >= nmodules)
-              newsensor = newsensor - nmodules;
-            if (newmodule < 0 || newmodule >= nrings)
-              continue; // out of disk
-
-            // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-
-            if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
-            }
-          }
-        }
         dz = -dz;
         phi += iphi;
       }
@@ -266,8 +189,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   sdet.setAttributes(theDetector, envelope, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
 
   sdet.addExtension<dd4hep::rec::ZDiskPetalsData>(zDiskPetalsData);
-  // added extension
-  sdet.addExtension<dd4hep::rec::NeighbourSurfacesData>(neighbourSurfacesData);
   std::cout << "XXX Tracker endcap layers:" << zDiskPetalsData->layers.size() << std::endl;
 
   return sdet;

--- a/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v03_geo.cpp
@@ -13,10 +13,6 @@
 #include "DDRec/DetectorData.h"
 #include "XML/Utilities.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
-
 using namespace std;
 
 using dd4hep::_toString;
@@ -35,7 +31,6 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Tube;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZPlanarData;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
@@ -50,13 +45,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   map<string, Placements> sensitives;
   PlacedVolume pv;
 
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
-
   // --- create an envelope volume and position it into the world ---------------------
 
   Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
@@ -67,7 +55,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
   //-----------------------------------------------------------------------------------
   ZPlanarData* zPlanarData = new ZPlanarData();
-  NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
 
   sens.setType("tracker");
 
@@ -165,54 +152,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
       for (int j = 0; j < nz; j++) {
         string sensor_name = _toString(sensor_idx, "sensor%d");
 
-        ///////////////////
-
-        // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-
-        // encoding
-
-        encoder[lcio::LCTrackerCellID::layer()] = lay_id;
-        encoder[lcio::LCTrackerCellID::module()] = module_idx;
-        encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
-
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-        // compute neighbours
-
-        int n_neighbours_module = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-        int n_neighbours_sensor = 1;
-
-        int newmodule = 0, newsensor = 0;
-
-        for (int imodule = -n_neighbours_module; imodule <= n_neighbours_module; imodule++) {   // neighbouring modules
-          for (int isensor = -n_neighbours_sensor; isensor <= n_neighbours_sensor; isensor++) { // neighbouring sensors
-
-            if (imodule == 0 && isensor == 0)
-              continue; // cellID we started with
-            newmodule = module_idx + imodule;
-            newsensor = sensor_idx + isensor;
-
-            // compute special case at the boundary
-            // general computation to allow (if necessary) more then adjacent neighbours (ie: +-2)
-
-            if (newmodule < 0)
-              newmodule = nphi + newmodule;
-            if (newmodule >= nphi)
-              newmodule = newmodule - nphi;
-
-            if (newsensor < 0 || newsensor >= nz)
-              continue; // out of the stave
-
-            // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-          }
-        }
-
-        ///////////////////
-
         // FIXME
         sensor_name = module_name + sensor_name;
 
@@ -292,7 +231,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   }
   sdet.setAttributes(theDetector, envelope, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
   sdet.addExtension<ZPlanarData>(zPlanarData);
-  sdet.addExtension<NeighbourSurfacesData>(neighbourSurfacesData);
 
   // envelope.setVisAttributes(theDetector.invisible());
   /*pv = theDetector.pickMotherVolume(sdet).placeVolume(assembly);

--- a/detector/tracker/TrackerBarrel_o1_v04_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v04_geo.cpp
@@ -13,10 +13,6 @@
 #include "DDRec/DetectorData.h"
 #include "XML/Utilities.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
-
 using namespace std;
 
 using dd4hep::_toString;
@@ -35,7 +31,6 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Tube;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZPlanarData;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
@@ -50,13 +45,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   map<string, Placements> sensitives;
   PlacedVolume pv;
 
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
-
   // --- create an envelope volume and position it into the world ---------------------
 
   Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
@@ -67,7 +55,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
   //-----------------------------------------------------------------------------------
   ZPlanarData* zPlanarData = new ZPlanarData();
-  NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
 
   sens.setType("tracker");
 
@@ -166,54 +153,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
       for (int j = 0; j < nz; j++) {
         string sensor_name = _toString(sensor_idx, "sensor%d");
 
-        ///////////////////
-
-        // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-
-        // encoding
-
-        encoder[lcio::LCTrackerCellID::layer()] = lay_id;
-        encoder[lcio::LCTrackerCellID::module()] = module_idx;
-        encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
-
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-        // compute neighbours
-
-        int n_neighbours_module = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-        int n_neighbours_sensor = 1;
-
-        int newmodule = 0, newsensor = 0;
-
-        for (int imodule = -n_neighbours_module; imodule <= n_neighbours_module; imodule++) {   // neighbouring modules
-          for (int isensor = -n_neighbours_sensor; isensor <= n_neighbours_sensor; isensor++) { // neighbouring sensors
-
-            if (imodule == 0 && isensor == 0)
-              continue; // cellID we started with
-            newmodule = module_idx + imodule;
-            newsensor = sensor_idx + isensor;
-
-            // compute special case at the boundary
-            // general computation to allow (if necessary) more then adjacent neighbours (ie: +-2)
-
-            if (newmodule < 0)
-              newmodule = nphi + newmodule;
-            if (newmodule >= nphi)
-              newmodule = newmodule - nphi;
-
-            if (newsensor < 0 || newsensor >= nz)
-              continue; // out of the stave
-
-            // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-          }
-        }
-
-        ///////////////////
-
         // FIXME
         sensor_name = module_name + sensor_name;
 
@@ -293,7 +232,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   }
   sdet.setAttributes(theDetector, envelope, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
   sdet.addExtension<ZPlanarData>(zPlanarData);
-  sdet.addExtension<NeighbourSurfacesData>(neighbourSurfacesData);
 
   // envelope.setVisAttributes(theDetector.invisible());
   /*pv = theDetector.pickMotherVolume(sdet).placeVolume(assembly);

--- a/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerBarrel_o1_v05_geo.cpp
@@ -16,10 +16,6 @@
 #include "XML/DocumentHandler.h"
 #include "XML/Utilities.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
-
 using namespace std;
 
 using dd4hep::_toString;
@@ -38,7 +34,6 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Tube;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZPlanarData;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
@@ -53,13 +48,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   map<string, Placements> sensitives;
   PlacedVolume pv;
 
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
-
   // --- create an envelope volume and position it into the world ---------------------
 
   Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
@@ -70,7 +58,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
   //-----------------------------------------------------------------------------------
   ZPlanarData* zPlanarData = new ZPlanarData();
-  NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
 
   sens.setType("tracker");
 
@@ -179,54 +166,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
       for (int j = 0; j < nz; j++) {
         string sensor_name = _toString(sensor_idx, "sensor%d");
 
-        ///////////////////
-
-        // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-
-        // encoding
-
-        encoder[lcio::LCTrackerCellID::layer()] = lay_id;
-        encoder[lcio::LCTrackerCellID::module()] = module_idx;
-        encoder[lcio::LCTrackerCellID::sensor()] = sensor_idx;
-
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-        // compute neighbours
-
-        int n_neighbours_module = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-        int n_neighbours_sensor = 1;
-
-        int newmodule = 0, newsensor = 0;
-
-        for (int imodule = -n_neighbours_module; imodule <= n_neighbours_module; imodule++) {   // neighbouring modules
-          for (int isensor = -n_neighbours_sensor; isensor <= n_neighbours_sensor; isensor++) { // neighbouring sensors
-
-            if (imodule == 0 && isensor == 0)
-              continue; // cellID we started with
-            newmodule = module_idx + imodule;
-            newsensor = sensor_idx + isensor;
-
-            // compute special case at the boundary
-            // general computation to allow (if necessary) more then adjacent neighbours (ie: +-2)
-
-            if (newmodule < 0)
-              newmodule = nphi + newmodule;
-            if (newmodule >= nphi)
-              newmodule = newmodule - nphi;
-
-            if (newsensor < 0 || newsensor >= nz)
-              continue; // out of the stave
-
-            // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-          }
-        }
-
-        ///////////////////
-
         // FIXME
         sensor_name = module_name + sensor_name;
 
@@ -306,7 +245,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   }
   sdet.setAttributes(theDetector, envelope, x_det.regionStr(), x_det.limitsStr(), x_det.visStr());
   sdet.addExtension<ZPlanarData>(zPlanarData);
-  sdet.addExtension<NeighbourSurfacesData>(neighbourSurfacesData);
 
   // envelope.setVisAttributes(theDetector.invisible());
   /*pv = theDetector.pickMotherVolume(sdet).placeVolume(assembly);

--- a/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o1_v05_geo.cpp
@@ -25,10 +25,6 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
-
 using namespace std;
 
 using dd4hep::_toString;
@@ -47,7 +43,6 @@ using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
@@ -63,12 +58,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   map<string, Placements> sensitives;
   PlacedVolume pv;
 
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-
   // --- create an envelope volume and position it into the world ---------------------
 
   Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
@@ -80,7 +69,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   //-----------------------------------------------------------------------------------
 
   ZDiskPetalsData* zDiskPetalsData = new ZDiskPetalsData;
-  NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
   std::map<std::string, double> moduleSensThickness;
 
   envelope.setVisAttributes(theDetector.invisible());
@@ -135,13 +123,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
     double sumZ(0.), innerR(1e100), outerR(0.);
 
     double sensitiveThickness(0.0);
-
-    // loop only to count the number of rings in a disk - it is then needed for looking for neighborous when you are in
-    // a "border" cell
-    int nrings = 0;
-    for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
-      nrings++;
-    }
 
     for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
       xml_comp_t x_ring = ri;
@@ -209,73 +190,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
           }
         }
 
-        ///////////////////
-
-        // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-
-        // encoding
-
-        dd4hep::CellID cellID_reflect;
-        if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-          cellID_reflect = encoder.lowWord(); // 32 bits
-        }
-
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-        // compute neighbours
-
-        int n_neighbours_module = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-        int n_neighbours_sensor = 1;
-
-        int newmodule = 0, newsensor = 0;
-
-        for (int imodule = -n_neighbours_module; imodule <= n_neighbours_module; imodule++) {   // neighbouring modules
-          for (int isensor = -n_neighbours_sensor; isensor <= n_neighbours_sensor; isensor++) { // neighbouring sensors
-
-            if (imodule == 0 && isensor == 0)
-              continue; // cellID we started with
-            newmodule = mod_num + imodule;
-            newsensor = k + isensor;
-
-            // compute special case at the boundary
-            // general computation to allow (if necessary) more then adiacent neighbours (ie: +-2)
-            if (newsensor < 0)
-              newsensor = nmodules + newsensor;
-            if (newsensor >= nmodules)
-              newsensor = newsensor - nmodules;
-
-            if (newmodule < 0 || newmodule >= nrings)
-              continue; // out of disk
-
-            // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-
-            if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
-            }
-          }
-        }
-
-        ///////////////////
-
         dz = -dz;
         phi += iphi;
       }
@@ -302,7 +216,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   }
 
   sdet.addExtension<ZDiskPetalsData>(zDiskPetalsData);
-  sdet.addExtension<NeighbourSurfacesData>(neighbourSurfacesData);
 
   return sdet;
 }

--- a/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v04_geo.cpp
@@ -45,7 +45,6 @@ using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {

--- a/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v05_geo.cpp
@@ -25,10 +25,6 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
-
 using namespace std;
 
 using dd4hep::_toString;
@@ -49,7 +45,6 @@ using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
@@ -65,12 +60,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   map<string, Placements> sensitives;
   PlacedVolume pv;
 
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-
   // --- create an envelope volume and position it into the world ---------------------
 
   Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
@@ -82,7 +71,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   //-----------------------------------------------------------------------------------
 
   ZDiskPetalsData* zDiskPetalsData = new ZDiskPetalsData;
-  NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
   std::map<std::string, double> moduleSensThickness;
 
   envelope.setVisAttributes(theDetector.invisible());
@@ -135,13 +123,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
     // Cannot handle rings in ZDiskPetalsData, calculate approximate petal quantities
     double sumZ(0.), innerR(1e100), outerR(0.);
     double sensitiveThickness(0.0);
-
-    // loop only to count the number of rings in a disk - it is then needed for looking for neighborous when you are in
-    // a "border" cell
-    int nrings = 0;
-    for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
-      nrings++;
-    }
 
     for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
       xml_comp_t x_ring = ri;
@@ -211,73 +192,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
           }
         }
 
-        ///////////////////
-
-        // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-
-        // encoding
-
-        dd4hep::CellID cellID_reflect;
-        if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-          cellID_reflect = encoder.lowWord(); // 32 bits
-        }
-
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-        // compute neighbours
-
-        int n_neighbours_module = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-        int n_neighbours_sensor = 1;
-
-        int newmodule = 0, newsensor = 0;
-
-        for (int imodule = -n_neighbours_module; imodule <= n_neighbours_module; imodule++) {   // neighbouring modules
-          for (int isensor = -n_neighbours_sensor; isensor <= n_neighbours_sensor; isensor++) { // neighbouring sensors
-
-            if (imodule == 0 && isensor == 0)
-              continue; // cellID we started with
-            newmodule = mod_num + imodule;
-            newsensor = k + isensor;
-
-            // compute special case at the boundary
-            // general computation to allow (if necessary) more then adiacent neighbours (ie: +-2)
-            if (newsensor < 0)
-              newsensor = nmodules + newsensor;
-            if (newsensor >= nmodules)
-              newsensor = newsensor - nmodules;
-
-            if (newmodule < 0 || newmodule >= nrings)
-              continue; // out of disk
-
-            // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-
-            if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
-            }
-          }
-        }
-
-        ///////////////////
-
         dz = -dz;
         phi += iphi;
       }
@@ -304,7 +218,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   }
 
   sdet.addExtension<ZDiskPetalsData>(zDiskPetalsData);
-  sdet.addExtension<NeighbourSurfacesData>(neighbourSurfacesData);
 
   return sdet;
 }

--- a/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v06_geo.cpp
@@ -29,10 +29,6 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
-
 using namespace std;
 
 using dd4hep::_toString;
@@ -53,7 +49,6 @@ using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
@@ -69,12 +64,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   map<string, Placements> sensitives;
   PlacedVolume pv;
 
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-
   // --- create an envelope volume and position it into the world ---------------------
 
   Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
@@ -86,7 +75,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   //-----------------------------------------------------------------------------------
 
   ZDiskPetalsData* zDiskPetalsData = new ZDiskPetalsData;
-  NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
   std::map<std::string, double> moduleSensThickness;
 
   envelope.setVisAttributes(theDetector.invisible());
@@ -151,13 +139,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
     // Cannot handle rings in ZDiskPetalsData, calculate approximate petal quantities
     double sumZ(0.), innerR(1e100), outerR(0.);
     double sensitiveThickness(0.0);
-
-    // loop only to count the number of rings in a disk - it is then needed for looking for neighborous when you are in
-    // a "border" cell
-    int nrings = 0;
-    for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
-      nrings++;
-    }
 
     for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
       xml_comp_t x_ring = ri;
@@ -227,73 +208,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
           }
         }
 
-        ///////////////////
-
-        // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-
-        // encoding
-
-        dd4hep::CellID cellID_reflect;
-        if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-          cellID_reflect = encoder.lowWord(); // 32 bits
-        }
-
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-        // compute neighbours
-
-        int n_neighbours_module = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-        int n_neighbours_sensor = 1;
-
-        int newmodule = 0, newsensor = 0;
-
-        for (int imodule = -n_neighbours_module; imodule <= n_neighbours_module; imodule++) {   // neighbouring modules
-          for (int isensor = -n_neighbours_sensor; isensor <= n_neighbours_sensor; isensor++) { // neighbouring sensors
-
-            if (imodule == 0 && isensor == 0)
-              continue; // cellID we started with
-            newmodule = mod_num + imodule;
-            newsensor = k + isensor;
-
-            // compute special case at the boundary
-            // general computation to allow (if necessary) more then adiacent neighbours (ie: +-2)
-            if (newsensor < 0)
-              newsensor = nmodules + newsensor;
-            if (newsensor >= nmodules)
-              newsensor = newsensor - nmodules;
-
-            if (newmodule < 0 || newmodule >= nrings)
-              continue; // out of disk
-
-            // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-
-            if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
-            }
-          }
-        }
-
-        ///////////////////
-
         dz = -dz;
         phi += iphi;
       }
@@ -320,7 +234,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   }
 
   sdet.addExtension<ZDiskPetalsData>(zDiskPetalsData);
-  sdet.addExtension<NeighbourSurfacesData>(neighbourSurfacesData);
 
   return sdet;
 }

--- a/detector/tracker/TrackerEndcap_o2_v07_geo.cpp
+++ b/detector/tracker/TrackerEndcap_o2_v07_geo.cpp
@@ -32,10 +32,6 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
-
 using namespace std;
 
 using dd4hep::_toString;
@@ -56,7 +52,6 @@ using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Tube;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
@@ -72,12 +67,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   map<string, Placements> sensitives;
   PlacedVolume pv;
 
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
-
   // --- create an envelope volume and position it into the world ---------------------
 
   Volume envelope = dd4hep::xml::createPlacedEnvelope(theDetector, e, sdet);
@@ -89,7 +78,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   //-----------------------------------------------------------------------------------
 
   ZDiskPetalsData* zDiskPetalsData = new ZDiskPetalsData;
-  NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
   std::map<std::string, double> moduleSensThickness;
 
   envelope.setVisAttributes(theDetector.invisible());
@@ -161,13 +149,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
     DetElement lay_elt_pos(sdet, _toString(l_id, "layer_pos%d"), l_id);
     DetElement lay_elt_neg(sdet, _toString(l_id, "layer_neg%d"), l_id);
 
-    // loop only to count the number of rings in a disk - it is then needed for looking for neighborous when you are in
-    // a "border" cell
-    int nrings = 0;
-    for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
-      nrings++;
-    }
-
     for (xml_coll_t ri(x_layer, _U(ring)); ri; ++ri) {
       xml_comp_t x_ring = ri;
       double r = x_ring.r();
@@ -230,73 +211,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
           }
         }
 
-        ///////////////////
-
-        // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-
-        // encoding
-
-        dd4hep::CellID cellID_reflect;
-        if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = mod_num;
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-          cellID_reflect = encoder.lowWord(); // 32 bits
-        }
-
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = mod_num;
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-        // compute neighbours
-
-        int n_neighbours_module = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-        int n_neighbours_sensor = 1;
-
-        int newmodule = 0, newsensor = 0;
-
-        for (int imodule = -n_neighbours_module; imodule <= n_neighbours_module; imodule++) {   // neighbouring modules
-          for (int isensor = -n_neighbours_sensor; isensor <= n_neighbours_sensor; isensor++) { // neighbouring sensors
-
-            if (imodule == 0 && isensor == 0)
-              continue; // cellID we started with
-            newmodule = mod_num + imodule;
-            newsensor = k + isensor;
-
-            // compute special case at the boundary
-            // general computation to allow (if necessary) more then adiacent neighbours (ie: +-2)
-            if (newsensor < 0)
-              newsensor = nmodules + newsensor;
-            if (newsensor >= nmodules)
-              newsensor = newsensor - nmodules;
-
-            if (newmodule < 0 || newmodule >= nrings)
-              continue; // out of disk
-
-            // encoding
-            encoder[lcio::LCTrackerCellID::module()] = newmodule;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-            neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-
-            if (reflect) {
-              encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-              encoder[lcio::LCTrackerCellID::layer()] = l_id;
-              encoder[lcio::LCTrackerCellID::module()] = newmodule;
-              encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-              neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
-            }
-          }
-        }
-
-        ///////////////////
-
         dz = -dz;
         phi += iphi;
       }
@@ -337,7 +251,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   }
 
   sdet.addExtension<ZDiskPetalsData>(zDiskPetalsData);
-  sdet.addExtension<NeighbourSurfacesData>(neighbourSurfacesData);
 
   return sdet;
 }

--- a/detector/tracker/VertexEndcap_o1_v05_geo.cpp
+++ b/detector/tracker/VertexEndcap_o1_v05_geo.cpp
@@ -19,10 +19,6 @@
 #include "XML/Utilities.h"
 #include <map>
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
-
 using namespace std;
 
 using dd4hep::_toString;
@@ -39,7 +35,6 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::ZDiskPetalsData;
 
 static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector sens) {
@@ -54,12 +49,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
   map<string, Volume> modules;
   map<string, Placements> sensitives;
   PlacedVolume pv;
-
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = det_id;
 
   // --- create an envelope volume and position it into the world ---------------------
 
@@ -76,7 +65,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
   // -------- reconstruction parameters  ----------------
   ZDiskPetalsData* zDiskPetalsData = new ZDiskPetalsData;
-  NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
   std::map<std::string, double> moduleSensThickness;
 
   for (xml_coll_t mi(x_det, _U(module)); mi; ++mi) {
@@ -211,66 +199,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
           }
         }
 
-        ///////////////////
-
-        // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-
-        // encoding
-
-        dd4hep::CellID cellID_reflect;
-        if (reflect) {
-          encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-          encoder[lcio::LCTrackerCellID::layer()] = l_id;
-          encoder[lcio::LCTrackerCellID::module()] = 0; // only 1 ring so always 0
-          encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-          cellID_reflect = encoder.lowWord(); // 32 bits
-        }
-
-        encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::fwd;
-        encoder[lcio::LCTrackerCellID::layer()] = l_id;
-        encoder[lcio::LCTrackerCellID::module()] = 0; // only 1 ring so always 0
-        encoder[lcio::LCTrackerCellID::sensor()] = k;
-
-        const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-        // compute neighbours
-
-        int n_neighbours_sensor = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-
-        int newsensor = 0;
-
-        for (int isensor = -n_neighbours_sensor; isensor <= n_neighbours_sensor; isensor++) { // neighbouring sensors
-
-          if (isensor == 0)
-            continue; // cellID we started with
-          newsensor = k + isensor;
-
-          // compute special case at the boundary
-          // general computation to allow (if necessary) more then adiacent neighbours (ie: +-2)
-          if (newsensor < 0)
-            newsensor = nmodules + newsensor;
-          if (newsensor >= nmodules)
-            newsensor = newsensor - nmodules;
-
-          // encoding
-          encoder[lcio::LCTrackerCellID::module()] = 0;
-          encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-          neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-
-          if (reflect) {
-            encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::bwd;
-            encoder[lcio::LCTrackerCellID::layer()] = l_id;
-            encoder[lcio::LCTrackerCellID::module()] = 0;
-            encoder[lcio::LCTrackerCellID::sensor()] = newsensor;
-
-            neighbourSurfacesData->sameLayer[cellID_reflect].push_back(encoder.lowWord());
-          }
-        }
-
-        ///////////////////
-
         // dz   = -dz; //NOTE: For "spiraling" endcaps this is not needed. Could add xml option to turn on
         phi += iphi;
       }
@@ -283,7 +211,6 @@ static Ref_t create_detector(Detector& theDetector, xml_h e, SensitiveDetector s
 
   // attach data to detector
   sdet.addExtension<ZDiskPetalsData>(zDiskPetalsData);
-  sdet.addExtension<NeighbourSurfacesData>(neighbourSurfacesData);
 
   std::cout << "XXX Vertex endcap layers: " << zDiskPetalsData->layers.size() << std::endl;
 

--- a/detector/tracker/ZPlanarTracker_geo.cpp
+++ b/detector/tracker/ZPlanarTracker_geo.cpp
@@ -14,10 +14,6 @@
 #include "DDRec/DetectorData.h"
 #include "DDRec/Surface.h"
 
-#include "UTIL/LCTrackerConf.h"
-#include <UTIL/BitField64.h>
-#include <UTIL/ILDConf.h>
-
 using dd4hep::_toString;
 using dd4hep::Assembly;
 using dd4hep::Box;
@@ -33,7 +29,6 @@ using dd4hep::SensitiveDetector;
 using dd4hep::Transform3D;
 using dd4hep::Trapezoid;
 using dd4hep::Volume;
-using dd4hep::rec::NeighbourSurfacesData;
 using dd4hep::rec::SurfaceType;
 using dd4hep::rec::Vector3D;
 using dd4hep::rec::VolPlane;
@@ -54,15 +49,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 
   PlacedVolume pv;
 
-  // for encoding
-  std::string cellIDEncoding = sens.readout().idSpec().fieldDescription();
-  UTIL::BitField64 encoder(cellIDEncoding);
-  encoder.reset();
-  encoder[lcio::LCTrackerCellID::subdet()] = x_det.id();
-  encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
-
   ZPlanarData* zPlanarData = new ZPlanarData;
-  NeighbourSurfacesData* neighbourSurfacesData = new NeighbourSurfacesData();
 
   dd4hep::xml::setDetectorTypeFlag(e, tracker);
 
@@ -233,47 +220,6 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
       ladderDE.setPlacement(pv);
 
       volSurfaceList(ladderDE)->push_back(surf);
-
-      ///////////////////
-
-      // get cellID and fill map< cellID of surface, vector of cellID of neighbouring surfaces >
-
-      // encoding
-
-      encoder[lcio::LCTrackerCellID::side()] = lcio::ILDDetID::barrel;
-      encoder[lcio::LCTrackerCellID::layer()] = layer_id;
-      encoder[lcio::LCTrackerCellID::module()] = nLadders;
-      encoder[lcio::LCTrackerCellID::sensor()] = 0; // there is no sensor defintion in VertexBarrel at the moment
-
-      const dd4hep::CellID cellID = encoder.lowWord(); // 32 bits
-
-      // compute neighbours
-
-      int n_neighbours_module = 1; // 1 gives the adjacent modules (i do not think we would like to change this)
-
-      int newmodule = 0;
-
-      for (int imodule = -n_neighbours_module; imodule <= n_neighbours_module; imodule++) { // neighbouring modules
-
-        if (imodule == 0)
-          continue; // cellID we started with
-        newmodule = nLadders + imodule;
-
-        // compute special case at the boundary
-        // general computation to allow (if necessary) more then adiacent neighbours (ie: +-2)
-        if (newmodule < 0)
-          newmodule = nLadders + newmodule;
-        if (newmodule >= nLadders)
-          newmodule = newmodule - nLadders;
-
-        // encoding
-        encoder[lcio::LCTrackerCellID::module()] = newmodule;
-        encoder[lcio::LCTrackerCellID::sensor()] = 0;
-
-        neighbourSurfacesData->sameLayer[cellID].push_back(encoder.lowWord());
-      }
-
-      ///////////////////
     }
 
     //    tracker.setVisAttributes(theDetector, x_det.visStr(),laddervol);
@@ -304,7 +250,6 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 #endif //----------------------------------------------------------------------------------
 
   tracker.addExtension<ZPlanarData>(zPlanarData);
-  tracker.addExtension<NeighbourSurfacesData>(neighbourSurfacesData);
 
   Volume mother = theDetector.pickMotherVolume(tracker);
 


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [ ] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Remove the population of the `NeighbourSurfacesData` from the detector drivers as these are never used downstream by anything that is in production (or still being actively developed)
- Remove LCIO as a dependency because it is no longer necessary
- Deprecate the `K4GEO_USE_LCIO` option and default it to `OFF`.

ENDRELEASENOTES

Fixes #635 

This will make #632 and #634 obsolete

Disclaimer: This was mostly done via Claude.

