### PR TITLE
Fix detector type for IDEA o2 HCAL endcap

### DIFF
--- a/FCCee/IDEA/compact/IDEA_o2_v01/DREndcapTubes_o1_v01.xml
+++ b/FCCee/IDEA/compact/IDEA_o2_v01/DREndcapTubes_o1_v01.xml
@@ -244,7 +244,7 @@
   -->
   <detectors>
     <detector name="DREndcapTubes" type="DREndcapTubes" vis="DRETAssemblyVis" id ="DetID_DREndcapTubes" readout="DREndcapTubesRO">
-    <type_flags type=" DetType_CALORIMETER + DetType_ELECTROMAGNETIC + DetType_ENDCAP"/>
+    <type_flags type=" DetType_CALORIMETER + DetType_HADRONIC + DetType_ENDCAP"/>
     <dimensions 
       inner_radius="DRETinnerRadius"
       z_length="DRETtowerHeight"


### PR DESCRIPTION
To ease the review process, please consider the following before opening a pull request:
- [x] the code is sufficiently well documented (e.g. inline comments)
- [x] the relevant README(s) were updated. See e.g. https://github.com/key4hep/k4geo/blob/main/detector/calorimeter/README.md or https://github.com/key4hep/k4geo/blob/main/FCCee/IDEA/compact/README.md
- [x] the code is covered by tests. See https://github.com/key4hep/k4geo/blob/main/test/CMakeLists.txt
- [x] the PR source branch has been rebased (`--ff-only`) to `k4geo/main`
- [x] the PR does not contain any additions or modifications that do not belong to it
- [x] The release notes below contain a succinct and comprehensive description of the changes that are sufficiently self-explanatory

BEGINRELEASENOTES
- Fix detector type for IDEA o2 HCAL endcap

ENDRELEASENOTES

Fix detector type for IDEA o2 HCAL endcap. I spotted this and already fixed it for the barrel in #611, but the endcap was left stale.