### PR TITLE
Group and fix dangling vis definitions for each CLD version

### DIFF
--- a/FCCee/CLD/compact/CLD_o2_v05/Beampipe_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/Beampipe_o4_v05.xml
@@ -13,14 +13,6 @@
       <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
-        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
-        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
-        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
-    </display>
-
     <detectors>
 
       <!-- ;radius calculator lisp

--- a/FCCee/CLD/compact/CLD_o2_v05/CLD_o2_v05.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/CLD_o2_v05.xml
@@ -268,24 +268,9 @@
     </regions>
 
 
-    <display>
-      <vis name="VXDVis"        alpha="0.1" r="0.1" 	g=".5"      b=".5"    showDaughters="true"  visible="false"/>
-      <vis name="ITVis"       	alpha="1.0" r="0.54"  	g="0.43"    b="0.04"  showDaughters="true"  visible="true"/>
-      <vis name="OTVis"       	alpha="1.0" r="0.8"   	g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
-      <vis name="ECALVis"     	alpha="1.0" r="0.0"   	g="0.48"    b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="HCALVis"     	alpha="1.0" r="0.74" 	g="0.81"    b="0.55"  showDaughters="true"  visible="true"/>
-      <vis name="SOLVis"      	alpha="1.0" r="0.4"   	g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
-      <vis name="YOKEVis"     	alpha="1.0" r="0.0"   	g="0.56"    b="0.28"  showDaughters="true"  visible="true"/>
-      <vis name="LCALInstrVis"  alpha="1.0" r="0.35"  	g="0.0"     b="0.47"  showDaughters="true"  visible="true"/>
-      <vis name="LCALVis"    	alpha="1.0" r="0.25"  	g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
-      <vis name="LCALCoolVis"   alpha="1.0" r="0.2"   	g="0.6"     b="0"     showDaughters="true"  visible="true"/>
-      <vis name="CompSolVis"    alpha="1.0" r="0.5"   	g="0.5"     b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="ScreenSolVis"  alpha="1.0" r="1"   	g="1"       b="0"     showDaughters="true"  visible="true"/>
-      <vis name="TantalumVis"   alpha="1.0" r="1"   	g="0.5"     b="0.5"   showDaughters="true"  visible="true"/>
-      <vis name="SupportVis"  	alpha="1"   r="0.2"   	g="0.2"     b="0.2"   showDaughters="true" visible="true"/>
-    </display>
-
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+    <include ref="display.xml"/>
 
     <include ref="Beampipe_o4_v05.xml"/>
 

--- a/FCCee/CLD/compact/CLD_o2_v05/ECalBarrel_o2_v01_03.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/ECalBarrel_o2_v01_03.xml
@@ -12,17 +12,6 @@
         </readout>
     </readouts>
 
-    <!--  Definitions of visualization attributes  -->
-    <display>
-        <vis name="ECalStaveVis"      alpha="1.0" r="0.0"  g="0.8"  b="1.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalLayerVis"      alpha="1.0" r="0.8"  g="0.8"  b="0.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalSensitiveVis"  alpha="1.0" r="0.7"  g="0.3"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalAbsorberVis"   alpha="1.0" r="0.4"  g="0.4"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalEndcapVis"     alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true"  visible="true"/>
-	<vis name="HiddenEnvelope"    alpha="0.0" r="1.0"  g="1.0"  b="1.0"  showDaughters="true"  visible="false"/>
-	<vis name="CompositeVis"      alpha="1.0" r="1.0"  g="0.0"  b="0.0"  showDaughters="true"  visible="true"/>
-    </display>
-
     <detectors>
         <detector name="ECalBarrel" type="GenericCalBarrel_o1_v01" id="DetID_ECal_Barrel" readout="ECalBarrelCollection" vis="ECALVis" gap="0.*cm">
 

--- a/FCCee/CLD/compact/CLD_o2_v05/HCalBarrel_o1_v01_01.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/HCalBarrel_o1_v01_01.xml
@@ -7,18 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="HCalBarrelVis"    alpha="1" r="0.0"  g="0.3"  b="0.8" showDaughters="true" visible="true"/>
-        <vis name="HCalStavesVis"    alpha="1" r="0.0"  g="0.0"  b="0.1" showDaughters="true" visible="false"/>
-        <vis name="HCalLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-        <vis name="HCalSensorVis"    alpha="1" r="1.0"  g="0.0"  b="0.2" showDaughters="true" visible="true"/>
-        <vis name="HCalAbsorberVis"  alpha="1" r="0.4"  g="0.4"  b="0.6" showDaughters="true" visible="true"/>
-
-        <vis name="HCalEndcapVis"          alpha="1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
-        <vis name="HCalEndcapLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="HCalBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v05/InnerTracker_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/InnerTracker_o2_v07.xml
@@ -60,14 +60,6 @@
     </detectors>
 
 
-    <display>
-        <vis name="InnerTrackerModuleVis"  alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
-        <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
-        <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="InnerTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v05/OuterTracker_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/OuterTracker_o2_v07.xml
@@ -36,14 +36,6 @@
     </detectors>
 
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="OuterTrackerLayerVis"   alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
-        <vis name="OuterTrackerModuleVis"  alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="OuterTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v05/Solenoid_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/Solenoid_o1_v01_02.xml
@@ -7,14 +7,6 @@
 
 
 
-    <display>
-        <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
-        <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
-        <vis name="SolenoidVacuum"         alpha="0" r="1"    g="1"    b="1"   showDaughters="false" visible="true"/>
-    </display>
-
-
-
     <comment>Solenoid</comment>
     <detectors>
         <detector name="Solenoid" type="DD4hep_SubdetectorAssembly" vis="SOLVis">

--- a/FCCee/CLD/compact/CLD_o2_v05/Vertex_o4_v07_smallBP.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/Vertex_o4_v07_smallBP.xml
@@ -24,14 +24,6 @@
         </detector>
     </detectors>
 
-    <display>
-        <vis name="SiVertexModuleVis"    alpha="1.0" r="1" g="1"    b="0.6"     showDaughters="true"  visible="false"/>
-        <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2"  b="0.2"     showDaughters="true"  visible="true"/>
-        <vis name="SiVertexPassiveVis"   alpha="1.0" r="0.274" g="0.274"  b="0.274"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexCableVis"     alpha="1.0" r="0.85" g="0.53"    b="0.4"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexAir"          alpha="1.0" r="0" g="0"    b="0"       showDaughters="false"  visible="false"/>
-    </display>
-
     <define>
         <constant name="VertexBarrel_zmax" value="109*mm"/>
 <!--

--- a/FCCee/CLD/compact/CLD_o2_v05/YokeBarrel_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/YokeBarrel_o1_v01_02.xml
@@ -7,15 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeBarrelVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-        <vis name="YokeStavesVis"    alpha="1" r="0"    g="0.7"  b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeLayerVis"     alpha="1" r="0"    g="1"    b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
-        <vis name="YokeAbsorberVis"  alpha="1" r="0.28" g="0.4"  b="0.62" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="YokeBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v05/YokeEndcap_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/YokeEndcap_o1_v01_02.xml
@@ -8,11 +8,6 @@
         </readout>
     </readouts>
 
-        <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeEndcapVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Includes for sensitives and support                -->
     <detectors>
 

--- a/FCCee/CLD/compact/CLD_o2_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/display.xml
@@ -20,7 +20,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
-    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/> 
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -34,7 +34,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
-    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -66,8 +66,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
-    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
-    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -83,12 +83,12 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
-    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 
-    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <!-- Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
     <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
 
-    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
+    <!-- LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
     <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
     <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o2_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/display.xml
@@ -5,7 +5,7 @@
 
   <display>
 
-    <!-- Global palette (retrieved from CLD_o2_v05.xml) -->
+    <!-- Global palette (originally retrieved from CLD_o2_v05.xml) -->
     <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
     <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
     <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
@@ -22,13 +22,13 @@
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/> 
 
