### PR TITLE
chore(actions): pin actions to commit hashes and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'iLCSoft/Lcgeo'
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v5
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4 # v5.5
+    - uses: aidasoft/run-lcg-view@b4da52e1c5ccb70a60ad4e7216de0a90664d5849 # v6.0.2
       with:
         coverity-cmake-command: 'cmake -C $ILCSOFT/ILCSoft.cmake ..'
         coverity-project: 'iLCSoft%2FLcgeo'

--- a/.github/workflows/downstream-build.yaml
+++ b/.github/workflows/downstream-build.yaml
@@ -17,5 +17,5 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: key4hep/key4hep-actions/downstream-build@main

--- a/.github/workflows/key4hep-build.yaml
+++ b/.github/workflows/key4hep-build.yaml
@@ -38,7 +38,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Mount CVMFS
       run: /mount.sh
     - uses: key4hep/key4hep-actions/cache-external-data@main

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,9 +6,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: cvmfs-contrib/github-action-cvmfs@v5
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4 # v5.5
+    - uses: aidasoft/run-lcg-view@b4da52e1c5ccb70a60ad4e7216de0a90664d5849 # v6.0.2
       with:
         container: el9
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep


### PR DESCRIPTION
BEGINRELEASENOTES

- Pinned all GitHub actions to the full commit hash of their latest tag, so that a re-tagged action cannot silently change what runs in CI. The corresponding tag is kept as a comment on each line.
  - `actions/checkout`: `v3`/`v4` -> `v7.0.1`
  - `cvmfs-contrib/github-action-cvmfs`: `v5` -> `v5.5`
  - `aidasoft/run-lcg-view`: `v4` -> `v6.0.2`
- Added a Dependabot configuration that checks for GitHub action updates weekly, to keep the pinned hashes up to date.

ENDRELEASENOTES

As discussed in https://github.com/key4hep/k4geo/pull/653