### PR TITLE
Fixed `BoronOxide` definitions

### DIFF
--- a/MuColl/MAIA/compact/MAIA_v0/materials.xml
+++ b/MuColl/MAIA/compact/MAIA_v0/materials.xml
@@ -196,6 +196,7 @@
 
     <material name="BoronOxide">
         <D type="density" value="2.46" unit="g/cm3"/>
+        <composite n="2" ref="B"/>
         <composite n="3" ref="O"/>
     </material>
 

--- a/MuColl/MuColl/compact/MuColl_v1/materials.xml
+++ b/MuColl/MuColl/compact/MuColl_v1/materials.xml
@@ -188,6 +188,7 @@
 
     <material name="BoronOxide">
         <D type="density" value="2.46" unit="g/cm3"/>
+        <composite n="2" ref="B"/>
         <composite n="3" ref="O"/>
     </material>
 

--- a/MuColl/MuSIC/compact/MuSIC_v2/materials.xml
+++ b/MuColl/MuSIC/compact/MuSIC_v2/materials.xml
@@ -202,6 +202,7 @@
 
     <material name="BoronOxide">
         <D type="density" value="2.46" unit="g/cm3"/>
+        <composite n="2" ref="B"/>
         <composite n="3" ref="O"/>
     </material>
 


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [ ] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md  ---- n/a
- [ ] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt ---- n/a
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following: ---- n/a
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES
Fix `BoronOxide` material in `MAIA_v0`, `MuSIC_v2`, and `MuColl_v1`. Composite definition previously contained no boron, which gave a zero boron neutron capture XS in the muon system's `PyrexGlass`.
ENDRELEASENOTES