-    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <!-- Beampipe (originally retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
     <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
     <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
     <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
 
-    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <!-- Vertex (originally retrieved from Vertex_o4_v07_smallBP.xml) -->
     <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
     <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
@@ -36,20 +36,20 @@
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
     <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
-    <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
+    <!-- Inner tracker (originally retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
     <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
     <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- Outer tracker (retrieved from OuterTracker_o2_v07.xml) -->
+    <!-- Outer tracker (originally retrieved from OuterTracker_o2_v07.xml) -->
     <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
     <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <!-- ECal barrel / endcap (originally retrieved from ECalBarrel_o2_v01_03.xml) -->
     <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
     <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
     <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
@@ -58,7 +58,7 @@
     <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
     <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <!-- HCal barrel / endcap (originally retrieved from HCalBarrel_o1_v01_01.xml) -->
     <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
     <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
     <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
@@ -69,19 +69,19 @@
     <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
     <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <!-- Solenoid (originally retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
     <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
     <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
 
-    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <!-- Yoke barrel (originally retrieved from YokeBarrel_o1_v01_02.xml) -->
     <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
     <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
 
-    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <!-- Yoke endcap (originally retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 

--- a/FCCee/CLD/compact/CLD_o2_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/display.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+
+  <!-- FCCee CLD_o2_v05: legacy visualization (color) definitions -->
+
+  <display>
+
+    <!-- Global palette (retrieved from CLD_o2_v05.xml) -->
+    <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
+    <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
+    <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
+    <vis name="ECALVis" alpha="1.0" r="0.0" g="0.48" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="HCALVis" alpha="1.0" r="0.74" g="0.81" b="0.55" showDaughters="true" visible="true"/>
+    <vis name="SOLVis" alpha="1.0" r="0.4" g="0.4" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="YOKEVis" alpha="1.0" r="0.0" g="0.56" b="0.28" showDaughters="true" visible="true"/>
+    <vis name="LCALInstrVis" alpha="1.0" r="0.35" g="0.0" b="0.47" showDaughters="true" visible="true"/>
+    <vis name="LCALVis" alpha="1.0" r="0.25" g="0.88" b="0.81" showDaughters="true" visible="true"/>
+    <vis name="LCALCoolVis" alpha="1.0" r="0.2" g="0.6" b="0" showDaughters="true" visible="true"/>
+    <vis name="CompSolVis" alpha="1.0" r="0.5" g="0.5" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
+    <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+
+    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+    <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+
+    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
+    <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
+    <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+
+    <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
+    <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+    <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
+    <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- Outer tracker (retrieved from OuterTracker_o2_v07.xml) -->
+    <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalAbsorberVis" alpha="1.0" r="0.4" g="0.4" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalEndcapVis" alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true" visible="true"/>
+    <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+    <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+
+    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
+    <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
+    <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalSensorVis" alpha="1" r="1.0" g="0.0" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+
+    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
+    <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
+    <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
+
+    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
+    <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
+
+    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+
+  </display>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/display.xml
@@ -20,7 +20,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
-    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definiton -->
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -34,7 +34,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
-    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definiton -->
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -66,8 +66,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
-    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definiton -->
-    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -83,12 +83,12 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
-    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
-    <!-- Missing definiton. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
     <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
 
-    <!-- Missing definitons. LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
+    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
     <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
     <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o2_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/display.xml
@@ -20,6 +20,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definiton -->
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -33,6 +34,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definiton -->
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -64,6 +66,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definiton -->
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -79,6 +83,17 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+
+    <!-- Missing definiton. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+
+    <!-- Missing definitons. LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
+    <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
+    <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis3" alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="LCALShieldVis" alpha="1.0" r="0.6" g="0.3" b="0.0" showDaughters="true" visible="true"/>
 
   </display>
 

--- a/FCCee/CLD/compact/CLD_o2_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v05/display.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
 
-  <!-- FCCee CLD_o2_v05: legacy visualization (color) definitions -->
+  <!-- Consolidated visualization (color) definitions -->
 
   <display>
 

--- a/FCCee/CLD/compact/CLD_o2_v06/Beampipe_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/Beampipe_o4_v05.xml
@@ -13,14 +13,6 @@
       <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
-        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
-        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
-        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
-    </display>
-
     <detectors>
 
       <!-- ;radius calculator lisp

--- a/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml
@@ -270,24 +270,9 @@
     </regions>
 
 
-    <display>
-      <vis name="VXDVis"        alpha="0.1" r="0.1" 	g=".5"      b=".5"    showDaughters="true"  visible="false"/>
-      <vis name="ITVis"       	alpha="1.0" r="0.54"  	g="0.43"    b="0.04"  showDaughters="true"  visible="true"/>
-      <vis name="OTVis"       	alpha="1.0" r="0.8"   	g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
-      <vis name="ECALVis"     	alpha="1.0" r="0.0"   	g="0.48"    b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="HCALVis"     	alpha="1.0" r="0.74" 	g="0.81"    b="0.55"  showDaughters="true"  visible="true"/>
-      <vis name="SOLVis"      	alpha="1.0" r="0.4"   	g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
-      <vis name="YOKEVis"     	alpha="1.0" r="0.0"   	g="0.56"    b="0.28"  showDaughters="true"  visible="true"/>
-      <vis name="LCALInstrVis"  alpha="1.0" r="0.35"  	g="0.0"     b="0.47"  showDaughters="true"  visible="true"/>
-      <vis name="LCALVis"    	alpha="1.0" r="0.25"  	g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
-      <vis name="LCALCoolVis"   alpha="1.0" r="0.2"   	g="0.6"     b="0"     showDaughters="true"  visible="true"/>
-      <vis name="CompSolVis"    alpha="1.0" r="0.5"   	g="0.5"     b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="ScreenSolVis"  alpha="1.0" r="1"   	g="1"       b="0"     showDaughters="true"  visible="true"/>
-      <vis name="TantalumVis"   alpha="1.0" r="1"   	g="0.5"     b="0.5"   showDaughters="true"  visible="true"/>
-      <vis name="SupportVis"  	alpha="1"   r="0.2"   	g="0.2"     b="0.2"   showDaughters="true" visible="true"/>
-    </display>
-
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+    <include ref="display.xml"/>
 
     <include ref="Beampipe_o4_v05.xml"/>
 

--- a/FCCee/CLD/compact/CLD_o2_v06/ECalBarrel_o2_v01_03.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/ECalBarrel_o2_v01_03.xml
@@ -12,17 +12,6 @@
         </readout>
     </readouts>
 
-    <!--  Definitions of visualization attributes  -->
-    <display>
-        <vis name="ECalStaveVis"      alpha="1.0" r="0.0"  g="0.8"  b="1.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalLayerVis"      alpha="1.0" r="0.8"  g="0.8"  b="0.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalSensitiveVis"  alpha="1.0" r="0.7"  g="0.3"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalAbsorberVis"   alpha="1.0" r="0.4"  g="0.4"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalEndcapVis"     alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true"  visible="true"/>
-	<vis name="HiddenEnvelope"    alpha="0.0" r="1.0"  g="1.0"  b="1.0"  showDaughters="true"  visible="false"/>
-	<vis name="CompositeVis"      alpha="1.0" r="1.0"  g="0.0"  b="0.0"  showDaughters="true"  visible="true"/>
-    </display>
-
     <detectors>
         <detector name="ECalBarrel" type="GenericCalBarrel_o1_v01" id="DetID_ECal_Barrel" readout="ECalBarrelCollection" vis="ECALVis" gap="0.*cm">
 

--- a/FCCee/CLD/compact/CLD_o2_v06/HCalBarrel_o1_v01_01.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/HCalBarrel_o1_v01_01.xml
@@ -7,18 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="HCalBarrelVis"    alpha="1" r="0.0"  g="0.3"  b="0.8" showDaughters="true" visible="true"/>
-        <vis name="HCalStavesVis"    alpha="1" r="0.0"  g="0.0"  b="0.1" showDaughters="true" visible="false"/>
-        <vis name="HCalLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-        <vis name="HCalSensorVis"    alpha="1" r="1.0"  g="0.0"  b="0.2" showDaughters="true" visible="true"/>
-        <vis name="HCalAbsorberVis"  alpha="1" r="0.4"  g="0.4"  b="0.6" showDaughters="true" visible="true"/>
-
-        <vis name="HCalEndcapVis"          alpha="1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
-        <vis name="HCalEndcapLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="HCalBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v06/InnerTracker_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/InnerTracker_o2_v07.xml
@@ -60,14 +60,6 @@
     </detectors>
 
 
-    <display>
-        <vis name="InnerTrackerModuleVis"  alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
-        <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
-        <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="InnerTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v06/OuterTracker_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/OuterTracker_o2_v07.xml
@@ -36,14 +36,6 @@
     </detectors>
 
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="OuterTrackerLayerVis"   alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
-        <vis name="OuterTrackerModuleVis"  alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="OuterTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v06/Solenoid_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/Solenoid_o1_v01_02.xml
@@ -7,14 +7,6 @@
 
 
 
-    <display>
-        <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
-        <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
-        <vis name="SolenoidVacuum"         alpha="0" r="1"    g="1"    b="1"   showDaughters="false" visible="true"/>
-    </display>
-
-
-
     <comment>Solenoid</comment>
     <detectors>
         <detector name="Solenoid" type="DD4hep_SubdetectorAssembly" vis="SOLVis">

--- a/FCCee/CLD/compact/CLD_o2_v06/Vertex_o4_v07_smallBP.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/Vertex_o4_v07_smallBP.xml
@@ -24,14 +24,6 @@
         </detector>
     </detectors>
 
-    <display>
-        <vis name="SiVertexModuleVis"    alpha="1.0" r="1" g="1"    b="0.6"     showDaughters="true"  visible="false"/>
-        <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2"  b="0.2"     showDaughters="true"  visible="true"/>
-        <vis name="SiVertexPassiveVis"   alpha="1.0" r="0.274" g="0.274"  b="0.274"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexCableVis"     alpha="1.0" r="0.85" g="0.53"    b="0.4"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexAir"          alpha="1.0" r="0" g="0"    b="0"       showDaughters="false"  visible="false"/>
-    </display>
-
     <define>
         <constant name="VertexBarrel_zmax" value="109*mm"/>
 <!--

--- a/FCCee/CLD/compact/CLD_o2_v06/YokeBarrel_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/YokeBarrel_o1_v01_02.xml
@@ -7,15 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeBarrelVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-        <vis name="YokeStavesVis"    alpha="1" r="0"    g="0.7"  b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeLayerVis"     alpha="1" r="0"    g="1"    b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
-        <vis name="YokeAbsorberVis"  alpha="1" r="0.28" g="0.4"  b="0.62" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="YokeBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v06/YokeEndcap_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/YokeEndcap_o1_v01_02.xml
@@ -8,11 +8,6 @@
         </readout>
     </readouts>
 
-        <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeEndcapVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Includes for sensitives and support                -->
     <detectors>
 

--- a/FCCee/CLD/compact/CLD_o2_v06/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/display.xml
@@ -20,7 +20,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
-    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -34,7 +34,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
-    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -66,8 +66,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
-    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
-    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -83,12 +83,12 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
-    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 
-    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <!-- Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
     <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
 
-    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_04.xml) -->
+    <!-- LumiCal (referenced in LumiCal_o3_v02_04.xml) -->
     <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
     <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o2_v06/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/display.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
 
+  <!-- Consolidated visualization (color) definitions -->
+
   <display>
 
     <!-- Global palette (retrieved from CLD_o2_v06.xml) -->

--- a/FCCee/CLD/compact/CLD_o2_v06/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/display.xml
@@ -18,7 +18,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
-    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definiton -->
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -32,7 +32,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
-    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definiton -->
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -64,8 +64,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
-    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definiton -->
-    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -81,12 +81,12 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
-    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
-    <!-- Missing definiton. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
     <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
 
-    <!-- Missing definitons. LumiCal (referenced in LumiCal_o3_v02_04.xml) -->
+    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_04.xml) -->
     <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
     <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o2_v06/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/display.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+
+  <display>
+
+    <!-- Global palette (retrieved from CLD_o2_v06.xml) -->
+    <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
+    <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
+    <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
+    <vis name="ECALVis" alpha="1.0" r="0.0" g="0.48" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="HCALVis" alpha="1.0" r="0.74" g="0.81" b="0.55" showDaughters="true" visible="true"/>
+    <vis name="SOLVis" alpha="1.0" r="0.4" g="0.4" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="YOKEVis" alpha="1.0" r="0.0" g="0.56" b="0.28" showDaughters="true" visible="true"/>
+    <vis name="LCALInstrVis" alpha="1.0" r="0.35" g="0.0" b="0.47" showDaughters="true" visible="true"/>
+    <vis name="LCALVis" alpha="1.0" r="0.25" g="0.88" b="0.81" showDaughters="true" visible="true"/>
+    <vis name="LCALCoolVis" alpha="1.0" r="0.2" g="0.6" b="0" showDaughters="true" visible="true"/>
+    <vis name="CompSolVis" alpha="1.0" r="0.5" g="0.5" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
+    <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+
+    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+    <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+
+    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
+    <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
+    <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+
+    <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
+    <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+    <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
+    <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- Outer tracker (retrieved from OuterTracker_o2_v07.xml) -->
+    <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalAbsorberVis" alpha="1.0" r="0.4" g="0.4" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalEndcapVis" alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true" visible="true"/>
+    <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+    <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+
+    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
+    <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
+    <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalSensorVis" alpha="1" r="1.0" g="0.0" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+
+    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
+    <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
+    <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
+
+    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
+    <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
+
+    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+
+  </display>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v06/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/display.xml
@@ -5,7 +5,7 @@
 
   <display>
 
-    <!-- Global palette (retrieved from CLD_o2_v06.xml) -->
+    <!-- Global palette (originally retrieved from CLD_o2_v06.xml) -->
     <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
     <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
     <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
@@ -22,13 +22,13 @@
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>
 
-    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <!-- Beampipe (originally retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
     <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
     <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
     <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
 
-    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <!-- Vertex (originally retrieved from Vertex_o4_v07_smallBP.xml) -->
     <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
     <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
@@ -36,20 +36,20 @@
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
     <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
-    <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
+    <!-- Inner tracker (originally retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
     <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
     <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- Outer tracker (retrieved from OuterTracker_o2_v07.xml) -->
+    <!-- Outer tracker (originally retrieved from OuterTracker_o2_v07.xml) -->
     <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
     <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <!-- ECal barrel / endcap (originally retrieved from ECalBarrel_o2_v01_03.xml) -->
     <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
     <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
     <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
@@ -58,7 +58,7 @@
     <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
     <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <!-- HCal barrel / endcap (originally retrieved from HCalBarrel_o1_v01_01.xml) -->
     <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
     <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
     <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
@@ -69,19 +69,19 @@
     <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
     <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <!-- Solenoid (originally retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
     <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
     <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
 
-    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <!-- Yoke barrel (originally retrieved from YokeBarrel_o1_v01_02.xml) -->
     <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
     <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
 
-    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <!-- Yoke endcap (originally retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 

--- a/FCCee/CLD/compact/CLD_o2_v06/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v06/display.xml
@@ -18,6 +18,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definiton -->
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -31,6 +32,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definiton -->
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -62,6 +64,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definiton -->
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -77,6 +81,17 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+
+    <!-- Missing definiton. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+
+    <!-- Missing definitons. LumiCal (referenced in LumiCal_o3_v02_04.xml) -->
+    <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
+    <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis3" alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="LCALShieldVis" alpha="1.0" r="0.6" g="0.3" b="0.0" showDaughters="true" visible="true"/>
 
   </display>
 

--- a/FCCee/CLD/compact/CLD_o2_v07/Beampipe_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/Beampipe_o4_v05.xml
@@ -13,14 +13,6 @@
       <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
-        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
-        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
-        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
-    </display>
-
     <detectors>
 
       <!-- ;radius calculator lisp

--- a/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml
@@ -289,24 +289,9 @@
     </regions>
 
 
-    <display>
-      <vis name="VXDVis"        alpha="0.1" r="0.1" 	g=".5"      b=".5"    showDaughters="true"  visible="false"/>
-      <vis name="ITVis"       	alpha="1.0" r="0.54"  	g="0.43"    b="0.04"  showDaughters="true"  visible="true"/>
-      <vis name="OTVis"       	alpha="1.0" r="0.8"   	g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
-      <vis name="ECALVis"     	alpha="1.0" r="0.0"   	g="0.48"    b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="HCALVis"     	alpha="1.0" r="0.74" 	g="0.81"    b="0.55"  showDaughters="true"  visible="true"/>
-      <vis name="SOLVis"      	alpha="1.0" r="0.4"   	g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
-      <vis name="YOKEVis"     	alpha="1.0" r="0.0"   	g="0.56"    b="0.28"  showDaughters="true"  visible="true"/>
-      <vis name="LCALInstrVis"  alpha="1.0" r="0.35"  	g="0.0"     b="0.47"  showDaughters="true"  visible="true"/>
-      <vis name="LCALVis"    	alpha="1.0" r="0.25"  	g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
-      <vis name="LCALCoolVis"   alpha="1.0" r="0.2"   	g="0.6"     b="0"     showDaughters="true"  visible="true"/>
-      <vis name="CompSolVis"    alpha="1.0" r="0.5"   	g="0.5"     b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="ScreenSolVis"  alpha="1.0" r="1"   	g="1"       b="0"     showDaughters="true"  visible="true"/>
-      <vis name="TantalumVis"   alpha="1.0" r="1"   	g="0.5"     b="0.5"   showDaughters="true"  visible="true"/>
-      <vis name="SupportVis"  	alpha="1"   r="0.2"   	g="0.2"     b="0.2"   showDaughters="true" visible="true"/>
-    </display>
-
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+    <include ref="display.xml"/>
 
     <include ref="Beampipe_o4_v05.xml"/>
 

--- a/FCCee/CLD/compact/CLD_o2_v07/ECalBarrel_o2_v01_03.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/ECalBarrel_o2_v01_03.xml
@@ -12,17 +12,6 @@
         </readout>
     </readouts>
 
-    <!--  Definitions of visualization attributes  -->
-    <display>
-        <vis name="ECalStaveVis"      alpha="1.0" r="0.0"  g="0.8"  b="1.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalLayerVis"      alpha="1.0" r="0.8"  g="0.8"  b="0.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalSensitiveVis"  alpha="1.0" r="0.7"  g="0.3"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalAbsorberVis"   alpha="1.0" r="0.4"  g="0.4"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalEndcapVis"     alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true"  visible="true"/>
-	<vis name="HiddenEnvelope"    alpha="0.0" r="1.0"  g="1.0"  b="1.0"  showDaughters="true"  visible="false"/>
-	<vis name="CompositeVis"      alpha="1.0" r="1.0"  g="0.0"  b="0.0"  showDaughters="true"  visible="true"/>
-    </display>
-
     <detectors>
         <detector name="ECalBarrel" type="GenericCalBarrel_o1_v01" id="DetID_ECal_Barrel" readout="ECalBarrelCollection" vis="ECALVis" gap="0.*cm">
 

--- a/FCCee/CLD/compact/CLD_o2_v07/HCalBarrel_o1_v01_01.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/HCalBarrel_o1_v01_01.xml
@@ -7,18 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="HCalBarrelVis"    alpha="1" r="0.0"  g="0.3"  b="0.8" showDaughters="true" visible="true"/>
-        <vis name="HCalStavesVis"    alpha="1" r="0.0"  g="0.0"  b="0.1" showDaughters="true" visible="false"/>
-        <vis name="HCalLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-        <vis name="HCalSensorVis"    alpha="1" r="1.0"  g="0.0"  b="0.2" showDaughters="true" visible="true"/>
-        <vis name="HCalAbsorberVis"  alpha="1" r="0.4"  g="0.4"  b="0.6" showDaughters="true" visible="true"/>
-
-        <vis name="HCalEndcapVis"          alpha="1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
-        <vis name="HCalEndcapLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="HCalBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v07/InnerTracker_o2_v08.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/InnerTracker_o2_v08.xml
@@ -64,14 +64,6 @@
     </detectors>
 
 
-    <display>
-        <vis name="InnerTrackerModuleVis"  alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
-        <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
-        <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="InnerTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v07/OuterTracker_o2_v08.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/OuterTracker_o2_v08.xml
@@ -36,14 +36,6 @@
     </detectors>
 
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="OuterTrackerLayerVis"   alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
-        <vis name="OuterTrackerModuleVis"  alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="OuterTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v07/Solenoid_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/Solenoid_o1_v01_02.xml
@@ -7,14 +7,6 @@
 
 
 
-    <display>
-        <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
-        <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
-        <vis name="SolenoidVacuum"         alpha="0" r="1"    g="1"    b="1"   showDaughters="false" visible="true"/>
-    </display>
-
-
-
     <comment>Solenoid</comment>
     <detectors>
         <detector name="Solenoid" type="DD4hep_SubdetectorAssembly" vis="SOLVis">

--- a/FCCee/CLD/compact/CLD_o2_v07/Vertex_o4_v07_smallBP.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/Vertex_o4_v07_smallBP.xml
@@ -24,14 +24,6 @@
         </detector>
     </detectors>
 
-    <display>
-        <vis name="SiVertexModuleVis"    alpha="1.0" r="1" g="1"    b="0.6"     showDaughters="true"  visible="false"/>
-        <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2"  b="0.2"     showDaughters="true"  visible="true"/>
-        <vis name="SiVertexPassiveVis"   alpha="1.0" r="0.274" g="0.274"  b="0.274"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexCableVis"     alpha="1.0" r="0.85" g="0.53"    b="0.4"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexAir"          alpha="1.0" r="0" g="0"    b="0"       showDaughters="false"  visible="false"/>
-    </display>
-
     <define>
         <constant name="VertexBarrel_zmax" value="109*mm"/>
 <!--

--- a/FCCee/CLD/compact/CLD_o2_v07/YokeBarrel_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/YokeBarrel_o1_v01_02.xml
@@ -7,15 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeBarrelVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-        <vis name="YokeStavesVis"    alpha="1" r="0"    g="0.7"  b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeLayerVis"     alpha="1" r="0"    g="1"    b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
-        <vis name="YokeAbsorberVis"  alpha="1" r="0.28" g="0.4"  b="0.62" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="YokeBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v07/YokeEndcap_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/YokeEndcap_o1_v01_02.xml
@@ -8,11 +8,6 @@
         </readout>
     </readouts>
 
-        <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeEndcapVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Includes for sensitives and support                -->
     <detectors>
 

--- a/FCCee/CLD/compact/CLD_o2_v07/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/display.xml
@@ -5,7 +5,7 @@
 
   <display>
 
-    <!-- Global palette (retrieved from CLD_o2_v07.xml) -->
+    <!-- Global palette (originally retrieved from CLD_o2_v07.xml) -->
     <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
     <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
     <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
@@ -23,13 +23,13 @@
     <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
     <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>
 
-    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <!-- Beampipe (originally retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
     <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
     <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
     <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
 
-    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <!-- Vertex (originally retrieved from Vertex_o4_v07_smallBP.xml) -->
     <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
     <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
@@ -37,20 +37,20 @@
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
     <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
-    <!-- Inner tracker (retrieved from InnerTracker_o2_v08.xml) -->
+    <!-- Inner tracker (originally retrieved from InnerTracker_o2_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
     <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
     <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- Outer tracker (retrieved from OuterTracker_o2_v08.xml) -->
+    <!-- Outer tracker (originally retrieved from OuterTracker_o2_v08.xml) -->
     <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
     <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <!-- ECal barrel / endcap (originally retrieved from ECalBarrel_o2_v01_03.xml) -->
     <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
     <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
     <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
@@ -59,7 +59,7 @@
     <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
     <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <!-- HCal barrel / endcap (originally retrieved from HCalBarrel_o1_v01_01.xml) -->
     <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
     <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
     <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
@@ -70,19 +70,19 @@
     <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
     <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <!-- Solenoid (originally retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
     <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
     <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
 
-    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <!-- Yoke barrel (originally retrieved from YokeBarrel_o1_v01_02.xml) -->
     <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
     <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
 
-    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <!-- Yoke endcap (originally retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 

--- a/FCCee/CLD/compact/CLD_o2_v07/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/display.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
 
+  <!-- Consolidated visualization (color) definitions -->
+
   <display>
 
     <!-- Global palette (retrieved from CLD_o2_v07.xml) -->

--- a/FCCee/CLD/compact/CLD_o2_v07/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/display.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+
+  <display>
+
+    <!-- Global palette (retrieved from CLD_o2_v07.xml) -->
+    <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
+    <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
+    <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
+    <vis name="ECALVis" alpha="1.0" r="0.0" g="0.48" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="HCALVis" alpha="1.0" r="0.74" g="0.81" b="0.55" showDaughters="true" visible="true"/>
+    <vis name="SOLVis" alpha="1.0" r="0.4" g="0.4" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="YOKEVis" alpha="1.0" r="0.0" g="0.56" b="0.28" showDaughters="true" visible="true"/>
+    <vis name="LCALInstrVis" alpha="1.0" r="0.35" g="0.0" b="0.47" showDaughters="true" visible="true"/>
+    <vis name="LCALVis" alpha="1.0" r="0.25" g="0.88" b="0.81" showDaughters="true" visible="true"/>
+    <vis name="LCALCoolVis" alpha="1.0" r="0.2" g="0.6" b="0" showDaughters="true" visible="true"/>
+    <vis name="CompSolVis" alpha="1.0" r="0.5" g="0.5" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
+    <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+
+    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+    <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+
+    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
+    <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
+    <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+
+    <!-- Inner tracker (retrieved from InnerTracker_o2_v08.xml) -->
+    <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+    <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
+    <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- Outer tracker (retrieved from OuterTracker_o2_v08.xml) -->
+    <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalAbsorberVis" alpha="1.0" r="0.4" g="0.4" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalEndcapVis" alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true" visible="true"/>
+    <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+    <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+
+    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
+    <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
+    <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalSensorVis" alpha="1" r="1.0" g="0.0" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+
+    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
+    <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
+    <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
+
+    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
+    <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
+
+    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+
+  </display>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v07/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/display.xml
@@ -18,6 +18,8 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>  <!-- Missing definiton -->
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definiton -->
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -31,6 +33,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definiton -->
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -62,6 +65,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definiton -->
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -77,7 +82,17 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definiton -->
 
+    <!-- Missing definiton. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+
+    <!-- Missing definitons. LumiCal (referenced in LumiCal_o3_v02_05.xml) -->
+    <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
+    <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis3" alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="LCALShieldVis" alpha="1.0" r="0.6" g="0.3" b="0.0" showDaughters="true" visible="true"/>
   </display>
 
 </lccdd>

--- a/FCCee/CLD/compact/CLD_o2_v07/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/display.xml
@@ -18,8 +18,8 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
-    <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>  <!-- Missing definiton -->
-    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definiton -->
+    <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>  <!-- Missing definition -->
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -33,7 +33,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
-    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definiton -->
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -65,8 +65,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
-    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definiton -->
-    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -82,12 +82,12 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
-    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definiton -->
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
-    <!-- Missing definiton. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
     <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
 
-    <!-- Missing definitons. LumiCal (referenced in LumiCal_o3_v02_05.xml) -->
+    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_05.xml) -->
     <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
     <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o2_v07/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v07/display.xml
@@ -20,8 +20,8 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
-    <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>  <!-- Missing definition -->
-    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
+    <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -35,7 +35,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
-    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -67,8 +67,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
-    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
-    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -84,12 +84,12 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
-    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 
-    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <!-- Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
     <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
 
-    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_05.xml) -->
+    <!-- LumiCal (referenced in LumiCal_o3_v02_05.xml) -->
     <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
     <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o2_v08/Beampipe_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/Beampipe_o4_v05.xml
@@ -13,14 +13,6 @@
       <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
-        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
-        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
-        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
-    </display>
-
     <detectors>
 
       <!-- ;radius calculator lisp

--- a/FCCee/CLD/compact/CLD_o2_v08/CLD_o2_v08.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/CLD_o2_v08.xml
@@ -289,24 +289,9 @@
     </regions>
 
 
-    <display>
-      <vis name="VXDVis"        alpha="0.1" r="0.1" 	g=".5"      b=".5"    showDaughters="true"  visible="false"/>
-      <vis name="ITVis"       	alpha="1.0" r="0.54"  	g="0.43"    b="0.04"  showDaughters="true"  visible="true"/>
-      <vis name="OTVis"       	alpha="1.0" r="0.8"   	g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
-      <vis name="ECALVis"     	alpha="1.0" r="0.0"   	g="0.48"    b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="HCALVis"     	alpha="1.0" r="0.74" 	g="0.81"    b="0.55"  showDaughters="true"  visible="true"/>
-      <vis name="SOLVis"      	alpha="1.0" r="0.4"   	g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
-      <vis name="YOKEVis"     	alpha="1.0" r="0.0"   	g="0.56"    b="0.28"  showDaughters="true"  visible="true"/>
-      <vis name="LCALInstrVis"  alpha="1.0" r="0.35"  	g="0.0"     b="0.47"  showDaughters="true"  visible="true"/>
-      <vis name="LCALVis"    	alpha="1.0" r="0.25"  	g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
-      <vis name="LCALCoolVis"   alpha="1.0" r="0.2"   	g="0.6"     b="0"     showDaughters="true"  visible="true"/>
-      <vis name="CompSolVis"    alpha="1.0" r="0.5"   	g="0.5"     b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="ScreenSolVis"  alpha="1.0" r="1"   	g="1"       b="0"     showDaughters="true"  visible="true"/>
-      <vis name="TantalumVis"   alpha="1.0" r="1"   	g="0.5"     b="0.5"   showDaughters="true"  visible="true"/>
-      <vis name="SupportVis"  	alpha="1"   r="0.2"   	g="0.2"     b="0.2"   showDaughters="true" visible="true"/>
-    </display>
-
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+    <include ref="display.xml"/>
 
     <include ref="Beampipe_o4_v05.xml"/>
 

--- a/FCCee/CLD/compact/CLD_o2_v08/ECalBarrel_o2_v01_03.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/ECalBarrel_o2_v01_03.xml
@@ -12,17 +12,6 @@
         </readout>
     </readouts>
 
-    <!--  Definitions of visualization attributes  -->
-    <display>
-        <vis name="ECalStaveVis"      alpha="1.0" r="0.0"  g="0.8"  b="1.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalLayerVis"      alpha="1.0" r="0.8"  g="0.8"  b="0.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalSensitiveVis"  alpha="1.0" r="0.7"  g="0.3"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalAbsorberVis"   alpha="1.0" r="0.4"  g="0.4"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalEndcapVis"     alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true"  visible="true"/>
-	<vis name="HiddenEnvelope"    alpha="0.0" r="1.0"  g="1.0"  b="1.0"  showDaughters="true"  visible="false"/>
-	<vis name="CompositeVis"      alpha="1.0" r="1.0"  g="0.0"  b="0.0"  showDaughters="true"  visible="true"/>
-    </display>
-
     <detectors>
         <detector name="ECalBarrel" type="GenericCalBarrel_o1_v01" id="DetID_ECal_Barrel" readout="ECalBarrelCollection" vis="ECALVis" gap="0.*cm">
 

--- a/FCCee/CLD/compact/CLD_o2_v08/HCalBarrel_o1_v01_01.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/HCalBarrel_o1_v01_01.xml
@@ -7,18 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="HCalBarrelVis"    alpha="1" r="0.0"  g="0.3"  b="0.8" showDaughters="true" visible="true"/>
-        <vis name="HCalStavesVis"    alpha="1" r="0.0"  g="0.0"  b="0.1" showDaughters="true" visible="false"/>
-        <vis name="HCalLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-        <vis name="HCalSensorVis"    alpha="1" r="1.0"  g="0.0"  b="0.2" showDaughters="true" visible="true"/>
-        <vis name="HCalAbsorberVis"  alpha="1" r="0.4"  g="0.4"  b="0.6" showDaughters="true" visible="true"/>
-
-        <vis name="HCalEndcapVis"          alpha="1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
-        <vis name="HCalEndcapLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="HCalBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v08/InnerTracker_o2_v08.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/InnerTracker_o2_v08.xml
@@ -64,14 +64,6 @@
     </detectors>
 
 
-    <display>
-        <vis name="InnerTrackerModuleVis"  alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
-        <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
-        <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="InnerTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v08/OuterTracker_o2_v08.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/OuterTracker_o2_v08.xml
@@ -36,14 +36,6 @@
     </detectors>
 
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="OuterTrackerLayerVis"   alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
-        <vis name="OuterTrackerModuleVis"  alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="OuterTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v08/Solenoid_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/Solenoid_o1_v01_02.xml
@@ -7,14 +7,6 @@
 
 
 
-    <display>
-        <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
-        <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
-        <vis name="SolenoidVacuum"         alpha="0" r="1"    g="1"    b="1"   showDaughters="false" visible="true"/>
-    </display>
-
-
-
     <comment>Solenoid</comment>
     <detectors>
         <detector name="Solenoid" type="DD4hep_SubdetectorAssembly" vis="SOLVis">

--- a/FCCee/CLD/compact/CLD_o2_v08/Vertex_o4_v07_smallBP.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/Vertex_o4_v07_smallBP.xml
@@ -24,14 +24,6 @@
         </detector>
     </detectors>
 
-    <display>
-        <vis name="SiVertexModuleVis"    alpha="1.0" r="1" g="1"    b="0.6"     showDaughters="true"  visible="false"/>
-        <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2"  b="0.2"     showDaughters="true"  visible="true"/>
-        <vis name="SiVertexPassiveVis"   alpha="1.0" r="0.274" g="0.274"  b="0.274"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexCableVis"     alpha="1.0" r="0.85" g="0.53"    b="0.4"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexAir"          alpha="1.0" r="0" g="0"    b="0"       showDaughters="false"  visible="false"/>
-    </display>
-
     <define>
         <constant name="VertexBarrel_zmax" value="109*mm"/>
 <!--

--- a/FCCee/CLD/compact/CLD_o2_v08/YokeBarrel_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/YokeBarrel_o1_v01_02.xml
@@ -7,15 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeBarrelVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-        <vis name="YokeStavesVis"    alpha="1" r="0"    g="0.7"  b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeLayerVis"     alpha="1" r="0"    g="1"    b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
-        <vis name="YokeAbsorberVis"  alpha="1" r="0.28" g="0.4"  b="0.62" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="YokeBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o2_v08/YokeEndcap_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/YokeEndcap_o1_v01_02.xml
@@ -8,11 +8,6 @@
         </readout>
     </readouts>
 
-        <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeEndcapVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Includes for sensitives and support                -->
     <detectors>
 

--- a/FCCee/CLD/compact/CLD_o2_v08/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/display.xml
@@ -20,8 +20,8 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
-    <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>  <!-- Missing definition -->
-    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
+    <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/> 
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/> 
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -35,7 +35,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
-    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -67,8 +67,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
-    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
-    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -84,12 +84,12 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
-    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 
-    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <!-- Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
     <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
 
-    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_05.xml) -->
+    <!-- LumiCal (referenced in LumiCal_o3_v02_05.xml) -->
     <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
     <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o2_v08/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/display.xml
@@ -18,6 +18,8 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>  <!-- Missing definition -->
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -31,6 +33,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -62,6 +65,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -77,6 +82,17 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
+
+    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+
+    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_05.xml) -->
+    <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
+    <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis3" alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="LCALShieldVis" alpha="1.0" r="0.6" g="0.3" b="0.0" showDaughters="true" visible="true"/>
 
   </display>
 

--- a/FCCee/CLD/compact/CLD_o2_v08/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/display.xml
@@ -5,7 +5,7 @@
 
   <display>
 
-    <!-- Global palette (retrieved from CLD_o2_v08.xml) -->
+    <!-- Global palette (originally retrieved from CLD_o2_v08.xml) -->
     <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
     <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
     <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
@@ -23,13 +23,13 @@
     <vis name="VisibleBlue" alpha="0.1" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/> 
     <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/> 
 
-    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <!-- Beampipe (originally retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
     <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
     <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
     <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
 
-    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <!-- Vertex (originally retrieved from Vertex_o4_v07_smallBP.xml) -->
     <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
     <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
@@ -37,20 +37,20 @@
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
     <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
-    <!-- Inner tracker (retrieved from InnerTracker_o2_v08.xml) -->
+    <!-- Inner tracker (originally retrieved from InnerTracker_o2_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
     <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
     <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- Outer tracker (retrieved from OuterTracker_o2_v08.xml) -->
+    <!-- Outer tracker (originally retrieved from OuterTracker_o2_v08.xml) -->
     <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
     <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <!-- ECal barrel / endcap (originally retrieved from ECalBarrel_o2_v01_03.xml) -->
     <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
     <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
     <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
@@ -59,7 +59,7 @@
     <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
     <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <!-- HCal barrel / endcap (originally retrieved from HCalBarrel_o1_v01_01.xml) -->
     <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
     <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
     <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
@@ -70,19 +70,19 @@
     <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
     <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <!-- Solenoid (originally retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
     <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
     <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
 
-    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <!-- Yoke barrel (originally retrieved from YokeBarrel_o1_v01_02.xml) -->
     <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
     <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
 
-    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <!-- Yoke endcap (originally retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 

--- a/FCCee/CLD/compact/CLD_o2_v08/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/display.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
 
+  <!-- Consolidated visualization (color) definitions -->
+
   <display>
 
     <!-- Global palette (retrieved from CLD_o2_v08.xml) -->

--- a/FCCee/CLD/compact/CLD_o2_v08/display.xml
+++ b/FCCee/CLD/compact/CLD_o2_v08/display.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+
+  <display>
+
+    <!-- Global palette (retrieved from CLD_o2_v08.xml) -->
+    <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
+    <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
+    <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
+    <vis name="ECALVis" alpha="1.0" r="0.0" g="0.48" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="HCALVis" alpha="1.0" r="0.74" g="0.81" b="0.55" showDaughters="true" visible="true"/>
+    <vis name="SOLVis" alpha="1.0" r="0.4" g="0.4" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="YOKEVis" alpha="1.0" r="0.0" g="0.56" b="0.28" showDaughters="true" visible="true"/>
+    <vis name="LCALInstrVis" alpha="1.0" r="0.35" g="0.0" b="0.47" showDaughters="true" visible="true"/>
+    <vis name="LCALVis" alpha="1.0" r="0.25" g="0.88" b="0.81" showDaughters="true" visible="true"/>
+    <vis name="LCALCoolVis" alpha="1.0" r="0.2" g="0.6" b="0" showDaughters="true" visible="true"/>
+    <vis name="CompSolVis" alpha="1.0" r="0.5" g="0.5" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
+    <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+
+    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+    <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+
+    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
+    <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
+    <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+
+    <!-- Inner tracker (retrieved from InnerTracker_o2_v08.xml) -->
+    <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+    <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
+    <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- Outer tracker (retrieved from OuterTracker_o2_v08.xml) -->
+    <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalAbsorberVis" alpha="1.0" r="0.4" g="0.4" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalEndcapVis" alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true" visible="true"/>
+    <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+    <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+
+    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
+    <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
+    <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalSensorVis" alpha="1" r="1.0" g="0.0" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+
+    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
+    <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
+    <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
+
+    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
+    <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
+
+    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+
+  </display>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o3_v01/ARC_o1_v01.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/ARC_o1_v01.xml
@@ -5,39 +5,6 @@
   <gdmlFile ref="RadiatorCell_FinalOptimisation_o1_v01.xml"/>
 </includes>
 
-<display>
-  <vis name="arc_vessel_vis"  r="236/256" g="237/256" b="232/256" alpha="1.00"  showDaughters="true" visible="false" />
-  <vis name="arc_gas_vis"     r="227/256" g="239/256" b="217/256" alpha="0.3"  showDaughters="true" visible="true" />
-  <vis name="arc_aerogel_vis" r="244/256" g="177/256" b="132/256" alpha="0.5"  showDaughters="true" visible="true" />
-  <vis name="arc_cooling_vis" r="254/256" g="230/256" b="151/256" alpha="0.5"  showDaughters="true" visible="true" />
-  <vis name="arc_sensor_vis"  r="255/256" g="0/256"   b="0/256"   alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis"  r="255/256" g="230/256" b="153/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis1"  r="128/256" g="230/256" b="153/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis2"  r="128/256" g="128/256" b="153/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis3"  r="128/256" g="128/256" b="256/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis4"  r="000/256" g="128/256" b="256/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis5"  r="000/256" g="000/256" b="256/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis6"  r="256/256" g="000/256" b="256/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis7"  r="256/256" g="128/256" b="256/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis8"  r="256/256" g="128/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis9"  r="256/256" g="128/256" b="000/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis10" r="128/256" g="256/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis11" r="128/256" g="256/256" b="000/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis12" r="000/256" g="256/256" b="000/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis13" r="000/256" g="256/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis14" r="000/256" g="128/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis15" r="000/256" g="128/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis16" r="000/256" g="128/256" b="055/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis17" r="000/256" g="128/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis18" r="055/256" g="128/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis19" r="055/256" g="128/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis20" r="055/256" g="128/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_mirror_vis21" r="055/256" g="128/256" b="128/256" alpha="1.0"  showDaughters="true" visible="true" />
-  <vis name="arc_no_vis" showDaughters="true" visible="false" />
-  <vis name="arc_envelope_vis"  r="0/256"   g="96/256"  b="156/256" alpha="0.3"  showDaughters="true" visible="true" />
-  <vis name="arc_vessel_bulk_vis"  r="236/256" g="000/256" b="000/256" alpha="1.00"  showDaughters="true" visible="false" />
-</display>
-
 <define>
   <!-- ARC properties -->
   <constant name="ARC_VESSEL_WALL_THICKNESS"  value="1.0*cm"    />

--- a/FCCee/CLD/compact/CLD_o3_v01/Beampipe_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/Beampipe_o4_v05.xml
@@ -13,14 +13,6 @@
       <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
-        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
-        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
-        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
-    </display>
-
     <detectors>
 
       <!-- ;radius calculator lisp

--- a/FCCee/CLD/compact/CLD_o3_v01/CLD_o3_v01.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/CLD_o3_v01.xml
@@ -294,31 +294,9 @@
     </regions>
 
 
-    <display>
-        <vis name="VXDVis" alpha="0.1" r="0.1" g=".5" b=".5" showDaughters="true" visible="false" />
-        <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true" />
-        <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false" />
-        <vis name="ECALVis" alpha="1.0" r="0.0" g="0.48" b="0.0" showDaughters="true" visible="true" />
-        <vis name="HCALVis" alpha="1.0" r="0.74" g="0.81" b="0.55" showDaughters="true"
-            visible="true" />
-        <vis name="SOLVis" alpha="1.0" r="0.4" g="0.4" b="0.4" showDaughters="true" visible="true" />
-        <vis name="YOKEVis" alpha="1.0" r="0.0" g="0.56" b="0.28" showDaughters="true"
-            visible="true" />
-        <vis name="LCALInstrVis" alpha="1.0" r="0.35" g="0.0" b="0.47" showDaughters="true"
-            visible="true" />
-        <vis name="LCALVis" alpha="1.0" r="0.25" g="0.88" b="0.81" showDaughters="true"
-            visible="true" />
-        <vis name="LCALCoolVis" alpha="1.0" r="0.2" g="0.6" b="0" showDaughters="true"
-            visible="true" />
-        <vis name="CompSolVis" alpha="1.0" r="0.5" g="0.5" b="0.0" showDaughters="true"
-            visible="true" />
-        <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true" />
-        <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true"
-            visible="true" />
-        <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true" />
-    </display>
-
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml" />
+
+    <include ref="display.xml" />
 
      <include ref="Beampipe_o4_v05.xml" />
 

--- a/FCCee/CLD/compact/CLD_o3_v01/ECalBarrel_o2_v01_03.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/ECalBarrel_o2_v01_03.xml
@@ -12,17 +12,6 @@
         </readout>
     </readouts>
 
-    <!--  Definitions of visualization attributes  -->
-    <display>
-        <vis name="ECalStaveVis"      alpha="1.0" r="0.0"  g="0.8"  b="1.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalLayerVis"      alpha="1.0" r="0.8"  g="0.8"  b="0.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalSensitiveVis"  alpha="1.0" r="0.7"  g="0.3"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalAbsorberVis"   alpha="1.0" r="0.4"  g="0.4"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalEndcapVis"     alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true"  visible="true"/>
-	<vis name="HiddenEnvelope"    alpha="0.0" r="1.0"  g="1.0"  b="1.0"  showDaughters="true"  visible="false"/>
-	<vis name="CompositeVis"      alpha="1.0" r="1.0"  g="0.0"  b="0.0"  showDaughters="true"  visible="true"/>
-    </display>
-
     <detectors>
         <detector name="ECalBarrel" type="GenericCalBarrel_o1_v01" id="DetID_ECal_Barrel" readout="ECalBarrelCollection" vis="ECALVis" gap="0.*cm">
 

--- a/FCCee/CLD/compact/CLD_o3_v01/HCalBarrel_o1_v01_01.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/HCalBarrel_o1_v01_01.xml
@@ -7,18 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="HCalBarrelVis"    alpha="1" r="0.0"  g="0.3"  b="0.8" showDaughters="true" visible="true"/>
-        <vis name="HCalStavesVis"    alpha="1" r="0.0"  g="0.0"  b="0.1" showDaughters="true" visible="false"/>
-        <vis name="HCalLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-        <vis name="HCalSensorVis"    alpha="1" r="1.0"  g="0.0"  b="0.2" showDaughters="true" visible="true"/>
-        <vis name="HCalAbsorberVis"  alpha="1" r="0.4"  g="0.4"  b="0.6" showDaughters="true" visible="true"/>
-
-        <vis name="HCalEndcapVis"          alpha="1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
-        <vis name="HCalEndcapLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="HCalBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o3_v01/InnerTracker_o3_v08.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/InnerTracker_o3_v08.xml
@@ -72,17 +72,6 @@
     </detectors>
 
 
-    <display>
-        <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false"
-            visible="true" />
-        <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false"
-            visible="true" />
-        <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true" />
-        <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true" />
-        <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true"
-            visible="true" />
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="InnerTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o3_v01/OuterTracker_o3_v08.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/OuterTracker_o3_v08.xml
@@ -36,14 +36,6 @@
     </detectors>
 
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="OuterTrackerLayerVis"   alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
-        <vis name="OuterTrackerModuleVis"  alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="OuterTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o3_v01/Solenoid_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/Solenoid_o1_v01_02.xml
@@ -7,14 +7,6 @@
 
 
 
-    <display>
-        <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
-        <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
-        <vis name="SolenoidVacuum"         alpha="0" r="1"    g="1"    b="1"   showDaughters="false" visible="true"/>
-    </display>
-
-
-
     <comment>Solenoid</comment>
     <detectors>
         <detector name="Solenoid" type="DD4hep_SubdetectorAssembly" vis="SOLVis">

--- a/FCCee/CLD/compact/CLD_o3_v01/Vertex_o4_v07_smallBP.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/Vertex_o4_v07_smallBP.xml
@@ -24,14 +24,6 @@
         </detector>
     </detectors>
 
-    <display>
-        <vis name="SiVertexModuleVis"    alpha="1.0" r="1" g="1"    b="0.6"     showDaughters="true"  visible="false"/>
-        <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2"  b="0.2"     showDaughters="true"  visible="true"/>
-        <vis name="SiVertexPassiveVis"   alpha="1.0" r="0.274" g="0.274"  b="0.274"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexCableVis"     alpha="1.0" r="0.85" g="0.53"    b="0.4"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexAir"          alpha="1.0" r="0" g="0"    b="0"       showDaughters="false"  visible="false"/>
-    </display>
-
     <define>
         <constant name="VertexBarrel_zmax" value="109*mm"/>
 <!--

--- a/FCCee/CLD/compact/CLD_o3_v01/YokeBarrel_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/YokeBarrel_o1_v01_02.xml
@@ -7,15 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeBarrelVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-        <vis name="YokeStavesVis"    alpha="1" r="0"    g="0.7"  b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeLayerVis"     alpha="1" r="0"    g="1"    b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
-        <vis name="YokeAbsorberVis"  alpha="1" r="0.28" g="0.4"  b="0.62" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="YokeBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o3_v01/YokeEndcap_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/YokeEndcap_o1_v01_02.xml
@@ -8,11 +8,6 @@
         </readout>
     </readouts>
 
-        <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeEndcapVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Includes for sensitives and support                -->
     <detectors>
 

--- a/FCCee/CLD/compact/CLD_o3_v01/display.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/display.xml
@@ -20,7 +20,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
-    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/> 
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -34,7 +34,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
-    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
     <!-- Inner tracker (retrieved from InnerTracker_o3_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -66,8 +66,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
-    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
-    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -83,7 +83,7 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
-    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 
     <!-- ARC (retrieved from ARC_o1_v01.xml) -->
     <vis name="arc_vessel_vis" r="236/256" g="237/256" b="232/256" alpha="1.00" showDaughters="true" visible="false"/>
@@ -117,10 +117,10 @@
     <vis name="arc_envelope_vis" r="0/256" g="96/256" b="156/256" alpha="0.3" showDaughters="true" visible="true"/>
     <vis name="arc_vessel_bulk_vis" r="236/256" g="000/256" b="000/256" alpha="1.00" showDaughters="true" visible="false"/>
 
-    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <!-- Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
     <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
 
-    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
+    <!-- LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
     <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
     <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o3_v01/display.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/display.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+
+  <display>
+
+    <!-- Global palette (retrieved from CLD_o3_v01.xml) -->
+    <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
+    <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
+    <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
+    <vis name="ECALVis" alpha="1.0" r="0.0" g="0.48" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="HCALVis" alpha="1.0" r="0.74" g="0.81" b="0.55" showDaughters="true" visible="true"/>
+    <vis name="SOLVis" alpha="1.0" r="0.4" g="0.4" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="YOKEVis" alpha="1.0" r="0.0" g="0.56" b="0.28" showDaughters="true" visible="true"/>
+    <vis name="LCALInstrVis" alpha="1.0" r="0.35" g="0.0" b="0.47" showDaughters="true" visible="true"/>
+    <vis name="LCALVis" alpha="1.0" r="0.25" g="0.88" b="0.81" showDaughters="true" visible="true"/>
+    <vis name="LCALCoolVis" alpha="1.0" r="0.2" g="0.6" b="0" showDaughters="true" visible="true"/>
+    <vis name="CompSolVis" alpha="1.0" r="0.5" g="0.5" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
+    <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+
+    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+    <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+
+    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
+    <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
+    <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+
+    <!-- Inner tracker (retrieved from InnerTracker_o3_v08.xml) -->
+    <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+    <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
+    <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- Outer tracker (retrieved from OuterTracker_o3_v08.xml) -->
+    <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalAbsorberVis" alpha="1.0" r="0.4" g="0.4" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalEndcapVis" alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true" visible="true"/>
+    <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+    <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+
+    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
+    <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
+    <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalSensorVis" alpha="1" r="1.0" g="0.0" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+
+    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
+    <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
+    <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
+
+    <!--DONE. Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
+    <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
+
+    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+
+    <!-- ARC (retrieved from ARC_o1_v01.xml) -->
+    <vis name="arc_vessel_vis" r="236/256" g="237/256" b="232/256" alpha="1.00" showDaughters="true" visible="false"/>
+    <vis name="arc_gas_vis" r="227/256" g="239/256" b="217/256" alpha="0.3" showDaughters="true" visible="true"/>
+    <vis name="arc_aerogel_vis" r="244/256" g="177/256" b="132/256" alpha="0.5" showDaughters="true" visible="true"/>
+    <vis name="arc_cooling_vis" r="254/256" g="230/256" b="151/256" alpha="0.5" showDaughters="true" visible="true"/>
+    <vis name="arc_sensor_vis" r="255/256" g="0/256" b="0/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis" r="255/256" g="230/256" b="153/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis1" r="128/256" g="230/256" b="153/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis2" r="128/256" g="128/256" b="153/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis3" r="128/256" g="128/256" b="256/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis4" r="000/256" g="128/256" b="256/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis5" r="000/256" g="000/256" b="256/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis6" r="256/256" g="000/256" b="256/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis7" r="256/256" g="128/256" b="256/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis8" r="256/256" g="128/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis9" r="256/256" g="128/256" b="000/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis10" r="128/256" g="256/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis11" r="128/256" g="256/256" b="000/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis12" r="000/256" g="256/256" b="000/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis13" r="000/256" g="256/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis14" r="000/256" g="128/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis15" r="000/256" g="128/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis16" r="000/256" g="128/256" b="055/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis17" r="000/256" g="128/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis18" r="055/256" g="128/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis19" r="055/256" g="128/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis20" r="055/256" g="128/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_mirror_vis21" r="055/256" g="128/256" b="128/256" alpha="1.0" showDaughters="true" visible="true"/>
+    <vis name="arc_no_vis" showDaughters="true" visible="false"/>
+    <vis name="arc_envelope_vis" r="0/256" g="96/256" b="156/256" alpha="0.3" showDaughters="true" visible="true"/>
+    <vis name="arc_vessel_bulk_vis" r="236/256" g="000/256" b="000/256" alpha="1.00" showDaughters="true" visible="false"/>
+
+  </display>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o3_v01/display.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/display.xml
@@ -18,6 +18,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -31,6 +32,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
 
     <!-- Inner tracker (retrieved from InnerTracker_o3_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -62,13 +64,15 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
     <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
     <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
 
-    <!--DONE. Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
     <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
@@ -77,6 +81,7 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
     <!-- ARC (retrieved from ARC_o1_v01.xml) -->
     <vis name="arc_vessel_vis" r="236/256" g="237/256" b="232/256" alpha="1.00" showDaughters="true" visible="false"/>
@@ -109,6 +114,16 @@
     <vis name="arc_no_vis" showDaughters="true" visible="false"/>
     <vis name="arc_envelope_vis" r="0/256" g="96/256" b="156/256" alpha="0.3" showDaughters="true" visible="true"/>
     <vis name="arc_vessel_bulk_vis" r="236/256" g="000/256" b="000/256" alpha="1.00" showDaughters="true" visible="false"/>
+
+    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+
+    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
+    <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
+    <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis3" alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="LCALShieldVis" alpha="1.0" r="0.6" g="0.3" b="0.0" showDaughters="true" visible="true"/>
 
   </display>
 

--- a/FCCee/CLD/compact/CLD_o3_v01/display.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/display.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
 
+  <!-- Consolidated visualization (color) definitions -->
+
   <display>
 
     <!-- Global palette (retrieved from CLD_o3_v01.xml) -->

--- a/FCCee/CLD/compact/CLD_o3_v01/display.xml
+++ b/FCCee/CLD/compact/CLD_o3_v01/display.xml
@@ -5,7 +5,7 @@
 
   <display>
 
-    <!-- Global palette (retrieved from CLD_o3_v01.xml) -->
+    <!-- Global palette (originally retrieved from CLD_o3_v01.xml) -->
     <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
     <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
     <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
@@ -22,13 +22,13 @@
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/> 
 
-    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <!-- Beampipe (originally retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
     <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
     <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
     <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
 
-    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <!-- Vertex (originally retrieved from Vertex_o4_v07_smallBP.xml) -->
     <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
     <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
@@ -36,20 +36,20 @@
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
     <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
-    <!-- Inner tracker (retrieved from InnerTracker_o3_v08.xml) -->
+    <!-- Inner tracker (originally retrieved from InnerTracker_o3_v08.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
     <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
     <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- Outer tracker (retrieved from OuterTracker_o3_v08.xml) -->
+    <!-- Outer tracker (originally retrieved from OuterTracker_o3_v08.xml) -->
     <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
     <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml) -->
+    <!-- ECal barrel / endcap (originally retrieved from ECalBarrel_o2_v01_03.xml) -->
     <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
     <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
     <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
@@ -58,7 +58,7 @@
     <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
     <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <!-- HCal barrel / endcap (originally retrieved from HCalBarrel_o1_v01_01.xml) -->
     <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
     <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
     <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
@@ -69,23 +69,23 @@
     <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
     <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <!-- Solenoid (originally retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
     <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
     <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
 
-    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <!-- Yoke barrel (originally retrieved from YokeBarrel_o1_v01_02.xml) -->
     <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
     <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
 
-    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <!-- Yoke endcap (originally retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 
-    <!-- ARC (retrieved from ARC_o1_v01.xml) -->
+    <!-- ARC (originally retrieved from ARC_o1_v01.xml) -->
     <vis name="arc_vessel_vis" r="236/256" g="237/256" b="232/256" alpha="1.00" showDaughters="true" visible="false"/>
     <vis name="arc_gas_vis" r="227/256" g="239/256" b="217/256" alpha="0.3" showDaughters="true" visible="true"/>
     <vis name="arc_aerogel_vis" r="244/256" g="177/256" b="132/256" alpha="0.5" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o4_v05/Beampipe_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/Beampipe_o4_v05.xml
@@ -13,14 +13,6 @@
       <constant name="beampipegoldtolerance" value="BeamPipeGoldTolerance"/>
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
-        <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
-        <vis name="TubeVis"  alpha="1.0" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
-        <vis name="VacVis"   alpha="1.0" r="1.0" g="1.0"  b="1.0"   showDaughters="true"  visible="false"/>
-    </display>
-
     <detectors>
 
       <!-- ;radius calculator lisp

--- a/FCCee/CLD/compact/CLD_o4_v05/CLD_o4_v05.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/CLD_o4_v05.xml
@@ -268,24 +268,9 @@
     </regions>
 
 
-    <display>
-      <vis name="VXDVis"        alpha="0.1" r="0.1" 	g=".5"      b=".5"    showDaughters="true"  visible="false"/>
-      <vis name="ITVis"       	alpha="1.0" r="0.54"  	g="0.43"    b="0.04"  showDaughters="true"  visible="true"/>
-      <vis name="OTVis"       	alpha="1.0" r="0.8"   	g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
-      <vis name="ECALVis"     	alpha="1.0" r="0.0"   	g="0.48"    b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="HCALVis"     	alpha="1.0" r="0.74" 	g="0.81"    b="0.55"  showDaughters="true"  visible="true"/>
-      <vis name="SOLVis"      	alpha="1.0" r="0.4"   	g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
-      <vis name="YOKEVis"     	alpha="1.0" r="0.0"   	g="0.56"    b="0.28"  showDaughters="true"  visible="true"/>
-      <vis name="LCALInstrVis"  alpha="1.0" r="0.35"  	g="0.0"     b="0.47"  showDaughters="true"  visible="true"/>
-      <vis name="LCALVis"    	alpha="1.0" r="0.25"  	g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
-      <vis name="LCALCoolVis"   alpha="1.0" r="0.2"   	g="0.6"     b="0"     showDaughters="true"  visible="true"/>
-      <vis name="CompSolVis"    alpha="1.0" r="0.5"   	g="0.5"     b="0.0"   showDaughters="true"  visible="true"/>
-      <vis name="ScreenSolVis"  alpha="1.0" r="1"   	g="1"       b="0"     showDaughters="true"  visible="true"/>
-      <vis name="TantalumVis"   alpha="1.0" r="1"   	g="0.5"     b="0.5"   showDaughters="true"  visible="true"/>
-      <vis name="SupportVis"  	alpha="1"   r="0.2"   	g="0.2"     b="0.2"   showDaughters="true" visible="true"/>
-    </display>
-
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+
+    <include ref="display.xml"/>
 
     <include ref="Beampipe_o4_v05.xml"/>
 

--- a/FCCee/CLD/compact/CLD_o4_v05/ECalBarrel_o2_v01_03.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/ECalBarrel_o2_v01_03.xml
@@ -12,17 +12,6 @@
         </readout>
     </readouts>
 
-    <!--  Definitions of visualization attributes  -->
-    <display>
-        <vis name="ECalStaveVis"      alpha="1.0" r="0.0"  g="0.8"  b="1.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalLayerVis"      alpha="1.0" r="0.8"  g="0.8"  b="0.0"  showDaughters="true"  visible="true"/>
-        <vis name="ECalSensitiveVis"  alpha="1.0" r="0.7"  g="0.3"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalAbsorberVis"   alpha="1.0" r="0.4"  g="0.4"  b="0.0"  showDaughters="false" visible="true"/>
-        <vis name="ECalEndcapVis"     alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true"  visible="true"/>
-	<vis name="HiddenEnvelope"    alpha="0.0" r="1.0"  g="1.0"  b="1.0"  showDaughters="true"  visible="false"/>
-	<vis name="CompositeVis"      alpha="1.0" r="1.0"  g="0.0"  b="0.0"  showDaughters="true"  visible="true"/>
-    </display>
-
     <detectors>
         <detector name="ECalBarrel" type="GenericCalBarrel_o1_v01" id="DetID_ECal_Barrel" readout="ECalBarrelCollection" vis="ECALVis" gap="0.*cm">
 

--- a/FCCee/CLD/compact/CLD_o4_v05/HCalBarrel_o1_v01_01.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/HCalBarrel_o1_v01_01.xml
@@ -7,18 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="HCalBarrelVis"    alpha="1" r="0.0"  g="0.3"  b="0.8" showDaughters="true" visible="true"/>
-        <vis name="HCalStavesVis"    alpha="1" r="0.0"  g="0.0"  b="0.1" showDaughters="true" visible="false"/>
-        <vis name="HCalLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-        <vis name="HCalSensorVis"    alpha="1" r="1.0"  g="0.0"  b="0.2" showDaughters="true" visible="true"/>
-        <vis name="HCalAbsorberVis"  alpha="1" r="0.4"  g="0.4"  b="0.6" showDaughters="true" visible="true"/>
-
-        <vis name="HCalEndcapVis"          alpha="1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
-        <vis name="HCalEndcapLayerVis"     alpha="1" r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="HCalBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o4_v05/InnerTracker_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/InnerTracker_o2_v07.xml
@@ -60,14 +60,6 @@
     </detectors>
 
 
-    <display>
-        <vis name="InnerTrackerModuleVis"  alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
-        <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
-        <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="InnerTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o4_v05/LAr_ECalBarrel.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/LAr_ECalBarrel.xml
@@ -69,10 +69,6 @@
     <constant name="ECal_cell_size" value="20*mm"/>
   </define>
 
-  <display>
-    <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughters="false" visible="true" />
-  </display>
-
   <readouts>
     <!-- readout for the simulation -->
     <!-- offset in eta is eta max value including cryostat -->

--- a/FCCee/CLD/compact/CLD_o4_v05/OuterTracker_o2_v07.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/OuterTracker_o2_v07.xml
@@ -36,14 +36,6 @@
     </detectors>
 
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="OuterTrackerLayerVis"   alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
-        <vis name="OuterTrackerModuleVis"  alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
-        <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="OuterTrackerBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o4_v05/Solenoid_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/Solenoid_o1_v01_02.xml
@@ -7,14 +7,6 @@
 
 
 
-    <display>
-        <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
-        <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
-        <vis name="SolenoidVacuum"         alpha="0" r="1"    g="1"    b="1"   showDaughters="false" visible="true"/>
-    </display>
-
-
-
     <comment>Solenoid</comment>
     <detectors>
         <detector name="Solenoid" type="DD4hep_SubdetectorAssembly" vis="SOLVis">

--- a/FCCee/CLD/compact/CLD_o4_v05/Vertex_o4_v07_smallBP.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/Vertex_o4_v07_smallBP.xml
@@ -24,14 +24,6 @@
         </detector>
     </detectors>
 
-    <display>
-        <vis name="SiVertexModuleVis"    alpha="1.0" r="1" g="1"    b="0.6"     showDaughters="true"  visible="false"/>
-        <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2"  b="0.2"     showDaughters="true"  visible="true"/>
-        <vis name="SiVertexPassiveVis"   alpha="1.0" r="0.274" g="0.274"  b="0.274"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexCableVis"     alpha="1.0" r="0.85" g="0.53"    b="0.4"       showDaughters="true"  visible="true"/>
-        <vis name="SiVertexAir"          alpha="1.0" r="0" g="0"    b="0"       showDaughters="false"  visible="false"/>
-    </display>
-
     <define>
         <constant name="VertexBarrel_zmax" value="109*mm"/>
 <!--

--- a/FCCee/CLD/compact/CLD_o4_v05/YokeBarrel_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/YokeBarrel_o1_v01_02.xml
@@ -7,15 +7,6 @@
 
     </define>
 
-    <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeBarrelVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-        <vis name="YokeStavesVis"    alpha="1" r="0"    g="0.7"  b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeLayerVis"     alpha="1" r="0"    g="1"    b="0.3" showDaughters="true" visible="true"/>
-        <vis name="YokeSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
-        <vis name="YokeAbsorberVis"  alpha="1" r="0.28" g="0.4"  b="0.62" visible="true"/>
-    </display>
-
     <!--  Definition of the readout segmentation/definition  -->
     <readouts>
         <readout name="YokeBarrelCollection">

--- a/FCCee/CLD/compact/CLD_o4_v05/YokeEndcap_o1_v01_02.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/YokeEndcap_o1_v01_02.xml
@@ -8,11 +8,6 @@
         </readout>
     </readouts>
 
-        <!--  Definition of the used visualization attributes    -->
-    <display>
-        <vis name="YokeEndcapVis"          alpha="1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
-    </display>
-
     <!--  Includes for sensitives and support                -->
     <detectors>
 

--- a/FCCee/CLD/compact/CLD_o4_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/display.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+
+  <display>
+
+    <!-- Global palette (retrieved from CLD_o4_v05.xml) -->
+    <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
+    <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
+    <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
+    <vis name="ECALVis" alpha="1.0" r="0.0" g="0.48" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="HCALVis" alpha="1.0" r="0.74" g="0.81" b="0.55" showDaughters="true" visible="true"/>
+    <vis name="SOLVis" alpha="1.0" r="0.4" g="0.4" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="YOKEVis" alpha="1.0" r="0.0" g="0.56" b="0.28" showDaughters="true" visible="true"/>
+    <vis name="LCALInstrVis" alpha="1.0" r="0.35" g="0.0" b="0.47" showDaughters="true" visible="true"/>
+    <vis name="LCALVis" alpha="1.0" r="0.25" g="0.88" b="0.81" showDaughters="true" visible="true"/>
+    <vis name="LCALCoolVis" alpha="1.0" r="0.2" g="0.6" b="0" showDaughters="true" visible="true"/>
+    <vis name="CompSolVis" alpha="1.0" r="0.5" g="0.5" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
+    <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+
+    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
+    <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
+    <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+
+    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
+    <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
+    <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
+    <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+
+    <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
+    <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+    <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
+    <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- Outer tracker (retrieved from OuterTracker_o2_v07.xml) -->
+    <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
+
+    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml, not itself included by CLD_o4_v05.xml but its vis names are still used by ECalEndcap_o2_v01_03.xml) -->
+    <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalAbsorberVis" alpha="1.0" r="0.4" g="0.4" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="ECalEndcapVis" alpha="1.0" r="0.77" g="0.74" b="0.86" showDaughters="true" visible="true"/>
+    <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
+    <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+
+    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
+    <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
+    <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalSensorVis" alpha="1" r="1.0" g="0.0" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
+    <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
+    <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+
+    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
+    <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
+    <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
+
+    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
+    <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
+
+    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+
+    <!-- LAr ECal barrel (retrieved from LAr_ECalBarrel.xml) -->
+    <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughters="false" visible="true"/>
+
+  </display>
+
+</lccdd>

--- a/FCCee/CLD/compact/CLD_o4_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/display.xml
@@ -20,7 +20,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
-    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -34,7 +34,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
-    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -66,8 +66,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
-    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
-    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -83,15 +83,15 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
-    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 
     <!-- LAr ECal barrel (retrieved from LAr_ECalBarrel.xml) -->
     <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughters="false" visible="true"/>
 
-    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <!-- Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
     <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
 
-    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
+    <!-- LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
     <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
     <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>

--- a/FCCee/CLD/compact/CLD_o4_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/display.xml
@@ -18,6 +18,7 @@
     <vis name="ScreenSolVis" alpha="1.0" r="1" g="1" b="0" showDaughters="true" visible="true"/>
     <vis name="TantalumVis" alpha="1.0" r="1" g="0.5" b="0.5" showDaughters="true" visible="true"/>
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
+    <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>  <!-- Missing definition -->
 
     <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
@@ -31,6 +32,7 @@
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
     <vis name="SiVertexCableVis" alpha="1.0" r="0.85" g="0.53" b="0.4" showDaughters="true" visible="true"/>
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
+    <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/> <!-- Missing definition -->
 
     <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
@@ -62,6 +64,8 @@
     <vis name="HCalAbsorberVis" alpha="1" r="0.4" g="0.4" b="0.6" showDaughters="true" visible="true"/>
     <vis name="HCalEndcapVis" alpha="1" r="1" g="1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="HCalEndcapLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
+    <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/> <!-- Missing definition -->
+    <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
     <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
@@ -77,9 +81,20 @@
 
     <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
+    <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/> <!-- Missing definition -->
 
     <!-- LAr ECal barrel (retrieved from LAr_ECalBarrel.xml) -->
     <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughters="false" visible="true"/>
+
+    <!-- Missing definition. Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->
+    <vis name="CoilVis" alpha="1.0" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
+
+    <!-- Missing definitions. LumiCal (referenced in LumiCal_o3_v02_03.xml) -->
+    <vis name="SeeThrough" alpha="0.0" r="0" g="0" b="0" showDaughters="true" visible="false"/>
+    <vis name="BCLayerVis1" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis2" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BCLayerVis3" alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="LCALShieldVis" alpha="1.0" r="0.6" g="0.3" b="0.0" showDaughters="true" visible="true"/>
 
   </display>
 

--- a/FCCee/CLD/compact/CLD_o4_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/display.xml
@@ -5,7 +5,7 @@
 
   <display>
 
-    <!-- Global palette (retrieved from CLD_o4_v05.xml) -->
+    <!-- Global palette (originally retrieved from CLD_o4_v05.xml) -->
     <vis name="VXDVis" alpha="0.1" r="0.1" g="0.5" b="0.5" showDaughters="true" visible="false"/>
     <vis name="ITVis" alpha="1.0" r="0.54" g="0.43" b="0.04" showDaughters="true" visible="true"/>
     <vis name="OTVis" alpha="1.0" r="0.8" g="0.8" b="0.4" showDaughters="true" visible="false"/>
@@ -22,13 +22,13 @@
     <vis name="SupportVis" alpha="1" r="0.2" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="InvisibleNoDaughters" showDaughters="false" visible="false"/>
 
-    <!-- Beampipe (retrieved from Beampipe_o4_v05.xml) -->
+    <!-- Beampipe (originally retrieved from Beampipe_o4_v05.xml) -->
     <vis name="BeamPipeVis" alpha="0.0" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="false"/>
     <vis name="GoldCoatingVis" alpha="0.0" r="0.0" g="1.0" b="1.0" showDaughters="true" visible="true"/>
     <vis name="TubeVis" alpha="1.0" r="1.0" g="0.7" b="0.5" showDaughters="true" visible="true"/>
     <vis name="VacVis" alpha="1.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
 
-    <!-- Vertex (retrieved from Vertex_o4_v07_smallBP.xml) -->
+    <!-- Vertex (originally retrieved from Vertex_o4_v07_smallBP.xml) -->
     <vis name="SiVertexModuleVis" alpha="1.0" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
     <vis name="SiVertexSensitiveVis" alpha="1.0" r="1" g="0.2" b="0.2" showDaughters="true" visible="true"/>
     <vis name="SiVertexPassiveVis" alpha="1.0" r="0.274" g="0.274" b="0.274" showDaughters="true" visible="true"/>
@@ -36,20 +36,20 @@
     <vis name="SiVertexAir" alpha="1.0" r="0" g="0" b="0" showDaughters="false" visible="false"/>
     <vis name="SiVertexLayerVis" alpha="1.0" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
 
-    <!-- Inner tracker (retrieved from InnerTracker_o2_v07.xml) -->
+    <!-- Inner tracker (originally retrieved from InnerTracker_o2_v07.xml) -->
     <vis name="InnerTrackerModuleVis" alpha="0.5" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="InnerTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="RedVis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
     <vis name="BlueVis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
     <vis name="InterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- Outer tracker (retrieved from OuterTracker_o2_v07.xml) -->
+    <!-- Outer tracker (originally retrieved from OuterTracker_o2_v07.xml) -->
     <vis name="OuterTrackerLayerVis" alpha="1.0" r="1.0" g="1.0" b="0.6" showDaughters="true" visible="true"/>
     <vis name="OuterTrackerModuleVis" alpha="0.1" r="0.0" g="1.0" b="0.6" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
     <vis name="OuterTrackerInterlinkVis" alpha="1.0" r="0.078" g="0.12" b="0.59" showDaughters="true" visible="true"/>
 
-    <!-- ECal barrel / endcap (retrieved from ECalBarrel_o2_v01_03.xml, not itself included by CLD_o4_v05.xml but its vis names are still used by ECalEndcap_o2_v01_03.xml) -->
+    <!-- ECal barrel / endcap (originally retrieved from ECalBarrel_o2_v01_03.xml, not itself included by CLD_o4_v05.xml but its vis names are still used by ECalEndcap_o2_v01_03.xml) -->
     <vis name="ECalStaveVis" alpha="1.0" r="0.0" g="0.8" b="1.0" showDaughters="true" visible="true"/>
     <vis name="ECalLayerVis" alpha="1.0" r="0.8" g="0.8" b="0.0" showDaughters="true" visible="true"/>
     <vis name="ECalSensitiveVis" alpha="1.0" r="0.7" g="0.3" b="0.0" showDaughters="false" visible="true"/>
@@ -58,7 +58,7 @@
     <vis name="HiddenEnvelope" alpha="0.0" r="1.0" g="1.0" b="1.0" showDaughters="true" visible="false"/>
     <vis name="CompositeVis" alpha="1.0" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- HCal barrel / endcap (retrieved from HCalBarrel_o1_v01_01.xml) -->
+    <!-- HCal barrel / endcap (originally retrieved from HCalBarrel_o1_v01_01.xml) -->
     <vis name="HCalBarrelVis" alpha="1" r="0.0" g="0.3" b="0.8" showDaughters="true" visible="true"/>
     <vis name="HCalStavesVis" alpha="1" r="0.0" g="0.0" b="0.1" showDaughters="true" visible="false"/>
     <vis name="HCalLayerVis" alpha="1" r="1" g="0" b="0.5" showDaughters="false" visible="true"/>
@@ -69,23 +69,23 @@
     <vis name="HCalCopperVis" alpha="1.0" r="0.72" g="0.45" b="0.2" showDaughters="true" visible="true"/>
     <vis name="HCalPCBVis" alpha="1.0" r="0.0" g="0.4" b="0.0" showDaughters="true" visible="true"/>
 
-    <!-- Solenoid (retrieved from Solenoid_o1_v01_02.xml) -->
+    <!-- Solenoid (originally retrieved from Solenoid_o1_v01_02.xml) -->
     <vis name="SolenoidBarrelLayerVis" alpha="1" r="0" g="0.3" b="0.3" showDaughters="false" visible="true"/>
     <vis name="SolenoidCoilEndsVis" alpha="1" r="0" g="0.9" b="0.9" showDaughters="false" visible="true"/>
     <vis name="SolenoidVacuum" alpha="0" r="1" g="1" b="1" showDaughters="false" visible="true"/>
 
-    <!-- Yoke barrel (retrieved from YokeBarrel_o1_v01_02.xml) -->
+    <!-- Yoke barrel (originally retrieved from YokeBarrel_o1_v01_02.xml) -->
     <vis name="YokeBarrelVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeStavesVis" alpha="1" r="0" g="0.7" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
     <vis name="YokeSensorVis" alpha="1" r="0.54" g="0.4" b="0.41" visible="true"/>
     <vis name="YokeAbsorberVis" alpha="1" r="0.28" g="0.4" b="0.62" visible="true"/>
 
-    <!-- Yoke endcap (retrieved from YokeEndcap_o1_v01_02.xml) -->
+    <!-- Yoke endcap (originally retrieved from YokeEndcap_o1_v01_02.xml) -->
     <vis name="YokeEndcapVis" alpha="1" r="1" g="0.4" b="0.62" showDaughters="true" visible="true"/>
     <vis name="YokeEndcapLayerVis" alpha="1" r="0" g="1" b="0.3" showDaughters="true" visible="true"/>
 
-    <!-- LAr ECal barrel (retrieved from LAr_ECalBarrel.xml) -->
+    <!-- LAr ECal barrel (originally retrieved from LAr_ECalBarrel.xml) -->
     <vis name="ecal_envelope" r="0.1" g="0.2" b="0.6" alpha="1" showDaughters="false" visible="true"/>
 
     <!-- Beam instrumentation (referenced in BeamInstrumentation_o3_v02_fitShield.xml) -->

--- a/FCCee/CLD/compact/CLD_o4_v05/display.xml
+++ b/FCCee/CLD/compact/CLD_o4_v05/display.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd>
 
+  <!-- Consolidated visualization (color) definitions -->
+
   <display>
 
     <!-- Global palette (retrieved from CLD_o4_v05.xml) -->


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [x] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

If you are modifying detector dimensions or adding new xml parameters, also consider the following:
- [ ] the xml file free parameters that can not be modified without additional prescriptions are well indicated
- [ ] the changes in this PR have not introduced any overlaps. You can check so with the following command: `ddsim --compactFile PATH_TO_COMPACT_FILE --runType run --ui.commandsInitialize "/geometry/test/run" > overlapDump.txt`

BEGINRELEASENOTES

- Create ```display.xml``` file with vis attributes for each CLD version
- Fix dangling references in each version

ENDRELEASENOTES

This is a continuation of previous pull requests that grouped and fixed dangling vis references for every [IDEA](https://github.com/key4hep/k4geo/pull/630#event-29338472743) and [ALLEGRO](https://github.com/key4hep/k4geo/pull/639) version. This one does the same for CLD.

Here's an example of the dangling references now assigned in CLD o2 v05:
- **`InvisibleNoDaughters`: applied in ECalBarrel, ECalEndcap, HCalBarrel, HCalEndcap and HCalRing.** 
- `SiVertexLayerVis`: unread by VertexEndcap (might require a fix). 
- `HCalCopperVis` and`HCalPCBVis`: applied in HCalBarrel, HCalEndcap and HCalRing but not shown as parent has `showDaughters="false"`.
- `YokeEndcapLayerVis`: applied in YokeEndcap but not visible in Root due to overlapping children volume (a workaround is applied [by the Root to GLTF conversion](https://github.com/HEP-FCC/root2gltf/pull/15)).
- `CoilVis`: applied in CompSol and ScreenSol but not assigned to a solid (not visible).
- **`SeeThrough`: applied in LumiCal, LumiCalInstrumentation, LumiCalCooling, and LumiCalBackShield**.
- `BCLayerVis1/2/3`: applied in LumiCal but not visible in Root due to overlapping children volume (a workaround is applied [in the Root to GLTF conversion](https://github.com/HEP-FCC/root2gltf/pull/15)).
- `LCALShieldVis`:applied in LumiCalBackShield but not visible in Root due to overlapping children volume (a workaround is applied [in the Root to GLTF conversion](https://github.com/HEP-FCC/root2gltf/pull/15)).

