### PR TITLE
Adjust MAIA B field in z direction

### DIFF
--- a/MuColl/MAIA/compact/MAIA_v0/MAIA_v0.xml
+++ b/MuColl/MAIA/compact/MAIA_v0/MAIA_v0.xml
@@ -249,10 +249,11 @@
     </plugins>
 
     <fields>
+        <!-- Note that zmax is set here to go into the endcap region so that track states at the endcaps have non zero omega -->
 		<field name="GlobalSolenoid" type="solenoid"
 			inner_field="5.0*tesla"
 			outer_field="-0.936941*tesla"
-			zmax="Solenoid_half_length-SolenoidVacuumTank_thickness"
+			zmax="ECalEndcap_min_z+2*env_safety"
 			inner_radius="Solenoid_inner_radius+SolenoidVacuumTank_thickness + SolenoidCoil_thickness/2"
 			outer_radius="HCalBarrel_outer_radius">
 		</field>


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [x] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
- Extended MAIA's B solenoidal B field to zmax="ECalEndcap_min_z+2*env_safety" so that track states on the endcap face get a non-zero omega

ENDRELEASENOTES

