### PR TITLE
Fix phi computations in STT_info

### DIFF
--- a/detector/tracker/StrawTubeTracker_o1_v01_geo.cpp
+++ b/detector/tracker/StrawTubeTracker_o1_v01_geo.cpp
@@ -205,7 +205,7 @@ static dd4hep::Ref_t create_straw_tracker(dd4hep::Detector& theDetector, xml_h e
 
         } // repeat (tubes in the phi direction)
       } // sectors within superlayer
-      layerRadius += (tubeThickness + tube_gap) * std::sqrt(3)/2; // equal tube gap
+      layerRadius += (tubeThickness + tube_gap) * std::sqrt(3) / 2; // equal tube gap
       ++ilayer;
     } // layers within superlayer
     SLInnerRadius += SLThickness;

--- a/detector/tracker/StrawTubeTracker_o1_v01_geo.cpp
+++ b/detector/tracker/StrawTubeTracker_o1_v01_geo.cpp
@@ -69,6 +69,7 @@ static dd4hep::Ref_t create_straw_tracker(dd4hep::Detector& theDetector, xml_h e
   int tubeNum = 0;
   double tubeThickness = 0.0;
   double mloffset = 0.0;
+  int ilayer = 1;
 
   // convenience class to add all slice thicknesses together
   dd4hep::Layering layering(x_det);
@@ -115,7 +116,7 @@ static dd4hep::Ref_t create_straw_tracker(dd4hep::Detector& theDetector, xml_h e
 
     // check that the phi repeat is set
     // and it is a sensible value
-    double maxRepeat = std::floor((2 * 3.14159 * layerRadius / SLSectors - SLphiGap) / (tubeThickness + tube_gap));
+    double maxRepeat = std::floor((dd4hep::twopi * layerRadius / SLSectors - SLphiGap) / (tubeThickness + tube_gap));
     if (SLphiRepeat < 0) {
       SLphiRepeat = maxRepeat;
     }
@@ -131,6 +132,7 @@ static dd4hep::Ref_t create_straw_tracker(dd4hep::Detector& theDetector, xml_h e
     STT_i->Add_delta_phi(SLDelta_phi);
     STT_i->Add_stereo(Angle);
     STT_i->Add_innermost_radius(layerRadius);
+    STT_i->Add_offset(mloffset);
 
     // all asserts passed, can start building!
 
@@ -177,21 +179,21 @@ static dd4hep::Ref_t create_straw_tracker(dd4hep::Detector& theDetector, xml_h e
       for (int l = 0; l < SLSectors; ++l) {
         for (int i = 0; i < SLphiRepeat; ++i) {
           // place the envelope volume in the superlayer envelope
-          double phi = STT_i->Get_cell_phi_angle(SLNum, j, l, i);
+          double phi = STT_i->Get_cell_phi_angle(SLNum, ilayer, l, i);
 
           std::string placedTubeName = SLName + dd4hep::_toString(l, "sector%d") + dd4hep::_toString(j, "layer%d") +
                                        dd4hep::_toString(i, "tube%d");
           dd4hep::DetElement tubeElement = dd4hep::DetElement(sdet, placedTubeName, tubeNum++);
 
           // Position vector of the tube barycenter
-          ROOT::Math::XYZVector axis(layerRadius * cos(phi + mloffset), layerRadius * sin(phi + mloffset), 0);
+          ROOT::Math::XYZVector axis(layerRadius * cos(phi), layerRadius * sin(phi), 0);
 
           // Rotation around the tube barycenter position vector --> stereo angle
           ROOT::Math::AxisAngle rot(axis, Angle);
 
           // Position (=displacement) vector of the tube barycenter, required for Transform3D
-          ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>> pos(layerRadius * cos(phi + mloffset),
-                                                                                layerRadius * sin(phi + mloffset), 0);
+          ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>> pos(layerRadius * cos(phi),
+                                                                                layerRadius * sin(phi), 0);
           // Rotation + translation of the tube (ROOT::Math::Transform3D)
           dd4hep::Transform3D tubeTransform = dd4hep::Transform3D(rot, pos);
           dd4hep::PlacedVolume tubePlacedVolume = SLVol.placeVolume(singleVol, tubeTransform);
@@ -203,7 +205,8 @@ static dd4hep::Ref_t create_straw_tracker(dd4hep::Detector& theDetector, xml_h e
 
         } // repeat (tubes in the phi direction)
       } // sectors within superlayer
-      layerRadius += (tubeThickness + tube_gap) * 0.866; // equal tube gap
+      layerRadius += (tubeThickness + tube_gap) * std::sqrt(3)/2; // equal tube gap
+      ++ilayer;
     } // layers within superlayer
     SLInnerRadius += SLThickness;
     mloffset += SLoffset;

--- a/detectorCommon/include/detectorCommon/WireTracker_info.h
+++ b/detectorCommon/include/detectorCommon/WireTracker_info.h
@@ -510,7 +510,9 @@ namespace rec {
     void Add_nsectors(int _val) { nsectors.push_back(_val); }
     void Add_ntubesPerSector(int _val) { ntubesPerSector.push_back(_val); }
     void Add_delta_phi(angle_t _val) { delta_phi.push_back(_val); }
-    void Add_stereo(angle_t _val) { stereo.push_back(_val); }
+    // The stereo angle as implemented in the geometry is the opposite rotation to the one implemented by
+    // WireTracker_info
+    void Add_stereo(angle_t _val) { stereo.push_back(-_val); }
     void Add_innermost_radius(length_t _val) { innermost_radius.push_back(_val); }
     void Add_offset(angle_t _val) { offset.push_back(_val); }
 

--- a/detectorCommon/include/detectorCommon/WireTracker_info.h
+++ b/detectorCommon/include/detectorCommon/WireTracker_info.h
@@ -499,6 +499,8 @@ namespace rec {
     std::vector<angle_t> stereo{};
     // placement radius of sensitive wire in innermost layers of each superlayer
     std::vector<length_t> innermost_radius{};
+    // phi offset of sector 0
+    std::vector<angle_t> offset{};
 
     //--------------------------------------------------------------
     // setters
@@ -510,6 +512,7 @@ namespace rec {
     void Add_delta_phi(angle_t _val) { delta_phi.push_back(_val); }
     void Add_stereo(angle_t _val) { stereo.push_back(_val); }
     void Add_innermost_radius(length_t _val) { innermost_radius.push_back(_val); }
+    void Add_offset(angle_t _val) { offset.push_back(_val); }
 
     //--------------------------------------------------------------
     // STT geo helpers
@@ -518,12 +521,15 @@ namespace rec {
     // STT geo interface implementation
 
     /// Global phi positioning in STT,
-    /// sum of sector phi + phi offset due to layer staggering + tube phi within the layer.
+    /// sum of sector phi + phi offset due to layer staggering + tube phi within the layer
+    /// + overall superlayer offset.
     /// Note that the direction of diagonal gap between sectors changes per superlayer.
     angle_t Get_cell_phi_angle(int superlayer, int ilayer, int sector, int tube) const override final {
-      angle_t phi_start = sector * (2 * dd4hep::pi / this->nsectors.at(superlayer));
-      angle_t phi_rel = (ilayer + 2 * tube) * this->delta_phi.at(superlayer) * pow(-1, superlayer);
-      return phi_start + phi_rel;
+      auto layer = CalculateLocalLayerFromILayer(ilayer, superlayer);
+      angle_t phi_start = sector * (dd4hep::twopi / this->nsectors.at(superlayer));
+      angle_t phi_rel = (layer + 2 * tube) * this->delta_phi.at(superlayer) * pow(-1, superlayer);
+      angle_t phi_offset = this->offset.at(superlayer);
+      return phi_start + phi_rel + phi_offset;
     }
 
     /// Calculate the global layer starting form the layer index within the super layer
@@ -533,6 +539,14 @@ namespace rec {
       int inner_layers = std::accumulate(sum_begin, sum_begin + superlayer, 0);
       layer_t ilayer = layer + inner_layers + 1;
       return ilayer;
+    }
+
+    /// Calculate the global layer starting form the layer index within the super layer
+    /// (super)layer counting starts at 0, while global layer numbers starts at 1.
+    int CalculateLocalLayerFromILayer(layer_t ilayer, int superlayer) const {
+      auto sum_begin = nlayersPerSuperlayer.begin();
+      int inner_layers = std::accumulate(sum_begin, sum_begin + superlayer, 0);
+      return ilayer - inner_layers - 1;
     }
 
     //--------------------------------------------------------------

--- a/detectorCommon/include/detectorCommon/WireTracker_info.h
+++ b/detectorCommon/include/detectorCommon/WireTracker_info.h
@@ -545,7 +545,7 @@ namespace rec {
 
     /// Calculate the global layer starting form the layer index within the super layer
     /// (super)layer counting starts at 0, while global layer numbers starts at 1.
-    int CalculateLocalLayerFromILayer(layer_t ilayer, int superlayer) const {
+    layer_t CalculateLocalLayerFromILayer(layer_t ilayer, int superlayer) const {
       auto sum_begin = nlayersPerSuperlayer.begin();
       int inner_layers = std::accumulate(sum_begin, sum_begin + superlayer, 0);
       return ilayer - inner_layers - 1;


### PR DESCRIPTION
Fix some issues in the implementation of `STT_info` that caused tube positions to differ from the GEANT geometry

BEGINRELEASENOTES
- Fix STT phi computations in `STT_info`: correctly include superlayer offsets and fix bug mixing local and global layer number; use defined constants instead of hard-coded floats
- Fix sign of `STT_info` stereo angle to match GEANT geometry
ENDRELEASENOTES

